### PR TITLE
Fnichol/updates 2025 w29

### DIFF
--- a/bin/bedrock/src/main.rs
+++ b/bin/bedrock/src/main.rs
@@ -39,7 +39,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .service_name(BIN_NAME)
             .service_namespace("si")

--- a/bin/cyclone/src/main.rs
+++ b/bin/cyclone/src/main.rs
@@ -30,7 +30,11 @@ async fn main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/edda/src/main.rs
+++ b/bin/edda/src/main.rs
@@ -39,7 +39,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/forklift/src/main.rs
+++ b/bin/forklift/src/main.rs
@@ -39,7 +39,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/hoist/src/diff.rs
+++ b/bin/hoist/src/diff.rs
@@ -42,7 +42,7 @@ impl Display for PatchTarget {
                     return Err(fmt::Error);
                 };
 
-                f.write_str(format!("{} socket {}", kind, name).as_str())
+                f.write_str(format!("{kind} socket {name}").as_str())
             }
             PatchTarget::SocketContents(name) => {
                 let split_name = name.split("-").collect::<Vec<_>>();
@@ -50,13 +50,13 @@ impl Display for PatchTarget {
                     return Err(fmt::Error);
                 };
 
-                f.write_str(format!("contents of {} socket {}", kind, name).as_str())
+                f.write_str(format!("contents of {kind} socket {name}").as_str())
             }
-            PatchTarget::Prop(name) => f.write_str(format!("prop {}", name).as_str()),
+            PatchTarget::Prop(name) => f.write_str(format!("prop {name}").as_str()),
             PatchTarget::PropContents((name, target)) => {
-                f.write_str(format!("contents of prop {} at {}", name, target).as_str())
+                f.write_str(format!("contents of prop {name} at {target}").as_str())
             }
-            PatchTarget::Func(name) => f.write_str(format!("function {}", name).as_str()),
+            PatchTarget::Func(name) => f.write_str(format!("function {name}").as_str()),
             PatchTarget::FuncBinding(kind) => f.write_str(format!("{kind} binding").as_str()),
             PatchTarget::Variant => f.write_str("variant"),
             PatchTarget::VariantContent(path) => {

--- a/bin/hoist/src/main.rs
+++ b/bin/hoist/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
         }
         None => {
             if let Err(err) = Args::command().print_help() {
-                eprintln!("Error displaying help: {}", err);
+                eprintln!("Error displaying help: {err}");
                 std::process::exit(1);
             }
             std::process::exit(0);
@@ -228,7 +228,7 @@ async fn write_single_spec(
         .iter()
         .find(|m| m.name == spec_name)
         .cloned()
-        .unwrap_or_else(|| panic!("Unable to find spec with name: {}", spec_name));
+        .unwrap_or_else(|| panic!("Unable to find spec with name: {spec_name}"));
     write_spec(client, module.id, out).await
 }
 
@@ -366,10 +366,7 @@ async fn diff_summaries_with_module_index(
     let changes_with_summary = changes_with_summary.load(Ordering::SeqCst);
     let hash_mismatches = hash_mismatches.load(Ordering::SeqCst);
 
-    println!(
-        "Total: {} new asset(s), {} changed asset(s)",
-        total_added, hash_mismatches
-    );
+    println!("Total: {total_added} new asset(s), {hash_mismatches} changed asset(s)");
 
     if changes_with_summary != hash_mismatches {
         println!(
@@ -439,7 +436,7 @@ async fn upload_pkg_specs(
         let msg = format!("Parsing module: {}", spec.file_name().to_string_lossy());
         pb.set_message(msg.to_string());
         if non_interactive {
-            println!("{}", msg);
+            println!("{msg}");
         };
 
         let pkg = json_to_pkg(spec.path())?;
@@ -458,10 +455,7 @@ async fn upload_pkg_specs(
         }
     }
 
-    println!(
-        "🟰 {} modules have matching hashes and will be skipped",
-        no_action_needed
-    );
+    println!("🟰 {no_action_needed} modules have matching hashes and will be skipped");
     println!(
         "🔼 {} modules exist and will be updated",
         modules_with_updates.len()
@@ -485,12 +479,12 @@ async fn upload_pkg_specs(
                 "p" => break,
                 "n" => {
                     for module in &new_modules {
-                        println!("{}", module);
+                        println!("{module}");
                     }
                 }
                 "u" => {
                     for module in &modules_with_updates {
-                        println!("{}", module);
+                        println!("{module}");
                     }
                 }
 
@@ -505,7 +499,7 @@ async fn upload_pkg_specs(
     let msg = "⏰ Beginning uploads ...";
     pb.set_message(msg);
     if non_interactive {
-        println!("{}", msg);
+        println!("{msg}");
     };
 
     // Generates the "X failed" message for various set_message() calls to use
@@ -513,7 +507,7 @@ async fn upload_pkg_specs(
     let failed_message = || {
         let failed = failed.load(Ordering::Relaxed);
         if failed > 0 {
-            format!(" ❌ {} failed.  ", failed)
+            format!(" ❌ {failed} failed.  ")
         } else {
             "".to_string()
         }
@@ -526,7 +520,7 @@ async fn upload_pkg_specs(
             let msg = format!("{}⏰ Uploading: {}", failed_message(), metadata.name());
             pb.set_message(msg.to_string());
             if non_interactive {
-                println!("{}", msg);
+                println!("{msg}");
             };
             pb.inc(1);
             async move {
@@ -576,7 +570,7 @@ async fn upload_pkg_specs(
     );
     pb.finish_with_message(msg.to_string());
     if non_interactive {
-        println!("{}", msg);
+        println!("{msg}");
     };
     // If this message is not here, the console does not show the final message for some reason
     println!("Done");

--- a/bin/innit/src/main.rs
+++ b/bin/innit/src/main.rs
@@ -39,7 +39,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .service_name(BIN_NAME)
             .service_namespace("si")

--- a/bin/innitctl/src/main.rs
+++ b/bin/innitctl/src/main.rs
@@ -24,7 +24,11 @@ async fn main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .service_name(BIN_NAME)
             .service_namespace("si")

--- a/bin/luminork/src/main.rs
+++ b/bin/luminork/src/main.rs
@@ -51,7 +51,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/module-index/src/main.rs
+++ b/bin/module-index/src/main.rs
@@ -36,7 +36,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name("module-index")

--- a/bin/openapi-extractor/src/main.rs
+++ b/bin/openapi-extractor/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api = match api_result {
         Ok(json_api) => json_api.0,
         Err((status, message)) => {
-            return Err(format!("API Error ({}): {}", status, message).into());
+            return Err(format!("API Error ({status}): {message}").into());
         }
     };
 

--- a/bin/pinga/src/main.rs
+++ b/bin/pinga/src/main.rs
@@ -41,7 +41,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/rebaser/src/main.rs
+++ b/bin/rebaser/src/main.rs
@@ -41,7 +41,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/sdf/src/main.rs
+++ b/bin/sdf/src/main.rs
@@ -55,7 +55,11 @@ async fn async_main() -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/bin/veritech/src/main.rs
+++ b/bin/veritech/src/main.rs
@@ -36,7 +36,11 @@ async fn async_main(args: args::Args) -> Result<()> {
         let config = TelemetryConfig::builder()
             .force_color(args.force_color.then_some(true))
             .no_color(args.no_color.then_some(true))
-            .log_format(args.log_json.then_some(LogFormat::Json).unwrap_or_default())
+            .log_format(if args.log_json {
+                LogFormat::Json
+            } else {
+                Default::default()
+            })
             .log_file_directory(args.log_file_directory.clone())
             .tokio_console(args.tokio_console)
             .service_name(BIN_NAME)

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "pinnedDenoVersion": {
+      "locked": {
+        "lastModified": 1748124733,
+        "narHash": "sha256-y7OLqUkEb0Leg/eZCO5/AQh1u5byAnMEj13OMIJ6Uqo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4684fd6b0c01e4b7d99027a34c93c2e09ecafee2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4684fd6b0c01e4b7d99027a34c93c2e09ecafee2",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "pinnedDenoVersion": "pinnedDenoVersion",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747312588,
-        "narHash": "sha256-MmJvj6mlWzeRwKGLcwmZpKaOPZ5nJb/6al5CXqJsgjo=",
+        "lastModified": 1752683762,
+        "narHash": "sha256-CVC4bpthYhKk4Qb4mt00SqfJ7CJ4vfTX06pLN2OHa1c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1bebd0fe266bbd1820019612ead889e96a8fa2d",
+        "rev": "fa64ec5c1ca6f17746f3defedb988b9248e97616",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747190175,
-        "narHash": "sha256-s33mQ2s5L/2nyllhRTywgECNZyCqyF4MJeM3vG/GaRo=",
+        "lastModified": 1752720268,
+        "narHash": "sha256-XCiJdtXIN09Iv0i1gs5ajJ9CVHk537Gy1iG/4nIdpVI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "58160be7abad81f6f8cb53120d5b88c16e01c06d",
+        "rev": "dc221f842e9ddc8c0416beae8d77f2ea356b91ae",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,9 @@
           "x86_64-darwin" = "/dev/null";
           "aarch64-darwin" = "/dev/null";
         }
-        .${system};
+        .${
+          system
+        };
 
       # This isn't an exact science, but confirmed the system interpreter by
       # running `ldd /bin/sh` in Docker containers running:
@@ -105,7 +107,9 @@
           "x86_64-darwin" = "/dev/null";
           "aarch64-darwin" = "/dev/null";
         }
-        .${system};
+        .${
+          system
+        };
 
       langJsExtraPkgs = with pkgs; [
         awscli2

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,29 @@
         nixpkgs.follows = "nixpkgs";
       };
     };
+    # NOTE 2025-07-17
+    # ---------------
+    #
+    # Pin Deno to version 2.2.12 as this is the last version that successfully
+    # built via Hydra. All newer versions revert to source-building which takes
+    # way too long for every developer.
+    #
+    # When the build failures are clear and there are pre-built packages
+    # available for Deno again, remove this input.
+    #
+    # References: https://github.com/NixOS/nixpkgs/issues/417331
+    # References: https://github.com/NixOS/nixpkgs/pull/384838
+    #
+    # See: https://aalbacetef.io/blog/nix-pinning-a-specific-package-version-in-a-flake-using-overlays/
+    # See: https://lazamar.co.uk/nix-versions/?channel=nixpkgs-unstable&package=deno
+    pinnedDenoVersion.url = "github:NixOS/nixpkgs/4684fd6b0c01e4b7d99027a34c93c2e09ecafee2";
   };
 
   outputs = {
     nixpkgs,
     flake-utils,
     rust-overlay,
+    pinnedDenoVersion,
     ...
   }:
     flake-utils.lib.eachDefaultSystem (system: let
@@ -24,6 +41,11 @@
           nodejs = super.nodejs_20;
         })
         (import rust-overlay)
+        # NOTE 2025-07-17: see inputs for explanation. When input is deleted,
+        # remove this overlay too.
+        (final: prev: {
+          deno = pinnedDenoVersion.legacyPackages.${prev.system}.deno;
+        })
       ];
 
       pkgs = import nixpkgs {inherit overlays system;};

--- a/lib/auth-api-client/src/client.rs
+++ b/lib/auth-api-client/src/client.rs
@@ -69,11 +69,8 @@ impl AuthApiClient {
         workspace_id: WorkspacePk,
         token_id: AuthTokenId,
     ) -> AuthApiResult<GetAuthTokenResponse> {
-        self.get(&format!(
-            "workspaces/{}/authTokens/{}",
-            workspace_id, token_id
-        ))
-        .await
+        self.get(&format!("workspaces/{workspace_id}/authTokens/{token_id}"))
+            .await
     }
 
     async fn get<T: DeserializeOwned>(&self, path: &str) -> AuthApiResult<T> {

--- a/lib/bedrock-server/src/profiles/rebaser/measure_rebase.rs
+++ b/lib/bedrock-server/src/profiles/rebaser/measure_rebase.rs
@@ -52,7 +52,7 @@ fn load_message_sequence(recording_id: &str) -> Vec<JsonMessage> {
     let mut other_messages = Vec::new();
 
     for entry in entries {
-        let entry = entry.unwrap_or_else(|e| panic!("Failed to read entry: {}", e));
+        let entry = entry.unwrap_or_else(|e| panic!("Failed to read entry: {e}"));
         let path = entry.path();
 
         if path.is_file() {
@@ -98,7 +98,7 @@ pub async fn reissue_rebaser_tracker_message(
     workspace_id: &str,
     changeset_id: &str,
 ) -> Result<(), String> {
-    let subject = format!("rebaser.tasks.{}.{}.process", workspace_id, changeset_id);
+    let subject = format!("rebaser.tasks.{workspace_id}.{changeset_id}.process");
 
     let js = jetstream::new(nats.clone());
     let headers = HeaderMap::new();
@@ -155,7 +155,7 @@ impl TestProfile for MeasureRebase {
         let mut success_count = 0;
 
         for (i, json_msg) in messages.into_iter().enumerate() {
-            let reply_subject = format!("_INBOX.INCOMING_RESPONSES.{}", i);
+            let reply_subject = format!("_INBOX.INCOMING_RESPONSES.{i}");
             let mut headers = HeaderMap::new();
             let new_ulid = Ulid::new().to_string();
 
@@ -233,10 +233,10 @@ impl TestProfile for MeasureRebase {
                         let response = tokio::select! {
                             msg = sub.next() => msg,
                             _ = &mut timeout => {
-                                println!("Timeout waiting for response on {}", reply_subject);
+                                println!("Timeout waiting for response on {reply_subject}");
                                 return TestResult {
                                     success: false,
-                                    message: format!("Timeout waiting for response from service on subject {}", reply_subject),
+                                    message: format!("Timeout waiting for response from service on subject {reply_subject}"),
                                     duration_ms: None,
                                     output: Some(json!({
                                         "failed_message_index": i,
@@ -270,15 +270,11 @@ impl TestProfile for MeasureRebase {
                                             .and_then(|err| err.get("message"))
                                             .and_then(|msg| msg.as_str())
                                         {
-                                            println!(
-                                                "Early exit: error in response: {}",
-                                                error_msg
-                                            );
+                                            println!("Early exit: error in response: {error_msg}");
                                             return TestResult {
                                                 success: false,
                                                 message: format!(
-                                                    "Error at message {}: {}",
-                                                    i, error_msg
+                                                    "Error at message {i}: {error_msg}"
                                                 ),
                                                 duration_ms: None,
                                                 output: Some(json!({
@@ -289,11 +285,11 @@ impl TestProfile for MeasureRebase {
                                         }
                                     }
                                     Err(e) => {
-                                        println!("Failed to parse response CBOR: {:?}", e);
+                                        println!("Failed to parse response CBOR: {e:?}");
                                     }
                                 }
                             }
-                            None => println!("No response received on {}", reply_subject),
+                            None => println!("No response received on {reply_subject}"),
                         }
                     }
                     Err(e) => println!("Ack error for {}: {:?}", json_msg.subject, e),
@@ -304,7 +300,7 @@ impl TestProfile for MeasureRebase {
 
         TestResult {
             success: true,
-            message: format!("Sent and received {} message-response pairs", success_count),
+            message: format!("Sent and received {success_count} message-response pairs"),
             duration_ms: Some(42),
             output: Some(json!({ "message_response_pairs": success_count })),
         }

--- a/lib/bedrock-server/src/routes/prepare.rs
+++ b/lib/bedrock-server/src/routes/prepare.rs
@@ -51,7 +51,7 @@ pub async fn prepare_route(
     if let Err(e) = prepare_databases(database_sql_dumps).await {
         let result = PrepareResult {
             success: false,
-            message: format!("Failed to prepare requested databases: {}", e),
+            message: format!("Failed to prepare requested databases: {e}"),
             recording_id,
             duration_ms: Some(start_time.elapsed().as_millis() as u64),
             output: None,
@@ -62,7 +62,7 @@ pub async fn prepare_route(
     if let Err(e) = clear_nats(&state.nats).await {
         let result = PrepareResult {
             success: false,
-            message: format!("Failed to clear nats: {}", e),
+            message: format!("Failed to clear nats: {e}"),
             recording_id,
             duration_ms: Some(start_time.elapsed().as_millis() as u64),
             output: None,
@@ -81,7 +81,7 @@ pub async fn prepare_route(
         Err(e) => {
             let result = PrepareResult {
                 success: false,
-                message: format!("Failed to collect files: {}", e),
+                message: format!("Failed to collect files: {e}"),
                 recording_id,
                 duration_ms: Some(start_time.elapsed().as_millis() as u64),
                 output: None,

--- a/lib/bedrock-server/src/routes/record.rs
+++ b/lib/bedrock-server/src/routes/record.rs
@@ -41,7 +41,7 @@ pub async fn start_recording_route(
         if let Err(e) = configure_nats(&state.nats, nats_streams, &recording_id).await {
             let result = RecordResult {
                 success: false,
-                message: format!("Failed to setup nats: {}", e),
+                message: format!("Failed to setup nats: {e}"),
                 recording_id,
                 duration_ms: Some(start_time.elapsed().as_millis() as u64),
                 output: None,
@@ -55,7 +55,7 @@ pub async fn start_recording_route(
         if let Err(e) = dump_databases(postgres_dbs, &recording_id, "start").await {
             let result = RecordResult {
                 success: false,
-                message: format!("Failed to dump requested databases: {}", e),
+                message: format!("Failed to dump requested databases: {e}"),
                 recording_id,
                 duration_ms: Some(start_time.elapsed().as_millis() as u64),
                 output: None,
@@ -103,7 +103,7 @@ pub async fn stop_recording_route(
         if let Err(e) = capture_nats(&state.nats, nats_streams, &recording_id).await {
             let result = RecordResult {
                 success: false,
-                message: format!("Failed to capture messages on nats: {}", e),
+                message: format!("Failed to capture messages on nats: {e}"),
                 recording_id,
                 duration_ms: Some(start_time.elapsed().as_millis() as u64),
                 output: None,
@@ -117,7 +117,7 @@ pub async fn stop_recording_route(
         if let Err(e) = dump_databases(postgres_dbs, &recording_id, "end").await {
             let result = RecordResult {
                 success: false,
-                message: format!("Failed to dump requested databases: {}", e),
+                message: format!("Failed to dump requested databases: {e}"),
                 recording_id,
                 duration_ms: Some(start_time.elapsed().as_millis() as u64),
                 output: None,
@@ -135,8 +135,7 @@ pub async fn stop_recording_route(
     let response = RecordResult {
         success: true,
         message: format!(
-            "Recording stopped, please see output directory for content for recording_id {}",
-            recording_id
+            "Recording stopped, please see output directory for content for recording_id {recording_id}"
         ),
         recording_id,
         duration_ms: Some(duration),

--- a/lib/bedrock-server/src/server.rs
+++ b/lib/bedrock-server/src/server.rs
@@ -162,7 +162,7 @@ pub fn build_service(
                     tracing::error!(error = %err, "Unexpected error in request processing");
                     Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(format!("Internal server error: {}", err))
+                        .body(format!("Internal server error: {err}"))
                         .expect("Unable to build error response body")
                         .into_response()
                 }))

--- a/lib/config-file/src/parameter_provider.rs
+++ b/lib/config-file/src/parameter_provider.rs
@@ -61,7 +61,7 @@ impl<P: ParameterProvider> ParameterSource<P> {
         builder: ConfigBuilder<St>,
     ) -> Result<ConfigBuilder<St>, config::ConfigError> {
         let environment = self.provider.environment().await;
-        let global_path = format!("si/{}/global", environment);
+        let global_path = format!("si/{environment}/global");
         let global_params = match self
             .provider
             .get_parameters_by_path(global_path.clone())

--- a/lib/dal-test/src/expand_helpers.rs
+++ b/lib/dal-test/src/expand_helpers.rs
@@ -116,15 +116,14 @@ fn tracing_init_inner(span_events_env_var: &str, log_env_var: &str) {
                     "active" => FmtSpan::ACTIVE,
                     "full" => FmtSpan::FULL,
                     _ => panic!(
-                        "{} must contain filters separated by `,`.\n\t\
+                        "{span_events_env_var} must contain filters separated by `,`.\n\t\
                             For example: `active` or `new,close`\n\t
-                            Got: {}",
-                        span_events_env_var, value,
+                            Got: {value}",
                     ),
                 })
                 .fold(FmtSpan::NONE, |acc, filter| filter | acc),
             Err(::std::env::VarError::NotUnicode(_)) => {
-                panic!("{} must contain a valid UTF-8 string", span_events_env_var,)
+                panic!("{span_events_env_var} must contain a valid UTF-8 string",)
             }
             Err(::std::env::VarError::NotPresent) => FmtSpan::NONE,
         }

--- a/lib/dal/examples/rebase/main.rs
+++ b/lib/dal/examples/rebase/main.rs
@@ -34,7 +34,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + 'static>>;
 const USAGE: &str = "usage: cargo run --example rebase <TO_REBASE_FILE_PATH> <REBASE_BATCH_PATH>";
 
 fn load_serialized_stuff<T: DeserializeOwned>(path: &str) -> Result<T> {
-    println!("opening file: {}", path);
+    println!("opening file: {path}");
     let mut file = File::open(path)?;
     let mut bytes = vec![];
     file.read_to_end(&mut bytes)?;
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
         graph_to_update.perform_updates(&updates);
 
         if let Err(Cycle(node_id)) = toposort(&graph_to_update) {
-            println!("Cycle detected at node ID: {}", node_id);
+            println!("Cycle detected at node ID: {node_id}");
             // dbg!(
             //     graph_to_update
             //         .raw_nodes()

--- a/lib/dal/examples/snapshot-surfer/main.rs
+++ b/lib/dal/examples/snapshot-surfer/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         let ident = node_ident(&graph, node_idx)?;
         println!();
         println!("{}", "=".repeat(ident.len()));
-        println!("{}", ident);
+        println!("{ident}");
         println!();
         println!("  {:?}", graph.get_node_weight(node_idx)?);
         print_edges(&graph, node_idx)?;
@@ -87,7 +87,7 @@ fn print_edges(graph: &WorkspaceSnapshotGraph, index: NodeIndex) -> Result<()> {
         .try_collect()?;
     println!();
     for incoming in incoming {
-        println!("  {}", incoming);
+        println!("  {incoming}");
     }
 
     println!();
@@ -99,7 +99,7 @@ fn print_edges(graph: &WorkspaceSnapshotGraph, index: NodeIndex) -> Result<()> {
         })
         .try_collect()?;
     for outgoing in outgoing {
-        println!("  {}", outgoing);
+        println!("  {outgoing}");
     }
     Ok(())
 }

--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -76,43 +76,127 @@ pub mod prototype;
 #[derive(Debug, Error)]
 pub enum ActionError {
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] crate::attribute::prototype::AttributePrototypeError),
+    AttributePrototype(#[from] Box<crate::attribute::prototype::AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(
-        #[from] crate::attribute::prototype::argument::AttributePrototypeArgumentError,
+        #[from] Box<crate::attribute::prototype::argument::AttributePrototypeArgumentError>,
     ),
     #[error("AttributeValue error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("Change Set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("Component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("component not found for action: {0}")]
     ComponentNotFoundForAction(ActionId),
     #[error("dependent value root error: {0}")]
-    DependentValueRoot(#[from] DependentValueRootError),
+    DependentValueRoot(#[from] Box<DependentValueRootError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("Helper error: {0}")]
-    Helper(#[from] HelperError),
+    Helper(#[from] Box<HelperError>),
     #[error("InferredConnectionGraph error: {0}")]
-    InferredConnectionGraph(#[from] InferredConnectionGraphError),
+    InferredConnectionGraph(#[from] Box<InferredConnectionGraphError>),
     #[error("Layer DB error: {0}")]
     LayerDb(#[from] LayerDbError),
     #[error("Node Weight error: {0}")]
-    NodeWeight(#[from] NodeWeightError),
+    NodeWeight(#[from] Box<NodeWeightError>),
     #[error("prototype not found for action: {0}")]
     PrototypeNotFoundForAction(ActionId),
     #[error("Transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("Unable to determine kind for action: {0}")]
     UnableToGetKind(ActionId),
     #[error("Workspace Snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<ActionPrototypeError> for ActionError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::attribute::prototype::AttributePrototypeError> for ActionError {
+    fn from(value: crate::attribute::prototype::AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::attribute::prototype::argument::AttributePrototypeArgumentError> for ActionError {
+    fn from(value: crate::attribute::prototype::argument::AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for ActionError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for ActionError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for ActionError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DependentValueRootError> for ActionError {
+    fn from(value: DependentValueRootError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for ActionError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<HelperError> for ActionError {
+    fn from(value: HelperError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InferredConnectionGraphError> for ActionError {
+    fn from(value: InferredConnectionGraphError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for ActionError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for ActionError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for ActionError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for ActionError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type ActionResult<T> = Result<T, ActionError>;

--- a/lib/dal/src/action/prototype.rs
+++ b/lib/dal/src/action/prototype.rs
@@ -71,37 +71,103 @@ pub enum ActionPrototypeError {
     #[error("action error: {0}")]
     Action(#[from] Box<ActionError>),
     #[error("Change Set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("diagram error: {0}")]
-    Diagram(#[from] DiagramError),
+    Diagram(#[from] Box<DiagramError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func not found for prototype: {0}")]
     FuncNotFoundForPrototype(ActionPrototypeId),
     #[error("func runner error: {0}")]
-    FuncRunner(#[from] FuncRunnerError),
+    FuncRunner(#[from] Box<FuncRunnerError>),
     #[error("func runner has failed to send a value and exited")]
     FuncRunnerSend,
     #[error("Helper error: {0}")]
-    Helper(#[from] HelperError),
+    Helper(#[from] Box<HelperError>),
     #[error("Layer DB Error: {0}")]
     LayerDb(#[from] LayerDbError),
     #[error("Node Weight error: {0}")]
-    NodeWeight(#[from] NodeWeightError),
+    NodeWeight(#[from] Box<NodeWeightError>),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant not found for prototype: {0}")]
     SchemaVariantNotFoundForPrototype(ActionPrototypeId),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("Transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("Workspace Snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<ChangeSetError> for ActionPrototypeError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for ActionPrototypeError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DiagramError> for ActionPrototypeError {
+    fn from(value: DiagramError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for ActionPrototypeError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncRunnerError> for ActionPrototypeError {
+    fn from(value: FuncRunnerError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<HelperError> for ActionPrototypeError {
+    fn from(value: HelperError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for ActionPrototypeError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for ActionPrototypeError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for ActionPrototypeError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for ActionPrototypeError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for ActionPrototypeError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type ActionPrototypeResult<T> = Result<T, ActionPrototypeError>;

--- a/lib/dal/src/attribute/path.rs
+++ b/lib/dal/src/attribute/path.rs
@@ -32,7 +32,7 @@ pub enum AttributePath {
 impl std::fmt::Display for AttributePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AttributePath::JsonPointer(path) => write!(f, "{}", path),
+            AttributePath::JsonPointer(path) => write!(f, "{path}"),
         }
     }
 }

--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -97,13 +97,13 @@ pub enum AttributePrototypeError {
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func error: {0}")]
-    FuncArgument(#[from] crate::func::argument::FuncArgumentError),
+    FuncArgument(#[from] Box<crate::func::argument::FuncArgumentError>),
     #[error("helper error: {0}")]
-    Helper(#[from] HelperError),
+    Helper(#[from] Box<HelperError>),
     #[error("layer db error: {0}")]
     LayerDb(#[from] LayerDbError),
     #[error("attribute prototype {0} is missing a function edge")]
@@ -138,6 +138,30 @@ pub type AttributePrototypeResult<T> = Result<T, AttributePrototypeError>;
 
 impl From<AttributePrototypeArgumentError> for AttributePrototypeError {
     fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for AttributePrototypeError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for AttributePrototypeError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::func::argument::FuncArgumentError> for AttributePrototypeError {
+    fn from(value: crate::func::argument::FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<HelperError> for AttributePrototypeError {
+    fn from(value: HelperError) -> Self {
         Box::new(value).into()
     }
 }

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -61,33 +61,33 @@ type AttributePrototypeDebugViewResult<T> = Result<T, AttributePrototypeDebugVie
 #[derive(Error, Debug)]
 pub enum AttributePrototypeDebugViewError {
     #[error("attribute prototype argument Error: {0}")]
-    AttributePrototypeArgumentError(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgumentError(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototypeError(#[from] AttributePrototypeError),
+    AttributePrototypeError(#[from] Box<AttributePrototypeError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("component error: {0}")]
-    ComponentError(#[from] ComponentError),
+    ComponentError(#[from] Box<ComponentError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgumentError(#[from] FuncArgumentError),
+    FuncArgumentError(#[from] Box<FuncArgumentError>),
     #[error("input socket error: {0}")]
-    InputSocketError(#[from] InputSocketError),
+    InputSocketError(#[from] Box<InputSocketError>),
     #[error("node weight error: {0}")]
-    NodeWeightError(#[from] NodeWeightError),
+    NodeWeightError(#[from] Box<NodeWeightError>),
     #[error("output socket error: {0}")]
-    OutputSocketError(#[from] OutputSocketError),
+    OutputSocketError(#[from] Box<OutputSocketError>),
     #[error("prop error: {0}")]
-    PropError(#[from] PropError),
+    PropError(#[from] Box<PropError>),
     #[error("secret error: {0}")]
-    SecretError(#[from] SecretError),
+    SecretError(#[from] Box<SecretError>),
     #[error("serde json error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
     #[error("value source error: {0}")]
-    ValueSourceError(#[from] ValueSourceError),
+    ValueSourceError(#[from] Box<ValueSourceError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshotError(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshotError(#[from] Box<WorkspaceSnapshotError>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -358,5 +358,83 @@ impl AttributePrototypeDebugView {
             is_component_specific: has_component_prototype,
         };
         Ok(view)
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for AttributePrototypeDebugViewError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for AttributePrototypeDebugViewError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for AttributePrototypeDebugViewError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for AttributePrototypeDebugViewError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for AttributePrototypeDebugViewError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for AttributePrototypeDebugViewError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for AttributePrototypeDebugViewError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for AttributePrototypeDebugViewError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for AttributePrototypeDebugViewError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for AttributePrototypeDebugViewError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SecretError> for AttributePrototypeDebugViewError {
+    fn from(value: SecretError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValueSourceError> for AttributePrototypeDebugViewError {
+    fn from(value: ValueSourceError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for AttributePrototypeDebugViewError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -176,7 +176,7 @@ impl AttributePrototypeDebugView {
                         vec![FuncArgDebugView {
                             value: view.unwrap_or(Value::Null),
                             name: func_arg_name.clone(),
-                            value_source: format!("{:?}", value_source),
+                            value_source: format!("{value_source:?}"),
                             value_source_id,
                             path: None,
                             socket_source_kind: None,
@@ -189,7 +189,7 @@ impl AttributePrototypeDebugView {
                                 "[REDACTED KEY FOR SECRET (ID: {secret_id})]"
                             ))?,
                             name: func_arg_name.clone(),
-                            value_source: format!("{:?}", value_source),
+                            value_source: format!("{value_source:?}"),
                             value_source_id: secret_id.into(),
                             path: None,
                             socket_source_kind: None,
@@ -203,7 +203,7 @@ impl AttributePrototypeDebugView {
                         vec![FuncArgDebugView {
                             value: val,
                             name: func_arg_name.clone(),
-                            value_source: format!("{:?}", value_source),
+                            value_source: format!("{value_source:?}"),
                             value_source_id: static_argument_value_id.into(),
                             path: None,
                             socket_source_kind: None,
@@ -225,7 +225,7 @@ impl AttributePrototypeDebugView {
                             let func_arg_debug = FuncArgDebugView {
                                 value: view,
                                 name: func_arg_name.clone(),
-                                value_source: format!("{:?}", value_source),
+                                value_source: format!("{value_source:?}"),
                                 value_source_id: prop_id.into(),
                                 socket_source_kind: None,
                                 path: prop_path,
@@ -252,7 +252,7 @@ impl AttributePrototypeDebugView {
                             let func_arg_debug = FuncArgDebugView {
                                 value: value_view,
                                 name: func_arg_name.clone(),
-                                value_source: format!("{:?}", value_source),
+                                value_source: format!("{value_source:?}"),
                                 value_source_id: input_socket_id.into(),
                                 socket_source_kind: Some(SocketSourceKind::Manual),
                                 path: attribute_value_path,
@@ -279,7 +279,7 @@ impl AttributePrototypeDebugView {
                             let func_arg_debug = FuncArgDebugView {
                                 value: value_view,
                                 name: func_arg_name.clone(),
-                                value_source: format!("{:?}", value_source),
+                                value_source: format!("{value_source:?}"),
                                 value_source_id: output_socket_id.into(),
                                 socket_source_kind: Some(SocketSourceKind::Manual),
                                 path: attribute_value_path,

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -131,9 +131,9 @@ pub enum AttributeValueError {
     #[error("action error: {0}")]
     Action(String),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error(
         "attribute prototype argument {0} has a value source {1:?} but no value for that prop found in component {2}"
     )]
@@ -192,9 +192,9 @@ pub enum AttributeValueError {
     #[error("object field is not a child prop of the object prop: {0}")]
     FieldNotChildOfObject(AttributeValueId),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("function result failure: kind={kind}, message={message}, backend={backend}")]
     FuncBackendResultFailure {
         kind: String,
@@ -212,7 +212,7 @@ pub enum AttributeValueError {
     #[error("InferredConnectionGraph error: {0}")]
     InferredConnectionGraph(#[from] InferredConnectionGraphError),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("cannot insert for prop kind: {0}")]
     InsertionForInvalidPropKind(PropKind),
     #[error("jsonptr parse error parsing {0}: {1}")]
@@ -252,11 +252,11 @@ pub enum AttributeValueError {
     #[error("attribute value {0} has no outgoing edge to a prop or socket")]
     OrphanedAttributeValue(AttributeValueId),
     #[error("output socket error: {0}")]
-    OutputSocketError(#[from] OutputSocketError),
+    OutputSocketError(#[from] Box<OutputSocketError>),
     #[error("parent prop of map or array not found: {0}")]
     ParentAttributeValueMissing(AttributeValueId),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("array or map prop missing element prop: {0}")]
     PropMissingElementProp(PropId),
     #[error("array or map prop has more than one child prop: {0}")]
@@ -286,9 +286,9 @@ pub enum AttributeValueError {
     #[error("reached unreachable code")]
     Unreachable,
     #[error("validation error: {0}")]
-    Validation(#[from] ValidationError),
+    Validation(#[from] Box<ValidationError>),
     #[error("value source error: {0}")]
-    ValueSource(#[from] ValueSourceError),
+    ValueSource(#[from] Box<ValueSourceError>),
     #[error("workspace error: {0}")]
     Workspace(String),
     #[error("workspace snapshot error: {0}")]
@@ -309,6 +309,60 @@ impl From<FuncRunnerError> for AttributeValueError {
 }
 impl From<SecretError> for AttributeValueError {
     fn from(value: SecretError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for AttributeValueError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for AttributeValueError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for AttributeValueError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for AttributeValueError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for AttributeValueError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for AttributeValueError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for AttributeValueError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValidationError> for AttributeValueError {
+    fn from(value: ValidationError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValueSourceError> for AttributeValueError {
+    fn from(value: ValueSourceError) -> Self {
         Box::new(value).into()
     }
 }

--- a/lib/dal/src/attribute/value/debug.rs
+++ b/lib/dal/src/attribute/value/debug.rs
@@ -69,29 +69,29 @@ type AttributeDebugViewResult<T> = Result<T, AttributeDebugViewError>;
 #[derive(Error, Debug)]
 pub enum AttributeDebugViewError {
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgumentError(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgumentError(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute debug view error: {0}")]
-    AttributePrototypeDebugViewError(#[from] AttributePrototypeDebugViewError),
+    AttributePrototypeDebugViewError(#[from] Box<AttributePrototypeDebugViewError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototypeError(#[from] AttributePrototypeError),
+    AttributePrototypeError(#[from] Box<AttributePrototypeError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("component error: {0}")]
-    ComponentError(#[from] ComponentError),
+    ComponentError(#[from] Box<ComponentError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("input socket error: {0}")]
-    InputSocketError(#[from] InputSocketError),
+    InputSocketError(#[from] Box<InputSocketError>),
     #[error("node weight error: {0}")]
-    NodeWeightError(#[from] NodeWeightError),
+    NodeWeightError(#[from] Box<NodeWeightError>),
     #[error("output socket error: {0}")]
-    OutputSocketError(#[from] OutputSocketError),
+    OutputSocketError(#[from] Box<OutputSocketError>),
     #[error("prop error: {0}")]
-    PropError(#[from] PropError),
+    PropError(#[from] Box<PropError>),
     #[error("value source error: {0}")]
-    ValueSourceError(#[from] ValueSourceError),
+    ValueSourceError(#[from] Box<ValueSourceError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshotError(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshotError(#[from] Box<WorkspaceSnapshotError>),
 }
 impl AttributeDebugView {
     #[instrument(level = "trace", skip_all)]
@@ -137,5 +137,77 @@ impl AttributeDebugView {
             view: value_view,
         };
         Ok(view)
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for AttributeDebugViewError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeDebugViewError> for AttributeDebugViewError {
+    fn from(value: AttributePrototypeDebugViewError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for AttributeDebugViewError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for AttributeDebugViewError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for AttributeDebugViewError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for AttributeDebugViewError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for AttributeDebugViewError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for AttributeDebugViewError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for AttributeDebugViewError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for AttributeDebugViewError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValueSourceError> for AttributeDebugViewError {
+    fn from(value: ValueSourceError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for AttributeDebugViewError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/attribute/value/dependent_value_graph.rs
+++ b/lib/dal/src/attribute/value/dependent_value_graph.rs
@@ -554,10 +554,7 @@ impl DependentValueGraph {
                     .map(ToOwned::to_owned)
                     .expect("component name exists for every value");
 
-                format!(
-                    "label = \"{}\n{}\n{}\"",
-                    component_name, attribute_value_id, is_for_string
-                )
+                format!("label = \"{component_name}\n{attribute_value_id}\n{is_for_string}\"")
             };
 
         let dot = petgraph::dot::Dot::with_attr_getters(

--- a/lib/dal/src/audit_logging.rs
+++ b/lib/dal/src/audit_logging.rs
@@ -81,7 +81,11 @@ pub(crate) async fn publish_pending(
     // TODO(nick): nuke this from intergalactic orbit. Then do it again.
     let workspace_id = match ctx.workspace_pk() {
         Ok(workspace_id) => workspace_id,
-        Err(TransactionsError::SiDb(si_db::Error::NoWorkspace)) => return Ok(()),
+        Err(TransactionsError::SiDb(si_db_err))
+            if matches!(si_db_err.as_ref(), si_db::Error::NoWorkspace) =>
+        {
+            return Ok(());
+        }
         Err(err) => return Err(AuditLoggingError::Transactions(Box::new(err))),
     };
 
@@ -217,7 +221,11 @@ pub(crate) async fn write(
     // TODO(nick): nuke this from intergalactic orbit. Then do it again.
     let workspace_id = match ctx.workspace_pk() {
         Ok(workspace_id) => workspace_id,
-        Err(TransactionsError::SiDb(si_db::Error::NoWorkspace)) => return Ok(()),
+        Err(TransactionsError::SiDb(si_db_err))
+            if matches!(si_db_err.as_ref(), si_db::Error::NoWorkspace) =>
+        {
+            return Ok(());
+        }
         Err(err) => return Err(AuditLoggingError::Transactions(Box::new(err))),
     };
 
@@ -248,7 +256,11 @@ pub(crate) async fn write_final_message(ctx: &DalContext) -> Result<()> {
     // TODO(nick): nuke this from intergalactic orbit. Then do it again.
     let workspace_id = match ctx.workspace_pk() {
         Ok(workspace_id) => workspace_id,
-        Err(TransactionsError::SiDb(si_db::Error::NoWorkspace)) => return Ok(()),
+        Err(TransactionsError::SiDb(si_db_err))
+            if matches!(si_db_err.as_ref(), si_db::Error::NoWorkspace) =>
+        {
+            return Ok(());
+        }
         Err(err) => return Err(AuditLoggingError::Transactions(Box::new(err))),
     };
 

--- a/lib/dal/src/builtins.rs
+++ b/lib/dal/src/builtins.rs
@@ -32,15 +32,15 @@ pub mod schema;
 #[derive(Error, Debug)]
 pub enum BuiltinsError {
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute value not found by id: {0}")]
     AttributeValueNotFound(AttributeValueId),
     #[error("builtin {0} missing func argument {1}")]
     BuiltinMissingFuncArgument(String, String),
     #[error("func error")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("json error {1} at file {0}")]
     FuncJson(String, serde_json::Error),
     #[error("func metadata error: {0}")]
@@ -54,9 +54,9 @@ pub enum BuiltinsError {
     #[error("no packages path configured")]
     MissingPkgsPath,
     #[error("module error: {0}")]
-    Module(#[from] ModuleError),
+    Module(#[from] Box<ModuleError>),
     #[error("pkg error: {0}")]
-    Pkg(#[from] PkgError),
+    Pkg(#[from] Box<PkgError>),
     #[error("prop cache not found: {0}")]
     PropCacheNotFound(SchemaVariantId),
     #[error("prop not bound by id: {0}")]
@@ -64,7 +64,7 @@ pub enum BuiltinsError {
     #[error("regex parsing error: {0}")]
     Regex(#[from] regex::Error),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("encountered serde json error for func ({0}): {1}")]
@@ -75,6 +75,42 @@ pub enum BuiltinsError {
     Spec(#[from] SpecError),
     #[error("error creating new transactions")]
     Transactions(#[from] TransactionsError),
+}
+
+impl From<ActionPrototypeError> for BuiltinsError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for BuiltinsError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for BuiltinsError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ModuleError> for BuiltinsError {
+    fn from(value: ModuleError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PkgError> for BuiltinsError {
+    fn from(value: PkgError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for BuiltinsError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type BuiltinsResult<T> = Result<T, BuiltinsError>;

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -110,7 +110,7 @@ pub enum ChangeSetError {
     #[error("tokio join error: {0}")]
     Join(#[from] tokio::task::JoinError),
     #[error("layer db error: {0}")]
-    LayerDb(#[from] LayerDbError),
+    LayerDb(#[from] Box<LayerDbError>),
     #[error("ulid monotonic error: {0}")]
     Monotonic(#[from] ulid::MonotonicError),
     #[error("mutex error: {0}")]
@@ -124,9 +124,9 @@ pub enum ChangeSetError {
     #[error("Changeset {0} does not have a workspace snapshot")]
     NoWorkspaceSnapshot(ChangeSetId),
     #[error("pg error: {0}")]
-    Pg(#[from] PgError),
+    Pg(#[from] Box<PgError>),
     #[error("rebaser client error: {0}")]
-    RebaserClient(#[from] rebaser_client::ClientError),
+    RebaserClient(#[from] Box<rebaser_client::ClientError>),
     #[error("schema error: {0}")]
     Schema(#[from] Box<SchemaError>),
     #[error("schema variant error: {0}")]
@@ -134,11 +134,11 @@ pub enum ChangeSetError {
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("si db error: {0}")]
-    SiDb(#[from] si_db::Error),
+    SiDb(#[from] Box<si_db::Error>),
     #[error("slow runtime error: {0}")]
     SlowRuntime(#[from] SlowRuntimeError),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("ulid decode error: {0}")]
     UlidDecode(#[from] ulid::DecodeError),
     #[error(
@@ -153,15 +153,75 @@ pub enum ChangeSetError {
     WsEvent(#[from] Box<WsEventError>),
 }
 
+impl From<LayerDbError> for ChangeSetError {
+    fn from(value: LayerDbError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<si_db::Error> for ChangeSetError {
+    fn from(value: si_db::Error) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PgError> for ChangeSetError {
+    fn from(value: PgError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<rebaser_client::ClientError> for ChangeSetError {
+    fn from(value: rebaser_client::ClientError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for ChangeSetError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
 impl From<WorkspaceError> for ChangeSetError {
     fn from(value: WorkspaceError) -> Self {
-        Self::Workspace(Box::new(value))
+        Box::new(value).into()
     }
 }
 
 impl From<WsEventError> for ChangeSetError {
     fn from(value: WsEventError) -> Self {
-        Self::WsEvent(Box::new(value))
+        Box::new(value).into()
+    }
+}
+
+impl From<ActionError> for ChangeSetApplyError {
+    fn from(value: ActionError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for ChangeSetApplyError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for ChangeSetApplyError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<si_db::Error> for ChangeSetApplyError {
+    fn from(value: si_db::Error) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for ChangeSetApplyError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
     }
 }
 
@@ -173,15 +233,15 @@ pub type ChangeSetResult<T> = Result<T, ChangeSetError>;
 #[derive(Debug, Error)]
 pub enum ChangeSetApplyError {
     #[error("action error: {0}")]
-    Action(#[from] ActionError),
+    Action(#[from] Box<ActionError>),
     #[error("action prototype not found for id: {0}")]
     ActionPrototypeNotFound(ActionId),
     #[error("Cannot apply changeset {0} to itself")]
     CannotApplyToItself(ChangeSetId),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("invalid user: {0}")]
     InvalidUser(UserPk),
     #[error("invalid user system init")]
@@ -189,9 +249,9 @@ pub enum ChangeSetApplyError {
     #[error("change set ({0}) does not have a base change set")]
     NoBaseChangeSet(ChangeSetId),
     #[error("si db error: {0}")]
-    SiDb(#[from] si_db::Error),
+    SiDb(#[from] Box<si_db::Error>),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
 }
 
 /// A superset of [`ChangeSetResult`] used when performing apply logic.

--- a/lib/dal/src/change_set.rs
+++ b/lib/dal/src/change_set.rs
@@ -1084,7 +1084,7 @@ impl ChangeSet {
     }
 
     pub async fn extract_userid_from_context(ctx: &DalContext) -> Option<UserPk> {
-        let user_id = match ctx.history_actor() {
+        match ctx.history_actor() {
             HistoryActor::User(user_pk) => {
                 let maybe_user = User::get_by_pk_opt(ctx, *user_pk).await;
                 match maybe_user {
@@ -1093,9 +1093,9 @@ impl ChangeSet {
                 }
             }
             HistoryActor::SystemInit => None,
-        };
-        user_id
+        }
     }
+
     pub async fn extract_userid_from_context_or_error(ctx: &DalContext) -> ChangeSetResult<UserPk> {
         let user_id = match ctx.history_actor() {
             HistoryActor::User(user_pk) => User::get_by_pk(ctx, *user_pk).await?.pk(),

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -4085,7 +4085,7 @@ impl Component {
         if name.ends_with("- Copy") {
             name
         } else {
-            format!("{} - Copy", name)
+            format!("{name} - Copy")
         }
     }
 

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -210,11 +210,11 @@ pub enum ComponentError {
     #[error("action prototype error: {0}")]
     ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error(
         "attribute value view could not be generated, root value not found; workspace_pk={0}, change_set_id={1}, component_id={2}"
     )]
@@ -224,7 +224,7 @@ pub enum ComponentError {
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("code view error: {0}")]
-    CodeView(#[from] CodeViewError),
+    CodeView(#[from] Box<CodeViewError>),
     #[error("component {0} already has a geometry for view {1}")]
     ComponentAlreadyInView(ComponentId, ViewId),
     #[error("component has children, cannot change to component type")]
@@ -256,17 +256,17 @@ pub enum ComponentError {
     #[error("frame error: {0}")]
     Frame(#[from] Box<FrameError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgumentError(#[from] FuncArgumentError),
+    FuncArgumentError(#[from] Box<FuncArgumentError>),
     #[error("func binding error: {0}")]
     FuncBinding(#[from] Box<FuncBindingError>),
     #[error("helper error: {0}")]
     Helper(#[from] HelperError),
     #[error("InferredConnectionGraph Error: {0}")]
-    InferredConnectionGraph(#[from] InferredConnectionGraphError),
+    InferredConnectionGraph(#[from] Box<InferredConnectionGraphError>),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("input socket {0} not found for component id {1}")]
     InputSocketNotFoundForComponentId(InputSocketId, ComponentId),
     #[error("input socket {0} has more than one attribute value")]
@@ -286,7 +286,7 @@ pub enum ComponentError {
     #[error("component {0} missing attribute value for root")]
     MissingRootProp(ComponentId),
     #[error("module error: {0}")]
-    Module(#[from] ModuleError),
+    Module(#[from] Box<ModuleError>),
     #[error("more than one schema variant found for component: {0}")]
     MoreThanOneSchemaVariantFound(ComponentId),
     #[error("found multiple parents for component: {0}")]
@@ -302,7 +302,7 @@ pub enum ComponentError {
     #[error("object prop {0} has no ordering node")]
     ObjectPropHasNoOrderingNode(PropId),
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("output socket has not found for attribute value id {0}")]
     OutputSocketNotFoundForAttributeValueId(AttributeValueId),
     #[error("output socket {0} not found for component id {1}")]
@@ -314,11 +314,11 @@ pub enum ComponentError {
     #[error(transparent)]
     ParseInt(#[from] ParseIntError),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("found prop id ({0}) that is not a prop")]
     PropIdNotAProp(PropId),
     #[error("qualification error: {0}")]
-    Qualification(#[from] QualificationError),
+    Qualification(#[from] Box<QualificationError>),
     #[error("ordering node not found for qualifications map {0} and component {1}")]
     QualificationNoOrderingNode(AttributeValueId, ComponentId),
     #[error("qualification summary error: {0}")]
@@ -328,7 +328,7 @@ pub enum ComponentError {
     #[error("root attribute value not found for component: {0}")]
     RootAttributeValueNotFound(ComponentId),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant not found for component: {0}")]
     SchemaVariantNotFound(ComponentId),
     #[error("serde_json error: {0}")]
@@ -356,11 +356,11 @@ pub enum ComponentError {
     )]
     UnexpectedExplicitAndInferredSources(ComponentId, ComponentId, ComponentInputSocket),
     #[error("validation error: {0}")]
-    Validation(#[from] ValidationError),
+    Validation(#[from] Box<ValidationError>),
     #[error("value source for known prop attribute value {0} is not a prop id")]
     ValueSourceForPropValueNotPropId(AttributeValueId),
     #[error("workspace error: {0}")]
-    Workspace(#[from] WorkspaceError),
+    Workspace(#[from] Box<WorkspaceError>),
     #[error("workspace pk not found on context")]
     WorkspacePkNone,
     #[error("workspace snapshot error: {0}")]
@@ -372,7 +372,7 @@ pub enum ComponentError {
     #[error("Attribute Prototype Argument used by too many Attribute Prototypes: {0}")]
     WrongNumberOfPrototypesForAttributePrototypeArgument(AttributePrototypeArgumentId),
     #[error("WsEvent error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
 }
 
 impl From<ActionError> for ComponentError {
@@ -405,6 +405,102 @@ impl From<FrameError> for ComponentError {
 impl From<FuncBindingError> for ComponentError {
     fn from(err: FuncBindingError) -> Self {
         Box::new(err).into()
+    }
+}
+
+impl From<AttributePrototypeError> for ComponentError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for ComponentError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for ComponentError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<CodeViewError> for ComponentError {
+    fn from(value: CodeViewError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for ComponentError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for ComponentError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InferredConnectionGraphError> for ComponentError {
+    fn from(value: InferredConnectionGraphError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for ComponentError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ModuleError> for ComponentError {
+    fn from(value: ModuleError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for ComponentError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for ComponentError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<QualificationError> for ComponentError {
+    fn from(value: QualificationError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for ComponentError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValidationError> for ComponentError {
+    fn from(value: ValidationError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceError> for ComponentError {
+    fn from(value: WorkspaceError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for ComponentError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
     }
 }
 

--- a/lib/dal/src/component/debug.rs
+++ b/lib/dal/src/component/debug.rs
@@ -216,7 +216,7 @@ impl ComponentDebugData {
         let name = component
             .name(ctx)
             .await
-            .map_err(|e| ComponentDebugViewError::Component(format!("get name error: {}", e)))?;
+            .map_err(|e| ComponentDebugViewError::Component(format!("get name error: {e}")))?;
 
         let debug_view = ComponentDebugData {
             name,

--- a/lib/dal/src/component/debug.rs
+++ b/lib/dal/src/component/debug.rs
@@ -90,25 +90,25 @@ pub struct ComponentDebugData {
 #[derive(Error, Debug)]
 pub enum ComponentDebugViewError {
     #[error("attribute debug view error: {0}")]
-    AttributeDebugViewError(#[from] AttributeDebugViewError),
+    AttributeDebugViewError(#[from] Box<AttributeDebugViewError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("Attribute Value tree badly constructed with root prop of {0}")]
     AttributeValueTreeBad(AttributeValueId),
     #[error("component error: {0}")]
     Component(String),
     #[error("component error: {0}")]
-    ComponentError(#[from] ComponentError),
+    ComponentError(#[from] Box<ComponentError>),
     #[error("diagram error: {0}")]
-    Diagram(#[from] DiagramError),
+    Diagram(#[from] Box<DiagramError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("input socket error: {0}")]
-    InputSocketError(#[from] InputSocketError),
+    InputSocketError(#[from] Box<InputSocketError>),
     #[error("json pointer not found: {1:?} at {0}")]
     JSONPointerNotFound(serde_json::Value, String),
     #[error("node weight error: {0}")]
-    NodeWeightError(#[from] NodeWeightError),
+    NodeWeightError(#[from] Box<NodeWeightError>),
     #[error("no internal provider for prop {0}")]
     NoInternalProvider(PropId),
     #[error("no root prop found for schema variant {0}")]
@@ -118,21 +118,21 @@ pub enum ComponentDebugViewError {
     #[error("component not found {0}")]
     NotFound(ComponentId),
     #[error("output socket error: {0}")]
-    OutputSocketError(#[from] OutputSocketError),
+    OutputSocketError(#[from] Box<OutputSocketError>),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("secret error: {0}")]
-    Secret(#[from] SecretError),
+    Secret(#[from] Box<SecretError>),
     #[error("secret not found: {0}")]
     SecretNotFound(SecretId),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("socket debug view error: {0}")]
-    SocketDebugViewError(#[from] SocketDebugViewError),
+    SocketDebugViewError(#[from] Box<SocketDebugViewError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshotError(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshotError(#[from] Box<WorkspaceSnapshotError>),
 }
 
 impl ComponentDebugView {
@@ -273,5 +273,83 @@ impl ComponentDebugData {
         component_id: ComponentId,
     ) -> ComponentDebugViewResult<HashMap<AttributeValueId, Vec<AttributeValueId>>> {
         Ok(AttributeValue::tree_for_component(ctx, component_id).await?)
+    }
+}
+
+impl From<AttributeDebugViewError> for ComponentDebugViewError {
+    fn from(value: AttributeDebugViewError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for ComponentDebugViewError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for ComponentDebugViewError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DiagramError> for ComponentDebugViewError {
+    fn from(value: DiagramError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for ComponentDebugViewError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for ComponentDebugViewError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for ComponentDebugViewError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for ComponentDebugViewError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for ComponentDebugViewError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for ComponentDebugViewError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SecretError> for ComponentDebugViewError {
+    fn from(value: SecretError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SocketDebugViewError> for ComponentDebugViewError {
+    fn from(value: SocketDebugViewError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for ComponentDebugViewError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/component/inferred_connection_graph.rs
+++ b/lib/dal/src/component/inferred_connection_graph.rs
@@ -57,13 +57,13 @@ pub enum InferredConnectionGraphError {
     #[error("Component error: {0}")]
     Component(#[from] Box<ComponentError>),
     #[error("InputSocket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("Missing graph node")]
     MissingGraphNode,
     #[error("Orphaned Component")]
     OrphanedComponent(ComponentId),
     #[error("OutputSocket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("Unable to compute costs for inferred connections")]
     UnableToComputeCost,
     #[error("Unsupported Component type {0} for Component {1}")]
@@ -778,5 +778,17 @@ fn cost_visitor(
             }
             Ok(Control::Continue)
         }
+    }
+}
+
+impl From<InputSocketError> for InferredConnectionGraphError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for InferredConnectionGraphError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -1633,7 +1633,7 @@ impl DalContextBuilder {
 #[derive(Debug, Error, EnumDiscriminants)]
 pub enum TransactionsError {
     #[error("audit logging error: {0}")]
-    AuditLogging(#[from] AuditLoggingError),
+    AuditLogging(#[from] Box<AuditLoggingError>),
     #[error("expected a {0:?} activity, but received a {1:?}")]
     BadActivity(ActivityPayloadDiscriminants, ActivityPayloadDiscriminants),
     /// Intentionally a bit vague as its used when either the user in question doesn't have access
@@ -1646,31 +1646,31 @@ pub enum TransactionsError {
     #[error("change set not set on DalContext")]
     ChangeSetNotSet,
     #[error("job queue processor error: {0}")]
-    JobQueueProcessor(#[from] JobQueueProcessorError),
+    JobQueueProcessor(#[from] Box<JobQueueProcessorError>),
     #[error("tokio join error: {0}")]
     Join(#[from] tokio::task::JoinError),
     #[error("layer db error: {0}")]
-    LayerDb(#[from] LayerDbError),
+    LayerDb(#[from] Box<LayerDbError>),
     #[error("nats error: {0}")]
     Nats(#[from] NatsError),
     #[error("no base change set for change set: {0}")]
     NoBaseChangeSet(ChangeSetId),
     #[error("pg error: {0}")]
-    Pg(#[from] PgError),
+    Pg(#[from] Box<PgError>),
     #[error("pg pool error: {0}")]
-    PgPool(#[from] PgPoolError),
+    PgPool(#[from] Box<PgPoolError>),
     #[error("rebase of batch {0} for change set id {1} failed: {2}")]
     RebaseFailed(RebaseBatchAddressKind, ChangeSetId, String),
     #[error("rebaser client error: {0}")]
-    Rebaser(#[from] rebaser_client::ClientError),
+    Rebaser(#[from] Box<rebaser_client::ClientError>),
     #[error("rebaser reply deadline elapsed; waited={0:?}, request_id={1}")]
     RebaserReplyDeadlineElasped(Duration, RequestId),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("si db error: {0}")]
-    SiDb(#[from] si_db::Error),
+    SiDb(#[from] Box<si_db::Error>),
     #[error("slow rt error: {0}")]
-    SlowRuntime(#[from] SlowRuntimeError),
+    SlowRuntime(#[from] Box<SlowRuntimeError>),
     #[error("unable to acquire lock: {0}")]
     TryLock(#[from] tokio::sync::TryLockError),
     #[error("cannot commit transactions on invalid connections state")]
@@ -1689,6 +1689,54 @@ pub enum TransactionsError {
 
 pub type TransactionsResult<T> = Result<T, TransactionsError>;
 
+impl From<AuditLoggingError> for TransactionsError {
+    fn from(value: AuditLoggingError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<JobQueueProcessorError> for TransactionsError {
+    fn from(value: JobQueueProcessorError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<LayerDbError> for TransactionsError {
+    fn from(value: LayerDbError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PgError> for TransactionsError {
+    fn from(value: PgError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PgPoolError> for TransactionsError {
+    fn from(value: PgPoolError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<rebaser_client::ClientError> for TransactionsError {
+    fn from(value: rebaser_client::ClientError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<si_db::Error> for TransactionsError {
+    fn from(value: si_db::Error) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SlowRuntimeError> for TransactionsError {
+    fn from(value: SlowRuntimeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
 impl From<WorkspaceError> for TransactionsError {
     fn from(err: WorkspaceError) -> Self {
         Box::new(err).into()
@@ -1704,7 +1752,7 @@ impl From<ChangeSetError> for TransactionsError {
 impl From<SiDbTransactionsError> for TransactionsError {
     fn from(err: SiDbTransactionsError) -> Self {
         match err {
-            SiDbTransactionsError::Pg(err) => TransactionsError::Pg(err),
+            SiDbTransactionsError::Pg(err) => TransactionsError::Pg(Box::new(err)),
             SiDbTransactionsError::TxnStart(state) => TransactionsError::TxnStart(state),
         }
     }

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -107,21 +107,21 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum DiagramError {
     #[error("approval requirement error: {0}")]
-    ApprovalRequirement(#[from] ApprovalRequirementError),
+    ApprovalRequirement(#[from] Box<ApprovalRequirementError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute prototype not found")]
     AttributePrototypeNotFound,
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("attribute value not found")]
     AttributeValueNotFound,
     #[error("Change Set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("component not found")]
     ComponentNotFound,
     #[error("component status not found for component: {0}")]
@@ -147,7 +147,7 @@ pub enum DiagramError {
     #[error("edge not found")]
     EdgeNotFound,
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("geometry can't represent: {0}")]
     GeometryCannotRepresentNodeWeight(NodeWeightDiscriminants),
     #[error("geometry not found: {0}")]
@@ -157,19 +157,19 @@ pub enum DiagramError {
     #[error("geometry not found for view object {0} on view {1}")]
     GeometryNotFoundForViewObjectAndView(ViewId, ViewId),
     #[error("Helper error: {0}")]
-    Helper(#[from] HelperError),
+    Helper(#[from] Box<HelperError>),
     #[error("InferredConnectionGraph error: {0}")]
-    InferredConnectionGraph(#[from] InferredConnectionGraphError),
+    InferredConnectionGraph(#[from] Box<InferredConnectionGraphError>),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("layerdb error: {0}")]
     LayerDb(#[from] LayerDbError),
     #[error("node not found")]
     NodeNotFound,
     #[error("node weight error: {0}")]
-    NodeWeight(#[from] NodeWeightError),
+    NodeWeight(#[from] Box<NodeWeightError>),
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error(transparent)]
     ParseFloat(#[from] ParseFloatError),
     #[error(transparent)]
@@ -181,7 +181,7 @@ pub enum DiagramError {
     #[error("schema not found")]
     SchemaNotFound,
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant not found")]
     SchemaVariantNotFound,
     #[error("serde error: {0}")]
@@ -191,7 +191,7 @@ pub enum DiagramError {
     #[error("socket not found")]
     SocketNotFound,
     #[error("Transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("could not acquire lock: {0}")]
     TryLock(#[from] tokio::sync::TryLockError),
     #[error("view category node not found")]
@@ -201,9 +201,105 @@ pub enum DiagramError {
     #[error("view not found for geometry id: {0}")]
     ViewNotFoundForGeometry(GeometryId),
     #[error("Workspace error: {0}")]
-    Workspace(#[from] WorkspaceError),
+    Workspace(#[from] Box<WorkspaceError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
+}
+
+impl From<ApprovalRequirementError> for DiagramError {
+    fn from(value: ApprovalRequirementError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for DiagramError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for DiagramError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for DiagramError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for DiagramError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for DiagramError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for DiagramError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<HelperError> for DiagramError {
+    fn from(value: HelperError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InferredConnectionGraphError> for DiagramError {
+    fn from(value: InferredConnectionGraphError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for DiagramError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for DiagramError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for DiagramError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for DiagramError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for DiagramError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceError> for DiagramError {
+    fn from(value: WorkspaceError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for DiagramError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type DiagramResult<T> = Result<T, DiagramError>;

--- a/lib/dal/src/entity_kind.rs
+++ b/lib/dal/src/entity_kind.rs
@@ -18,11 +18,11 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum EntityKindError {
     #[error("diagram error: {0}")]
-    Diagram(#[from] DiagramError),
+    Diagram(#[from] Box<DiagramError>),
     #[error("node not found for entity id {0}")]
     NodeNotFound(EntityId),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
 }
@@ -102,5 +102,17 @@ impl EntityKind {
             }
         };
         Ok(name)
+    }
+}
+
+impl From<DiagramError> for EntityKindError {
+    fn from(value: DiagramError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for EntityKindError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -122,25 +122,25 @@ pub enum FuncAuthoringError {
     )]
     ActionKindAlreadyExists(ActionKind, SchemaVariantId),
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("cannot unlock non-default schema variant: {0}")]
     CannotUnlockNonDefaultSchemaVariant(SchemaVariantId),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("dependent value root error: {0}")]
-    DependentValueRoot(#[from] DependentValueRootError),
+    DependentValueRoot(#[from] Box<DependentValueRootError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("func bindings error: {0}")]
-    FuncBinding(#[from] FuncBindingError),
+    FuncBinding(#[from] Box<FuncBindingError>),
     #[error("func named \"{0}\" already exists in this change set")]
     FuncNameExists(String),
     #[error("Function options are incompatible with variant")]
@@ -148,7 +148,7 @@ pub enum FuncAuthoringError {
     #[error("func run value sender is gone without sending a value")]
     FuncRunGone,
     #[error("func run error: {0}")]
-    FuncRunner(#[from] FuncRunnerError),
+    FuncRunner(#[from] Box<FuncRunnerError>),
     #[error("func runner has failed to send a value and exited")]
     FuncRunnerSend,
     #[error("invalid func kind for creation: {0}")]
@@ -166,15 +166,15 @@ pub enum FuncAuthoringError {
     #[error("func ({0}) is not runnable with kind: {1}")]
     NotRunnable(FuncId, FuncKind),
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("tokio task join error: {0}")]
     TokioTaskJoin(#[from] tokio::task::JoinError),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("unexpected func kind ({0}) creating attribute func")]
     UnexpectedFuncKindCreatingAttributeFunc(FuncKind),
     #[error(
@@ -184,9 +184,105 @@ pub enum FuncAuthoringError {
     #[error("variant authoring error: {0}")]
     VariantAuthoringClient(#[from] Box<VariantAuthoringError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<ActionPrototypeError> for FuncAuthoringError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for FuncAuthoringError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for FuncAuthoringError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for FuncAuthoringError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for FuncAuthoringError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DependentValueRootError> for FuncAuthoringError {
+    fn from(value: DependentValueRootError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for FuncAuthoringError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for FuncAuthoringError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncBindingError> for FuncAuthoringError {
+    fn from(value: FuncBindingError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncRunnerError> for FuncAuthoringError {
+    fn from(value: FuncRunnerError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for FuncAuthoringError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for FuncAuthoringError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for FuncAuthoringError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for FuncAuthoringError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for FuncAuthoringError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for FuncAuthoringError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 type FuncAuthoringResult<T> = Result<T, FuncAuthoringError>;

--- a/lib/dal/src/func/backend.rs
+++ b/lib/dal/src/func/backend.rs
@@ -79,10 +79,16 @@ pub enum FuncBackendError {
     #[error("unable to decode ulid")]
     Ulid(#[from] ulid::DecodeError),
     #[error("veritech client error: {0}")]
-    VeritechClient(#[from] veritech_client::ClientError),
+    VeritechClient(#[from] Box<veritech_client::ClientError>),
 }
 
 pub type FuncBackendResult<T> = Result<T, FuncBackendError>;
+
+impl From<veritech_client::ClientError> for FuncBackendError {
+    fn from(value: veritech_client::ClientError) -> Self {
+        Box::new(value).into()
+    }
+}
 
 // NOTE(nick,zack): do not add "remain::sorted" for postcard de/ser. We need the order to be
 // retained.

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -58,16 +58,19 @@ pub enum AttributeBindingMalformedInput {
     /// [`SchemaVariant`](crate::SchemaVariant) provided.
     EventualParentComponentNotFromSchemaVariant(ComponentId, SchemaVariantId),
     /// When assembling an input location, all options were provided. We only want one.
-    InputLocationAllOptionsProvided(PropId, InputSocketId, serde_json::Value),
+    InputLocationAllOptionsProvided(PropId, InputSocketId, Box<serde_json::Value>),
     /// When assembling an input location, both an [`InputSocketId`](crate::InputSocket) and a raw, static argument
     /// value were provided. We only want one option to be provided.
-    InputLocationBothInputSocketAndStaticArgumentValueProvided(InputSocketId, serde_json::Value),
+    InputLocationBothInputSocketAndStaticArgumentValueProvided(
+        InputSocketId,
+        Box<serde_json::Value>,
+    ),
     /// When assembling an input location, both a [`PropId`](crate::Prop) and an [`InputSocketId`](crate::InputSocket)
     /// were provided. We only want one option to be provided.
     InputLocationBothPropAndInputSocketProvided(PropId, InputSocketId),
     /// When assembling an input location, both an [`PropId`](crate::Prop) and a raw, static argument
     /// value were provided. We only want one option to be provided.
-    InputLocationBothPropAndStaticArgumentValueProvided(PropId, serde_json::Value),
+    InputLocationBothPropAndStaticArgumentValueProvided(PropId, Box<serde_json::Value>),
     /// When assembling an input location, no option was provided. We want one option to be provided.
     InputLocationNoOptionProvided,
     /// When assembling an output location, both a [`PropId`](crate::Prop) and an [`OutputSocketId`](crate::OutputSocket)
@@ -185,7 +188,7 @@ impl AttributeBinding {
                     AttributeBindingMalformedInput::InputLocationAllOptionsProvided(
                         prop_id,
                         input_socket_id,
-                        static_argument_value,
+                        static_argument_value.into(),
                     ),
                 ))
             }
@@ -197,12 +200,18 @@ impl AttributeBinding {
             )),
             (Some(prop_id), None, Some(static_argument_value)) => {
                 Err(FuncBindingError::MalformedInput(
-                    AttributeBindingMalformedInput::InputLocationBothPropAndStaticArgumentValueProvided(prop_id, static_argument_value),
+                    AttributeBindingMalformedInput::InputLocationBothPropAndStaticArgumentValueProvided(
+                        prop_id,
+                        static_argument_value.into(),
+                    ),
                 ))
             }
             (None, Some(input_socket_id), Some(static_argument_value)) => {
                 Err(FuncBindingError::MalformedInput(
-                    AttributeBindingMalformedInput::InputLocationBothInputSocketAndStaticArgumentValueProvided(input_socket_id, static_argument_value),
+                    AttributeBindingMalformedInput::InputLocationBothInputSocketAndStaticArgumentValueProvided(
+                        input_socket_id,
+                        static_argument_value.into(),
+                    ),
                 ))
             }
             (None, None, None) => Err(FuncBindingError::MalformedInput(

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -803,7 +803,7 @@ impl AttributeBinding {
 
         let output_ts = format!("type Output = {};", output_ts_types.join(" | "));
 
-        Ok(format!("{}\n{}", input_ts_types, output_ts))
+        Ok(format!("{input_ts_types}\n{output_ts}"))
     }
 
     /// Take the existing [`AttributeBinding`] and recreate it for the new [`Func`]

--- a/lib/dal/src/func/runner.rs
+++ b/lib/dal/src/func/runner.rs
@@ -133,17 +133,17 @@ pub enum FuncRunnerError {
     #[error("action prototype error: {0}")]
     ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("before func missing expected code: {0}")]
     BeforeFuncMissingCode(FuncId),
     #[error("before func missing expected handler: {0}")]
     BeforeFuncMissingHandler(FuncId),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error(
         "direct authentication func execution is unsupported (must go through \"before funcs\"), found: {0}"
     )]
@@ -155,9 +155,9 @@ pub enum FuncRunnerError {
     #[error("empty widget options for secret prop id: {0}")]
     EmptyWidgetOptionsForSecretProp(PropId),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("function backend error: {0}")]
-    FuncBackend(#[from] FuncBackendError),
+    FuncBackend(#[from] Box<FuncBackendError>),
     #[error("func run builder error: {0}")]
     FuncRunBuilder(#[from] FuncRunBuilderError),
     #[error("invalid resolver function type: {0}")]
@@ -171,7 +171,7 @@ pub enum FuncRunnerError {
     #[error("no widget options for secret prop id: {0}")]
     NoWidgetOptionsForSecretProp(PropId),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("reconciliation funcs are no longer supported (found: {0})")]
     ReconciliationFuncsNoLongerSupported(FuncId),
     #[error("function run result failure: kind={kind}, message={message}, backend={backend}")]
@@ -181,9 +181,9 @@ pub enum FuncRunnerError {
         backend: String,
     },
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("secret error: {0}")]
-    Secret(#[from] SecretError),
+    Secret(#[from] Box<SecretError>),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("si db error: {0}")]
@@ -195,7 +195,7 @@ pub enum FuncRunnerError {
     #[error("too many attribute values for component ({0}) and prop ({1})")]
     TooManyAttributeValues(ComponentId, PropId),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error(
         "unexpected value source ({0:?}) for secret prop ({1}), attribute prototype argument ({2}) and component ({3})"
     )]
@@ -210,7 +210,73 @@ pub enum FuncRunnerError {
     #[error("veritech value encrypt error: {0}")]
     VeritechValueEncrypt(#[from] VeritechValueEncryptError),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<AttributePrototypeArgumentError> for FuncRunnerError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for FuncRunnerError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for FuncRunnerError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for FuncRunnerError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for FuncRunnerError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncBackendError> for FuncRunnerError {
+    fn from(value: FuncBackendError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for FuncRunnerError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for FuncRunnerError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SecretError> for FuncRunnerError {
+    fn from(value: SecretError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for FuncRunnerError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for FuncRunnerError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type FuncRunnerResult<T> = Result<T, FuncRunnerError>;

--- a/lib/dal/src/job/consumer.rs
+++ b/lib/dal/src/job/consumer.rs
@@ -51,37 +51,37 @@ use crate::{
 #[allow(clippy::large_enum_variant)]
 pub enum JobConsumerError {
     #[error("action error: {0}")]
-    Action(#[from] ActionError),
+    Action(#[from] Box<ActionError>),
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("ActionProtoype {0} not found")]
     ActionPrototypeNotFound(ActionPrototypeId),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("billing publish error: {0}")]
     BillingPublish(#[from] BillingPublishError),
     #[error("Error blocking on job: {0}")]
-    BlockingJob(#[from] BlockingJobError),
+    BlockingJob(#[from] Box<BlockingJobError>),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("component {0} is destroyed")]
     ComponentIsDestroyed(ComponentId),
     #[error("dependent value update error: {0}")]
-    DependentValueUpdate(#[from] DependentValueUpdateError),
+    DependentValueUpdate(#[from] Box<DependentValueUpdateError>),
     #[error("diagram error: {0}")]
-    Diagram(#[from] DiagramError),
+    Diagram(#[from] Box<DiagramError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func runner error: {0}")]
-    FuncRunner(#[from] FuncRunnerError),
+    FuncRunner(#[from] Box<FuncRunnerError>),
     #[error("Invalid job arguments. Expected: {0} Actual: {1:?}")]
     InvalidArguments(String, Vec<Value>),
     #[error("std io error: {0}")]
     Io(#[from] ::std::io::Error),
     #[error("management function error: {0}")]
-    ManagementFunc(#[from] ManagementFuncJobError),
+    ManagementFunc(#[from] Box<ManagementFuncJobError>),
     #[error("nats error: {0}")]
     Nats(#[from] NatsError),
     #[error("nats is unavailable")]
@@ -89,7 +89,7 @@ pub enum JobConsumerError {
     #[error("pg pool error: {0}")]
     PgPool(#[from] PgPoolError),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("execution of job {0} failed after {1} retry attempts")]
     RetriesFailed(JobArgsVCurrent, u32),
     #[error("serde json error: {0}")]
@@ -97,20 +97,116 @@ pub enum JobConsumerError {
     #[error("tokio task error: {0}")]
     TokioTask(#[from] JoinError),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("ulid decode error: {0}")]
     UlidDecode(#[from] ulid::DecodeError),
     #[error("validation error: {0}")]
-    Validation(#[from] ValidationError),
+    Validation(#[from] Box<ValidationError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
 }
 
 impl From<JobConsumerError> for std::io::Error {
     fn from(jce: JobConsumerError) -> Self {
         Self::new(std::io::ErrorKind::InvalidData, jce)
+    }
+}
+
+impl From<ActionError> for JobConsumerError {
+    fn from(value: ActionError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for JobConsumerError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for JobConsumerError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DiagramError> for JobConsumerError {
+    fn from(value: DiagramError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for JobConsumerError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncRunnerError> for JobConsumerError {
+    fn from(value: FuncRunnerError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for JobConsumerError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ActionPrototypeError> for JobConsumerError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<BlockingJobError> for JobConsumerError {
+    fn from(value: BlockingJobError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for JobConsumerError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DependentValueUpdateError> for JobConsumerError {
+    fn from(value: DependentValueUpdateError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ManagementFuncJobError> for JobConsumerError {
+    fn from(value: ManagementFuncJobError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for JobConsumerError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for JobConsumerError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValidationError> for JobConsumerError {
+    fn from(value: ValidationError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for JobConsumerError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
     }
 }
 

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -76,33 +76,111 @@ use crate::{
 #[derive(Debug, Error)]
 pub enum DependentValueUpdateError {
     #[error("action error: {0}")]
-    Action(#[from] ActionError),
+    Action(#[from] Box<ActionError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("dependent value root error: {0}")]
-    DependentValueRoot(#[from] DependentValueRootError),
+    DependentValueRoot(#[from] Box<DependentValueRootError>),
     #[error("dependent values update audit log error: {0}")]
-    DependentValuesUpdateAuditLog(#[from] DependentValueUpdateAuditLogError),
+    DependentValuesUpdateAuditLog(#[from] Box<DependentValueUpdateAuditLogError>),
     #[error("func error: {0}")]
-    FuncError(#[from] crate::FuncError),
+    FuncError(#[from] Box<crate::FuncError>),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("status update error: {0}")]
-    StatusUpdate(#[from] StatusUpdateError),
+    StatusUpdate(#[from] Box<StatusUpdateError>),
     #[error(transparent)]
     TokioTask(#[from] JoinError),
     #[error(transparent)]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<ActionError> for DependentValueUpdateError {
+    fn from(value: ActionError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for DependentValueUpdateError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for DependentValueUpdateError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for DependentValueUpdateError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DependentValueRootError> for DependentValueUpdateError {
+    fn from(value: DependentValueRootError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DependentValueUpdateAuditLogError> for DependentValueUpdateError {
+    fn from(value: DependentValueUpdateAuditLogError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::FuncError> for DependentValueUpdateError {
+    fn from(value: crate::FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for DependentValueUpdateError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for DependentValueUpdateError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<StatusUpdateError> for DependentValueUpdateError {
+    fn from(value: StatusUpdateError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for DependentValueUpdateError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for DependentValueUpdateError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for DependentValueUpdateError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type DependentValueUpdateResult<T> = Result<T, DependentValueUpdateError>;
@@ -679,17 +757,53 @@ pub mod audit_log {
     #[derive(Debug, Error)]
     pub enum DependentValueUpdateAuditLogError {
         #[error("attribute value error: {0}")]
-        AttributeValue(#[from] AttributeValueError),
+        AttributeValue(#[from] Box<AttributeValueError>),
         #[error("component error: {0}")]
-        Component(#[from] ComponentError),
+        Component(#[from] Box<ComponentError>),
         #[error("input socket error: {0}")]
-        InputSocket(#[from] InputSocketError),
+        InputSocket(#[from] Box<InputSocketError>),
         #[error("output socket error: {0}")]
-        OutputSocket(#[from] OutputSocketError),
+        OutputSocket(#[from] Box<OutputSocketError>),
         #[error("prop error: {0}")]
-        Prop(#[from] PropError),
+        Prop(#[from] Box<PropError>),
         #[error("write audit log error: {0}")]
-        WriteAuditLog(#[source] TransactionsError),
+        WriteAuditLog(#[source] Box<TransactionsError>),
+    }
+
+    impl From<AttributeValueError> for DependentValueUpdateAuditLogError {
+        fn from(value: AttributeValueError) -> Self {
+            Box::new(value).into()
+        }
+    }
+
+    impl From<ComponentError> for DependentValueUpdateAuditLogError {
+        fn from(value: ComponentError) -> Self {
+            Box::new(value).into()
+        }
+    }
+
+    impl From<InputSocketError> for DependentValueUpdateAuditLogError {
+        fn from(value: InputSocketError) -> Self {
+            Box::new(value).into()
+        }
+    }
+
+    impl From<OutputSocketError> for DependentValueUpdateAuditLogError {
+        fn from(value: OutputSocketError) -> Self {
+            Box::new(value).into()
+        }
+    }
+
+    impl From<PropError> for DependentValueUpdateAuditLogError {
+        fn from(value: PropError) -> Self {
+            Box::new(value).into()
+        }
+    }
+
+    impl From<TransactionsError> for DependentValueUpdateAuditLogError {
+        fn from(value: TransactionsError) -> Self {
+            Self::WriteAuditLog(Box::new(value))
+        }
     }
 
     #[instrument(
@@ -742,7 +856,7 @@ pub mod audit_log {
                     input_socket.name().to_owned(),
                 )
                 .await
-                .map_err(DependentValueUpdateAuditLogError::WriteAuditLog)?;
+                .map_err(|e| DependentValueUpdateAuditLogError::WriteAuditLog(Box::new(e)))?;
             }
             ValueIsFor::OutputSocket(output_socket_id) => {
                 let output_socket = OutputSocket::get_by_id(ctx, output_socket_id).await?;
@@ -767,7 +881,7 @@ pub mod audit_log {
                     output_socket.name().to_owned(),
                 )
                 .await
-                .map_err(DependentValueUpdateAuditLogError::WriteAuditLog)?;
+                .map_err(|e| DependentValueUpdateAuditLogError::WriteAuditLog(Box::new(e)))?;
             }
             ValueIsFor::Prop(prop_id) => {
                 let prop = Prop::get_by_id(ctx, prop_id).await?;
@@ -792,7 +906,7 @@ pub mod audit_log {
                     prop.name,
                 )
                 .await
-                .map_err(DependentValueUpdateAuditLogError::WriteAuditLog)?;
+                .map_err(|e| DependentValueUpdateAuditLogError::WriteAuditLog(Box::new(e)))?;
             }
         }
 

--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -57,19 +57,19 @@ use crate::{
 #[derive(Debug, Error)]
 pub enum ManagementFuncJobError {
     #[error("dependent value root error: {0}")]
-    DependentValueRoot(#[from] DependentValueRootError),
+    DependentValueRoot(#[from] Box<DependentValueRootError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("management prototype {0} is not valid for component {1}")]
     InvalidPrototypeForComponent(ManagementPrototypeId, ComponentId),
     #[error("management error: {0}")]
-    Management(#[from] ManagementError),
+    Management(#[from] Box<ManagementError>),
     #[error("management execution state error: {0}")]
     ManagementFuncExecutionState(#[from] ManagementFuncExecutionError),
     #[error("management func js execution failed")]
     ManagementFuncJsExecutionFailed,
     #[error("management prototype error: {0}")]
-    ManagementPrototype(#[from] ManagementPrototypeError),
+    ManagementPrototype(#[from] Box<ManagementPrototypeError>),
     #[error(
         "no pending execution for component {0} and management prototype {1} in change set {2}"
     )]
@@ -79,15 +79,57 @@ pub enum ManagementFuncJobError {
     #[error(transparent)]
     TokioTask(#[from] JoinError),
     #[error(transparent)]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error(
         "management func {0} for component {1} waited too long for dependent values to be calculated"
     )]
     WaitedTooLongForDependentValueRoots(ManagementPrototypeId, ComponentId),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<DependentValueRootError> for ManagementFuncJobError {
+    fn from(value: DependentValueRootError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for ManagementFuncJobError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ManagementError> for ManagementFuncJobError {
+    fn from(value: ManagementError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ManagementPrototypeError> for ManagementFuncJobError {
+    fn from(value: ManagementPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for ManagementFuncJobError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for ManagementFuncJobError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for ManagementFuncJobError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type ManagementFuncJobResult<T> = Result<T, ManagementFuncJobError>;

--- a/lib/dal/src/job/processor.rs
+++ b/lib/dal/src/job/processor.rs
@@ -25,11 +25,17 @@ pub enum JobQueueProcessorError {
     #[error("missing required workspace_pk")]
     MissingWorkspacePk,
     #[error("pinga client error: {0}")]
-    PingaClient(#[from] pinga_client::ClientError),
+    PingaClient(#[from] Box<pinga_client::ClientError>),
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
     #[error(transparent)]
     Transport(Box<dyn std::error::Error + Sync + Send + 'static>),
+}
+
+impl From<pinga_client::ClientError> for JobQueueProcessorError {
+    fn from(value: pinga_client::ClientError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type JobQueueProcessorResult<T> = Result<T, JobQueueProcessorError>;

--- a/lib/dal/src/job/producer.rs
+++ b/lib/dal/src/job/producer.rs
@@ -18,9 +18,15 @@ pub enum BlockingJobError {
     #[error("no access builder found in job info")]
     NoAccessBuilder,
     #[error("pinga client error: {0}")]
-    PingaClient(#[from] pinga_client::ClientError),
+    PingaClient(#[from] Box<pinga_client::ClientError>),
     #[error("serde error: {0}")]
     Serde(String),
     #[error("A transactions error occurred: {0}")]
     Transactions(String),
+}
+
+impl From<pinga_client::ClientError> for BlockingJobError {
+    fn from(value: pinga_client::ClientError) -> Self {
+        Box::new(value).into()
+    }
 }

--- a/lib/dal/src/lib.rs
+++ b/lib/dal/src/lib.rs
@@ -1,5 +1,6 @@
 //! The Data Access Layer (DAL) for System Initiative.
 
+#![recursion_limit = "256"]
 #![warn(
     clippy::panic,
     clippy::panic_in_result_fn,

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -114,19 +114,19 @@ pub mod prototype;
 #[derive(Debug, Error)]
 pub enum ManagementError {
     #[error("action error: {0}")]
-    Action(#[from] ActionError),
+    Action(#[from] Box<ActionError>),
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("attributes error: {0}")]
-    Attributes(#[from] crate::attribute::attributes::Error),
+    Attributes(#[from] Box<crate::attribute::attributes::Error>),
     #[error("cannot create component with 'self' as a placeholder")]
     CannotCreateComponentWithSelfPlaceholder,
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error(
         "cannot add an action of kind {0} because component {1} does not have an action of that kind"
     )]
@@ -140,27 +140,27 @@ pub enum ManagementError {
     #[error("Component with management placeholder {0} could not be found")]
     ComponentWithPlaceholderNotFound(String),
     #[error("Diagram Error {0}")]
-    Diagram(#[from] DiagramError),
+    Diagram(#[from] Box<DiagramError>),
     #[error("Duplicate component placeholder {0}")]
     DuplicateComponentPlaceholder(String),
     #[error("frame error: {0}")]
-    Frame(#[from] FrameError),
+    Frame(#[from] Box<FrameError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("Component {0} does not have an input socket with name {1}")]
     InputSocketDoesNotExist(ComponentId, String),
     #[error("No existing or created view could be found named: {0}")]
     NoSuchView(String),
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("Component {0} does not have an output socket with name {1}")]
     OutputSocketDoesNotExist(ComponentId, String),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("schema error: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(#[from] Box<SchemaError>),
     #[error("si db error: {0}")]
     SiDb(#[from] si_db::Error),
     #[error("transactions error: {0}")]
@@ -170,7 +170,7 @@ pub enum ManagementError {
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
 }
 
 pub type ManagementResult<T> = Result<T, ManagementError>;
@@ -1988,4 +1988,88 @@ fn process_geometry(
     geometry.y.get_or_insert(default_y.unwrap_or(0.0));
 
     geometry.offset_by(origin_x, origin_y)
+}
+
+impl From<ActionError> for ManagementError {
+    fn from(value: ActionError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ActionPrototypeError> for ManagementError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::attribute::attributes::Error> for ManagementError {
+    fn from(value: crate::attribute::attributes::Error) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DiagramError> for ManagementError {
+    fn from(value: DiagramError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FrameError> for ManagementError {
+    fn from(value: FrameError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for ManagementError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for ManagementError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for ManagementError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for ManagementError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for ManagementError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for ManagementError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for ManagementError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for ManagementError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaError> for ManagementError {
+    fn from(value: SchemaError) -> Self {
+        Box::new(value).into()
+    }
 }

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -87,19 +87,19 @@ use crate::{
 #[derive(Debug, Error)]
 pub enum ManagementPrototypeError {
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] crate::attribute::prototype::AttributePrototypeError),
+    AttributePrototype(#[from] Box<crate::attribute::prototype::AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(
-        #[from] crate::attribute::prototype::argument::AttributePrototypeArgumentError,
+        #[from] Box<crate::attribute::prototype::argument::AttributePrototypeArgumentError>,
     ),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] crate::attribute::value::AttributeValueError),
+    AttributeValue(#[from] Box<crate::attribute::value::AttributeValueError>),
     #[error("cached module error: {0}")]
-    CachedModule(#[from] CachedModuleError),
+    CachedModule(#[from] Box<CachedModuleError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("diagram error: {0}")]
-    Diagram(#[from] DiagramError),
+    Diagram(#[from] Box<DiagramError>),
     #[error("empty value within func run value (FuncId {0} and FuncRunId {1})")]
     EmptyValueWithinFuncRunValue(FuncId, FuncRunId),
     #[error("func error: {0}")]
@@ -107,19 +107,19 @@ pub enum ManagementPrototypeError {
     #[error("func execution failure error: {0}")]
     FuncExecutionFailure(String),
     #[error("func runner error: {0}")]
-    FuncRunner(#[from] FuncRunnerError),
+    FuncRunner(#[from] Box<FuncRunnerError>),
     #[error("func runner recv error")]
     FuncRunnerRecvError,
     #[error("helper error: {0}")]
-    Helper(#[from] HelperError),
+    Helper(#[from] Box<HelperError>),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] crate::socket::input::InputSocketError),
+    InputSocket(#[from] Box<crate::socket::input::InputSocketError>),
     #[error("invalid prototype for component")]
     InvalidPrototypeForComponent(ManagementPrototypeId, ComponentId),
     #[error("layer db error: {0}")]
     LayerDbError(#[from] si_layer_cache::LayerDbError),
     #[error("management error: {0}")]
-    Management(#[from] ManagementError),
+    Management(#[from] Box<ManagementError>),
     #[error("management func execution state error: {0}")]
     ManagementExecution(#[from] si_db::ManagementFuncExecutionError),
     #[error("management prototype {0} has no use edge to a function")]
@@ -131,11 +131,11 @@ pub enum ManagementPrototypeError {
     #[error("management prototype {0} not found")]
     NotFound(ManagementPrototypeId),
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] crate::socket::output::OutputSocketError),
+    OutputSocket(#[from] Box<crate::socket::output::OutputSocketError>),
     #[error("schema error: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(#[from] Box<SchemaError>),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("too few variants: {0}")]
@@ -143,11 +143,95 @@ pub enum ManagementPrototypeError {
     #[error("too many variants: {0}")]
     TooManyVariants(ManagementPrototypeId),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("ws event error: {0}")]
-    WsEvent(#[from] WsEventError),
+    WsEvent(#[from] Box<WsEventError>),
+}
+
+impl From<crate::attribute::value::AttributeValueError> for ManagementPrototypeError {
+    fn from(value: crate::attribute::value::AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<CachedModuleError> for ManagementPrototypeError {
+    fn from(value: CachedModuleError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for ManagementPrototypeError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<DiagramError> for ManagementPrototypeError {
+    fn from(value: DiagramError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncRunnerError> for ManagementPrototypeError {
+    fn from(value: FuncRunnerError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<HelperError> for ManagementPrototypeError {
+    fn from(value: HelperError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::socket::input::InputSocketError> for ManagementPrototypeError {
+    fn from(value: crate::socket::input::InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ManagementError> for ManagementPrototypeError {
+    fn from(value: ManagementError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<crate::socket::output::OutputSocketError> for ManagementPrototypeError {
+    fn from(value: crate::socket::output::OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaError> for ManagementPrototypeError {
+    fn from(value: SchemaError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for ManagementPrototypeError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for ManagementPrototypeError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for ManagementPrototypeError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WsEventError> for ManagementPrototypeError {
+    fn from(value: WsEventError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type ManagementPrototypeResult<T> = Result<T, ManagementPrototypeError>;

--- a/lib/dal/src/pkg.rs
+++ b/lib/dal/src/pkg.rs
@@ -81,41 +81,41 @@ pub mod import;
 #[derive(Debug, Error)]
 pub enum PkgError {
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("attribute function for context {0:?} has key {1} but is not setting a prop value")]
     AttributeFuncForKeyMissingProp(import::AttrFuncContext, String),
     #[error("attribute function for prop {0} has a key {1} but prop kind is {2} not a map)")]
     AttributeFuncForKeySetOnWrongKind(PropId, String, PropKind),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attrbute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("AttributePrototypeArgument {0} missing FuncArgument {1}")]
     AttributePrototypeArgumentMissingFuncArgument(AttributePrototypeArgumentId, FuncArgumentId),
     #[error("attribute value error: {0}")]
-    AttributeValueError(#[from] AttributeValueError),
+    AttributeValueError(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
-    ChangeSet(#[from] ChangeSetError),
+    ChangeSet(#[from] Box<ChangeSetError>),
     #[error("connection annotation error: {0}")]
-    ConnectionAnnotation(#[from] ConnectionAnnotationError),
+    ConnectionAnnotation(#[from] Box<ConnectionAnnotationError>),
     #[error("expected data on an SiPkg node, but none found: {0}")]
     DataNotFound(String),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("func argument for {0} not found with name {1}")]
     FuncArgumentNotFoundByName(FuncId, String),
     #[error("action prototype error: {0}")]
-    FuncBinding(#[from] FuncBindingError),
+    FuncBinding(#[from] Box<FuncBindingError>),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("found multiple intrinsic func specs for name: {0}")]
     IntrinsicFuncSpecsMultipleForName(String),
     #[error("found no intrinsic func specs for name: {0}")]
     IntrinsicFuncSpecsNoneForName(String),
     #[error("management prototype error: {0}")]
-    ManagementPrototype(#[from] ManagementPrototypeError),
+    ManagementPrototype(#[from] Box<ManagementPrototypeError>),
     #[error("Missing Func {1} for AttributePrototype {0}")]
     MissingAttributePrototypeFunc(AttributePrototypeId, FuncId),
     #[error("Func {0} missing from exported funcs")]
@@ -131,9 +131,9 @@ pub enum PkgError {
     #[error("Unique id missing for node in workspace backup: {0}")]
     MissingUniqueIdForNode(String),
     #[error("module error: {0}")]
-    Module(#[from] ModuleError),
+    Module(#[from] Box<ModuleError>),
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("output socket {0} missing attribute prototype")]
     OutputSocketMissingPrototype(OutputSocketId),
     #[error("Package with that hash already installed: {0}")]
@@ -143,7 +143,7 @@ pub enum PkgError {
     #[error("pkg spec error: {0}")]
     PkgSpec(#[from] SpecError),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("prop {0} missing attribute prototype")]
     PropMissingPrototype(PropId),
     #[error("prop {0} not found")]
@@ -151,9 +151,9 @@ pub enum PkgError {
     #[error("prop spec structure is invalid: {0}")]
     PropSpecChildrenInvalid(String),
     #[error("schema error: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(#[from] Box<SchemaError>),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("json serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("si db error: {0}")]
@@ -163,19 +163,133 @@ pub enum PkgError {
     )]
     TakingOutputSocketAsInputForPropUnsupported(String, String),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("ulid decode error: {0}")]
     UlidDecode(#[from] ulid::DecodeError),
     #[error("url parse error: {0}")]
     Url(#[from] ParseError),
     #[error("workspace error: {0}")]
-    Workspace(#[from] WorkspaceError),
+    Workspace(#[from] Box<WorkspaceError>),
     #[error("workspace export not supported")]
     WorkspaceExportNotSupported(),
     #[error("workspace pk not found on context")]
     WorkspacePkNone,
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnaphot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnaphot(#[from] Box<WorkspaceSnapshotError>),
+}
+
+impl From<ActionPrototypeError> for PkgError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for PkgError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for PkgError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for PkgError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ChangeSetError> for PkgError {
+    fn from(value: ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ConnectionAnnotationError> for PkgError {
+    fn from(value: ConnectionAnnotationError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for PkgError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for PkgError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncBindingError> for PkgError {
+    fn from(value: FuncBindingError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for PkgError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ManagementPrototypeError> for PkgError {
+    fn from(value: ManagementPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ModuleError> for PkgError {
+    fn from(value: ModuleError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for PkgError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for PkgError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaError> for PkgError {
+    fn from(value: SchemaError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for PkgError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for PkgError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceError> for PkgError {
+    fn from(value: WorkspaceError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for PkgError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type PkgResult<T> = Result<T, PkgError>;

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -95,9 +95,9 @@ pub enum PropError {
     #[error("array missing child element: {0}")]
     ArrayMissingChildElement(PropId),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("path cannot include - (next element) because it will never yield a result")]
     CannotSubscribeToNextElement(PropId, String),
     #[error("change set error: {0}")]
@@ -107,9 +107,9 @@ pub enum PropError {
     #[error("prop {0} of kind {1} does not have an element prop")]
     ElementPropNotOnKind(PropId, PropKind),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("helper error: {0}")]
     Helper(#[from] HelperError),
     #[error("tokio join error: {0}")]
@@ -1218,5 +1218,29 @@ impl Prop {
 
     pub async fn ts_type(ctx: &DalContext, prop_id: PropId) -> PropResult<String> {
         ctx.workspace_snapshot()?.ts_type(prop_id).await
+    }
+}
+
+impl From<AttributePrototypeError> for PropError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for PropError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for PropError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for PropError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/property_editor.rs
+++ b/lib/dal/src/property_editor.rs
@@ -42,47 +42,47 @@ pub mod values;
 #[derive(Error, Debug)]
 pub enum PropertyEditorError {
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("invalid AttributeReadContext: {0}")]
     BadAttributeReadContext(String),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("component not found")]
     ComponentNotFound,
     #[error("cycle detected: {0}")]
     CycleDetected(AttributeValueId),
     #[error("node weight error: {0}")]
-    NodeWeight(#[from] NodeWeightError),
+    NodeWeight(#[from] Box<NodeWeightError>),
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("property editor value not found by prop id: {0}")]
     PropertyEditorValueNotFoundByPropId(PropId),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant not found: {0}")]
     SchemaVariantNotFound(SchemaVariantId),
     #[error("secret error: {0}")]
-    Secret(#[from] SecretError),
+    Secret(#[from] Box<SecretError>),
     #[error("secret prop for {0} leads to static value")]
     SecretPropLeadsToStaticValue(AttributeValueId, AttributeValueId),
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("transactions error: {0}")]
-    Transactions(#[from] TransactionsError),
+    Transactions(#[from] Box<TransactionsError>),
     #[error("could not acquire lock: {0}")]
     TryLock(#[from] tokio::sync::TryLockError),
     #[error("validation error: {0}")]
-    Validation(#[from] ValidationError),
+    Validation(#[from] Box<ValidationError>),
     #[error("value source error: {0}")]
-    ValueSource(#[from] ValueSourceError),
+    ValueSource(#[from] Box<ValueSourceError>),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
 }
 
 pub type PropertyEditorResult<T> = Result<T, PropertyEditorError>;
@@ -99,4 +99,76 @@ pub use si_id::{
 pub struct SelectWidgetOption {
     pub(crate) label: String,
     pub(crate) value: String,
+}
+
+impl From<AttributePrototypeError> for PropertyEditorError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for PropertyEditorError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for PropertyEditorError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for PropertyEditorError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<NodeWeightError> for PropertyEditorError {
+    fn from(value: NodeWeightError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for PropertyEditorError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for PropertyEditorError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SecretError> for PropertyEditorError {
+    fn from(value: SecretError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<TransactionsError> for PropertyEditorError {
+    fn from(value: TransactionsError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValidationError> for PropertyEditorError {
+    fn from(value: ValidationError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ValueSourceError> for PropertyEditorError {
+    fn from(value: ValueSourceError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for PropertyEditorError {
+    fn from(value: WorkspaceSnapshotError) -> Self {
+        Box::new(value).into()
+    }
 }

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -62,9 +62,15 @@ pub struct QualificationSummary {
 #[derive(Error, Debug)]
 pub enum QualificationSummaryError {
     #[error(transparent)]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error(transparent)]
     Pg(#[from] PgError),
+}
+
+impl From<ComponentError> for QualificationSummaryError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type QualificationSummaryResult<T> = Result<T, QualificationSummaryError>;

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -177,7 +177,7 @@ pub enum SchemaVariantError {
     #[error("attribute prototype error: {0}")]
     AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute argument prototype error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute prototype not found for input socket id: {0}")]
     AttributePrototypeNotFoundForInputSocket(InputSocketId),
     #[error("attribute prototype not found for output socket id: {0}")]
@@ -201,15 +201,15 @@ pub enum SchemaVariantError {
     #[error("dependent value root error: {0}")]
     DependentValueRoot(#[from] DependentValueRootError),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("helper error: {0}")]
     Helper(#[from] HelperError),
     #[error("{0} exists, but is not a schema variant id")]
     IdForWrongType(Ulid),
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("InputSocketNodeWeight error: {0}")]
     InputSocketNodeWeight(#[from] InputSocketNodeWeightError),
     #[error("layer db error: {0}")]
@@ -243,9 +243,9 @@ pub enum SchemaVariantError {
     #[error("schema spec has no variants")]
     NoVariants,
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("found prop id {0} that is not a prop")]
     PropIdNotAProp(PropId),
     #[error("cannot find prop at path {1} for SchemaVariant {0}")]
@@ -253,7 +253,7 @@ pub enum SchemaVariantError {
     #[error("schema variant {0} has no root node")]
     RootNodeMissing(SchemaVariantId),
     #[error("schema error: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(#[from] Box<SchemaError>),
     #[error("schema not found for schema variant: {0}")]
     SchemaNotFound(SchemaVariantId),
     #[error("schema variant locked: {0}")]
@@ -2515,5 +2515,47 @@ impl SchemaVariant {
         }
 
         Ok(schema_variants.into_values().collect())
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for SchemaVariantError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for SchemaVariantError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for SchemaVariantError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for SchemaVariantError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for SchemaVariantError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for SchemaVariantError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaError> for SchemaVariantError {
+    fn from(value: SchemaError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/schema/variant/authoring.rs
+++ b/lib/dal/src/schema/variant/authoring.rs
@@ -92,33 +92,33 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum VariantAuthoringError {
     #[error("action prototype error: {0}")]
-    ActionPrototype(#[from] ActionPrototypeError),
+    ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error(
         "found unexpected return type: expected type 'Asset' to be returned for asset func (FuncId {0}): raw error: {1})"
     )]
     AssetTypeNotReturnedForAssetFunc(FuncId, String),
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("there already exists a Schema with the name {0}")]
     DuplicatedSchemaName(String),
     #[error("empty value within func run value (FuncId {0} and FuncRunId {1})")]
     EmptyValueWithinFuncRunValue(FuncId, FuncRunId),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func authoring error: {0}")]
-    FuncAuthoring(#[from] FuncAuthoringError),
+    FuncAuthoring(#[from] Box<FuncAuthoringError>),
     #[error("func execution failure error: {0}")]
     FuncExecutionFailure(String),
     #[error("func run error: {0}")]
-    FuncRun(#[from] FuncRunnerError),
+    FuncRun(#[from] Box<FuncRunnerError>),
     #[error("func run value sender has terminated without sending")]
     FuncRunGone,
     #[error("input socket error: {0}")]
-    InputSocket(#[from] InputSocketError),
+    InputSocket(#[from] Box<InputSocketError>),
     #[error("layer db error: {0}")]
     LayerDb(#[from] LayerDbError),
     #[error("trying to modify locked variant: {0}")]
@@ -126,21 +126,21 @@ pub enum VariantAuthoringError {
     #[error("no new asset was created")]
     NoAssetCreated,
     #[error("output socket error: {0}")]
-    OutputSocket(#[from] OutputSocketError),
+    OutputSocket(#[from] Box<OutputSocketError>),
     #[error("pkg error: {0}")]
-    Pkg(#[from] PkgError),
+    Pkg(#[from] Box<PkgError>),
     #[error("constructed package has no schema node")]
     PkgMissingSchema,
     #[error("constructed package has no schema variant node")]
     PkgMissingSchemaVariant,
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("schema error: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(#[from] Box<SchemaError>),
     #[error("schema {0} already has unlocked variant: {1}")]
     SchemaAlreadyUnlocked(SchemaId, SchemaVariantId),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant asset func not found: {0}")]
     SchemaVariantAssetNotFound(SchemaVariantId),
     #[error("schema variant not found: {0}")]
@@ -155,6 +155,84 @@ pub enum VariantAuthoringError {
     SiPkg(#[from] SiPkgError),
     #[error("spec error: {0}")]
     Spec(#[from] SpecError),
+}
+
+impl From<ActionPrototypeError> for VariantAuthoringError {
+    fn from(value: ActionPrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for VariantAuthoringError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for VariantAuthoringError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for VariantAuthoringError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for VariantAuthoringError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncAuthoringError> for VariantAuthoringError {
+    fn from(value: FuncAuthoringError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncRunnerError> for VariantAuthoringError {
+    fn from(value: FuncRunnerError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for VariantAuthoringError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for VariantAuthoringError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PkgError> for VariantAuthoringError {
+    fn from(value: PkgError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for VariantAuthoringError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaError> for VariantAuthoringError {
+    fn from(value: SchemaError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for VariantAuthoringError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 type VariantAuthoringResult<T> = Result<T, VariantAuthoringError>;

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -161,15 +161,15 @@ pub use view::{
 #[derive(Error, Debug)]
 pub enum SecretError {
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
     #[error("component error: {0}")]
-    Component(#[from] ComponentError),
+    Component(#[from] Box<ComponentError>),
     #[error("error when decrypting encrypted secret")]
     DecryptionFailed,
     #[error("dependent value root error: {0}")]
@@ -181,9 +181,9 @@ pub enum SecretError {
     #[error("encrypted secret not found for key: {0}")]
     EncryptedSecretNotFound(EncryptedSecretKey),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func argument error: {0}")]
-    FuncArgument(#[from] FuncArgumentError),
+    FuncArgument(#[from] Box<FuncArgumentError>),
     #[error("func argument not found for func ({0}) and name ({1})")]
     FuncArgumentNotFound(FuncId, String),
     #[error("helper error: {0}")]
@@ -201,11 +201,11 @@ pub enum SecretError {
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("prop error: {0}")]
-    Prop(#[from] PropError),
+    Prop(#[from] Box<PropError>),
     #[error("not an error! prop id is not for a secret during MV build: {0}")]
     PropIdNotForSecret(PropId),
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant not secret defining: {0}")]
     SchemaVariantNotSecretDefining(SchemaVariantId),
     #[error("secret not found: {0}")]
@@ -987,6 +987,54 @@ impl DecryptedSecret {
 impl fmt::Debug for DecryptedSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DecryptedSecret").finish_non_exhaustive()
+    }
+}
+
+impl From<AttributeValueError> for SecretError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for SecretError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<SchemaVariantError> for SecretError {
+    fn from(value: SchemaVariantError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for SecretError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeArgumentError> for SecretError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for SecretError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncArgumentError> for SecretError {
+    fn from(value: FuncArgumentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<PropError> for SecretError {
+    fn from(value: PropError) -> Self {
+        Box::new(value).into()
     }
 }
 

--- a/lib/dal/src/slow_rt.rs
+++ b/lib/dal/src/slow_rt.rs
@@ -16,7 +16,13 @@ pub static SLOW_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 #[derive(Debug, Error)]
 pub enum SlowRuntimeError {
     #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] Box<std::io::Error>),
+}
+
+impl From<std::io::Error> for SlowRuntimeError {
+    fn from(value: std::io::Error) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type SlowRuntimeResult<T> = Result<T, SlowRuntimeError>;

--- a/lib/dal/src/socket/connection_annotation.rs
+++ b/lib/dal/src/socket/connection_annotation.rs
@@ -105,7 +105,7 @@ impl Display for ConnectionAnnotation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut out = self.tokens.last().ok_or(fmt::Error)?.clone();
         for token in self.tokens.iter().rev().skip(1) {
-            out = format!("{}<{}>", token, out);
+            out = format!("{token}<{out}>");
         }
 
         f.serialize_str(out.as_str())

--- a/lib/dal/src/socket/debug.rs
+++ b/lib/dal/src/socket/debug.rs
@@ -62,17 +62,17 @@ type SocketDebugViewResult<T> = Result<T, SocketDebugViewError>;
 #[derive(Error, Debug)]
 pub enum SocketDebugViewError {
     #[error("attribute prototype debug view error: {0}")]
-    AttributePrototypeDebugViewError(#[from] AttributePrototypeDebugViewError),
+    AttributePrototypeDebugViewError(#[from] Box<AttributePrototypeDebugViewError>),
     #[error("attribute prototype error: {0}")]
-    AttributePrototypeError(#[from] AttributePrototypeError),
+    AttributePrototypeError(#[from] Box<AttributePrototypeError>),
     #[error("attribute value error: {0}")]
-    AttributeValue(#[from] AttributeValueError),
+    AttributeValue(#[from] Box<AttributeValueError>),
     #[error("component error: {0}")]
-    ComponentError(#[from] ComponentError),
+    ComponentError(#[from] Box<ComponentError>),
     #[error("input socket error: {0}")]
-    InputSocketError(#[from] InputSocketError),
+    InputSocketError(#[from] Box<InputSocketError>),
     #[error("output socket error: {0}")]
-    OutputSocketError(#[from] OutputSocketError),
+    OutputSocketError(#[from] Box<OutputSocketError>),
 }
 
 impl SocketDebugView {
@@ -171,5 +171,41 @@ impl SocketDebugView {
             inferred_connections,
         };
         Ok(view)
+    }
+}
+
+impl From<AttributePrototypeDebugViewError> for SocketDebugViewError {
+    fn from(value: AttributePrototypeDebugViewError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributePrototypeError> for SocketDebugViewError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<AttributeValueError> for SocketDebugViewError {
+    fn from(value: AttributeValueError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<ComponentError> for SocketDebugViewError {
+    fn from(value: ComponentError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<InputSocketError> for SocketDebugViewError {
+    fn from(value: InputSocketError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<OutputSocketError> for SocketDebugViewError {
+    fn from(value: OutputSocketError) -> Self {
+        Box::new(value).into()
     }
 }

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -64,9 +64,9 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum InputSocketError {
     #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] AttributePrototypeError),
+    AttributePrototype(#[from] Box<AttributePrototypeError>),
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgumentError(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgumentError(#[source] Box<AttributePrototypeArgumentError>),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
@@ -78,7 +78,7 @@ pub enum InputSocketError {
     #[error("found too many matches for input and socket: {0}, {1}")]
     FoundTooManyForInputSocketId(InputSocketId, ComponentId),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("helper error: {0}")]
     Helper(#[from] HelperError),
     #[error("layer db error: {0}")]
@@ -103,6 +103,24 @@ pub enum InputSocketError {
     TryLock(#[from] tokio::sync::TryLockError),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+}
+
+impl From<AttributePrototypeArgumentError> for InputSocketError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
+        Self::AttributePrototypeArgumentError(Box::new(value))
+    }
+}
+
+impl From<AttributePrototypeError> for InputSocketError {
+    fn from(value: AttributePrototypeError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<FuncError> for InputSocketError {
+    fn from(value: FuncError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type InputSocketResult<T> = Result<T, InputSocketError>;

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -72,7 +72,7 @@ pub enum ValidationError {
     #[error("component error: {0}")]
     Component(#[from] Box<ComponentError>),
     #[error("func error: {0}")]
-    Func(#[from] FuncError),
+    Func(#[from] Box<FuncError>),
     #[error("func run went away before a value could be sent down the channel")]
     FuncRunGone,
     #[error("func runner error: {0}")]
@@ -94,7 +94,7 @@ pub enum ValidationError {
     #[error("schema not found")]
     SchemaNotFound,
     #[error("schema variant error: {0}")]
-    SchemaVariant(#[from] SchemaVariantError),
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("schema variant not found")]
     SchemaVariantNotFound,
     #[error("error serializing/deserializing json: {0}")]
@@ -102,7 +102,7 @@ pub enum ValidationError {
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
     #[error("workspace snapshot error: {0}")]
-    WorkspaceSnapshot(#[from] WorkspaceSnapshotError),
+    WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
 }
 
 impl From<AttributeValueError> for ValidationError {
@@ -117,8 +117,26 @@ impl From<ComponentError> for ValidationError {
     }
 }
 
+impl From<FuncError> for ValidationError {
+    fn from(e: FuncError) -> Self {
+        Box::new(e).into()
+    }
+}
+
 impl From<FuncRunnerError> for ValidationError {
     fn from(e: FuncRunnerError) -> Self {
+        Box::new(e).into()
+    }
+}
+
+impl From<SchemaVariantError> for ValidationError {
+    fn from(e: SchemaVariantError) -> Self {
+        Box::new(e).into()
+    }
+}
+
+impl From<WorkspaceSnapshotError> for ValidationError {
+    fn from(e: WorkspaceSnapshotError) -> Self {
         Box::new(e).into()
     }
 }

--- a/lib/dal/src/workspace_snapshot/dependent_value_root.rs
+++ b/lib/dal/src/workspace_snapshot/dependent_value_root.rs
@@ -25,7 +25,13 @@ pub enum DependentValueRootError {
     #[error("Workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),
     #[error("transaction error: {0}")]
-    Transactions(#[from] crate::TransactionsError),
+    Transactions(#[from] Box<crate::TransactionsError>),
+}
+
+impl From<crate::TransactionsError> for DependentValueRootError {
+    fn from(value: crate::TransactionsError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type DependentValueRootResult<T> = Result<T, DependentValueRootError>;

--- a/lib/dal/src/workspace_snapshot/graph/tests/detect_updates.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/detect_updates.rs
@@ -121,7 +121,7 @@ mod test {
             ] => {
                 assert_eq!(&EdgeWeightKind::new_use(), edge_weight.kind());
             }
-            other => panic!("Unexpected updates: {:?}", other),
+            other => panic!("Unexpected updates: {other:?}"),
         }
     }
 
@@ -180,7 +180,7 @@ mod test {
             [Update::NewNode { .. }, Update::NewEdge { edge_weight, .. }] => {
                 assert_eq!(&EdgeWeightKind::new_use(), edge_weight.kind());
             }
-            other => panic!("Unexpected updates: {:?}", other),
+            other => panic!("Unexpected updates: {other:?}"),
         }
     }
 
@@ -481,7 +481,7 @@ mod test {
                 assert_eq!(attribute_prototype_id, destination.id.into(),);
                 assert_eq!(&EdgeWeightKind::Prototype(None), edge_weight.kind());
             }
-            other => panic!("Unexpected updates: {:?}", other),
+            other => panic!("Unexpected updates: {other:?}"),
         }
     }
 

--- a/lib/dal/src/workspace_snapshot/graph/validator.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator.rs
@@ -678,7 +678,7 @@ pub fn av_path_from_root(
                 path.push_front("<MAP KEY SPECIFIED FOR ARRAY/OBJECT>")
             }
             (PropKind::Map, None) => path.push_front("<NO MAP KEY>"),
-            (kind, _) => path.push_front(format!("<BAD PARENT KIND {}>", kind)),
+            (kind, _) => path.push_front(format!("<BAD PARENT KIND {kind}>")),
         }
         index = parent_index;
     }

--- a/lib/dal/src/workspace_snapshot/graph/validator/connections.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator/connections.rs
@@ -644,7 +644,7 @@ impl std::fmt::Display for WithGraph<'_, &'_ ConnectionMigration> {
 
         match migration.explicit_connection_id {
             Some(explicit_connection_id) => {
-                write!(f, " (explicit connection APA {})", explicit_connection_id)
+                write!(f, " (explicit connection APA {explicit_connection_id})")
             }
             None => write!(f, " (inferred connection)"),
         }
@@ -725,7 +725,7 @@ impl std::fmt::Display for WithGraph<'_, &'_ ConnectionUnmigrateableBecause> {
                 )
             }
             ConnectionUnmigrateableBecause::InvalidGraph { ref error } => {
-                write!(f, "Invalid graph: {}", error)
+                write!(f, "Invalid graph: {error}")
             }
             ConnectionUnmigrateableBecause::MultipleConnectionsToSameProp => {
                 write!(f, "Multiple connections to the same prop")

--- a/lib/dal/tests/integration_test/asset.rs
+++ b/lib/dal/tests/integration_test/asset.rs
@@ -59,9 +59,9 @@ async fn asset_func_execution_papercuts(ctx: &mut DalContext) {
         Err(box_err) => match box_err.downcast_ref::<VariantAuthoringError>() {
             Some(err) => match err {
                 VariantAuthoringError::AssetTypeNotReturnedForAssetFunc(_, _) => {}
-                err => panic!("{:?}", err),
+                err => panic!("{err:?}"),
             },
-            None => panic!("{:?}", box_err),
+            None => panic!("{box_err:?}"),
         },
     }
 
@@ -79,9 +79,9 @@ async fn asset_func_execution_papercuts(ctx: &mut DalContext) {
         Err(box_err) => match box_err.downcast_ref::<VariantAuthoringError>() {
             Some(err) => match err {
                 VariantAuthoringError::AssetTypeNotReturnedForAssetFunc(_, _) => {}
-                err => panic!("{:?}", err),
+                err => panic!("{err:?}"),
             },
-            None => panic!("{:?}", box_err),
+            None => panic!("{box_err:?}"),
         },
     }
 

--- a/lib/dal/tests/integration_test/component.rs
+++ b/lib/dal/tests/integration_test/component.rs
@@ -298,8 +298,7 @@ async fn through_the_wormholes_simple(ctx: &mut DalContext) -> Result<()> {
     assert!(
         update_graph
             .direct_dependencies_of(naming_and_necessity_value_id)
-            .iter()
-            .any(|&id| id == rigid_designator_value_id),
+            .contains(&rigid_designator_value_id),
         "update graph declares that `naming_and_necessity` value depends on `rigid_designator` value"
     );
 

--- a/lib/dal/tests/integration_test/component/debug.rs
+++ b/lib/dal/tests/integration_test/component/debug.rs
@@ -86,7 +86,7 @@ async fn get_debug_view(ctx: &mut DalContext) {
     let attribute_path = AttributeValue::get_path_for_id(ctx, rigid_designator_value_id)
         .await
         .expect("can't get the path");
-    println!("attribute_path: {:?}", attribute_path);
+    println!("attribute_path: {attribute_path:?}");
     assert_eq!(
         attribute_path,
         Some(rigid_prop_path.with_replaced_sep("/").to_string())

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -1144,12 +1144,12 @@ async fn connections(ctx: &DalContext, component_id: ComponentId) -> Result<Vec<
     }
     for manager_id in Component::managers_by_id(ctx, component_id).await? {
         let manager = Component::name_by_id(ctx, manager_id).await?;
-        result.push(format!("[manager] {}", manager,));
+        result.push(format!("[manager] {manager}",));
     }
     let component = Component::get_by_id(ctx, component_id).await?;
     for managed_id in component.get_managed(ctx).await? {
         let managed = Component::name_by_id(ctx, managed_id).await?;
-        result.push(format!("[managed] {}", managed));
+        result.push(format!("[managed] {managed}"));
     }
     result.sort();
     Ok(result)

--- a/lib/dal/tests/integration_test/frame.rs
+++ b/lib/dal/tests/integration_test/frame.rs
@@ -196,7 +196,7 @@ async fn convert_component_to_frame_and_attach_no_nesting(ctx: &mut DalContext) 
     match Frame::upsert_parent(ctx, fallout_component.id(), starfield_component.id()).await {
         Ok(_) => panic!("attaching child to parent should fail if parent is not a frame"),
         Err(FrameError::ParentIsNotAFrame(..)) => {}
-        Err(other_error) => panic!("unexpected error: {0}", other_error),
+        Err(other_error) => panic!("unexpected error: {other_error}"),
     }
 
     // Change the parent to become a frame.
@@ -242,10 +242,7 @@ async fn convert_component_to_frame_and_attach_no_nesting(ctx: &mut DalContext) 
         match component.schema_name.as_str() {
             "starfield" => starfield_parent_node_id = Some(component.parent_id),
             "fallout" => fallout_parent_node_id = Some(component.parent_id),
-            schema_name => panic!(
-                "unexpected schema name for diagram component: {0}",
-                schema_name
-            ),
+            schema_name => panic!("unexpected schema name for diagram component: {schema_name}"),
         }
     }
     let starfield_parent_node_id =

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -8,14 +8,9 @@ use dal::{
     Prop,
     Schema,
     SchemaVariant,
-    SchemaVariantError,
     Secret,
-    WorkspaceSnapshotError,
     action::prototype::ActionKind,
-    attribute::prototype::argument::{
-        AttributePrototypeArgument,
-        AttributePrototypeArgumentError,
-    },
+    attribute::prototype::argument::AttributePrototypeArgument,
     func::{
         argument::{
             FuncArgument,
@@ -28,7 +23,6 @@ use dal::{
             AttributeFuncDestination,
             EventualParent,
             FuncBinding,
-            FuncBindingError,
             action::ActionBinding,
             attribute::AttributeBinding,
             authentication::AuthBinding,
@@ -45,7 +39,6 @@ use dal::{
             LeafKind,
         },
     },
-    workspace_snapshot::graph::WorkspaceSnapshotGraphError,
 };
 use dal_test::{
     WorkspaceSignup,
@@ -59,7 +52,6 @@ use dal_test::{
 };
 use itertools::Itertools;
 use pretty_assertions_sorted::assert_eq;
-use si_split_graph::SplitGraphError;
 
 mod action;
 mod attribute;
@@ -736,14 +728,7 @@ async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) {
     .await;
 
     match result {
-        Err(FuncBindingError::SchemaVariant(SchemaVariantError::AttributePrototypeArgument(
-            AttributePrototypeArgumentError::WorkspaceSnapshot(
-                WorkspaceSnapshotError::WorkspaceSnapshotGraph(
-                    WorkspaceSnapshotGraphError::CreateGraphCycle,
-                )
-                | WorkspaceSnapshotError::SplitGraph(SplitGraphError::WouldCreateGraphCycle),
-            ),
-        ))) => {}
+        Err(err) if err.is_create_graph_cycle() => {}
         other => panic!("Test should fail if we don't get this error, got: {other:?}"),
     }
 }

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -744,10 +744,7 @@ async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) {
                 | WorkspaceSnapshotError::SplitGraph(SplitGraphError::WouldCreateGraphCycle),
             ),
         ))) => {}
-        other => panic!(
-            "Test should fail if we don't get this error, got: {:?}",
-            other
-        ),
+        other => panic!("Test should fail if we don't get this error, got: {other:?}"),
     }
 }
 

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -89,7 +89,7 @@ async fn exec_mgmt_func(
         .await
         .map_err(|err| {
             if let ManagementPrototypeError::FuncExecutionFailure(ref err) = err {
-                println!("Error: {}", err);
+                println!("Error: {err}");
             }
             err
         })?;

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -246,7 +246,7 @@ async fn child_prop_names(
     let mut result = vec![];
     for Prop { name, id, .. } in Prop::direct_child_props_ordered(ctx, parent_prop_id).await? {
         let name = match prefix {
-            Some(prefix) => format!("{}.{}", prefix, name),
+            Some(prefix) => format!("{prefix}.{name}"),
             None => name.to_owned(),
         };
         result.push(name.clone());
@@ -273,7 +273,7 @@ async fn child_av_names(
     for child_av_id in AttributeValue::get_child_av_ids_in_order(ctx, parent_av_id).await? {
         let name = AttributeValue::prop(ctx, child_av_id).await?.name;
         let name = match prefix {
-            Some(prefix) => format!("{}.{}", prefix, name),
+            Some(prefix) => format!("{prefix}.{name}"),
             None => name.to_owned(),
         };
         result.push(name.clone());
@@ -291,7 +291,7 @@ fn spec_prop_child_names(parent_prop: &PropSpec, prefix: Option<&str>) -> Vec<St
     for child_prop in parent_prop.direct_children() {
         let name = child_prop.name();
         let name = match prefix {
-            Some(prefix) => format!("{}.{}", prefix, name),
+            Some(prefix) => format!("{prefix}.{name}"),
             None => name.to_owned(),
         };
         result.push(name.clone());

--- a/lib/dal/tests/integration_test/prop.rs
+++ b/lib/dal/tests/integration_test/prop.rs
@@ -59,8 +59,7 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) -> Result<()> {
 
         assert!(
             container_prop.can_be_used_as_prototype_arg,
-            "{:?} should be marked as able to be used as a prototype argument",
-            container_prop_path
+            "{container_prop_path:?} should be marked as able to be used as a prototype argument"
         );
     }
 
@@ -73,8 +72,7 @@ async fn verify_prop_used_as_input_flag(ctx: &DalContext) -> Result<()> {
 
         assert!(
             !item_prop.can_be_used_as_prototype_arg,
-            "{:?} should be marked as NOT able to be used as a prototype argument",
-            item_prop_path
+            "{item_prop_path:?} should be marked as NOT able to be used as a prototype argument"
         );
     }
 

--- a/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/create_variant.rs
@@ -58,7 +58,7 @@ async fn create_variant(ctx: &mut DalContext) {
     .await
     .expect("unable to get asset authoring func");
 
-    let scaffold_func_name = format!("{}Scaffold_", asset_name);
+    let scaffold_func_name = format!("{asset_name}Scaffold_");
     assert!(func.name.contains(&scaffold_func_name));
     assert_eq!(func.kind, FuncKind::SchemaVariantDefinition);
     assert_eq!(

--- a/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant/authoring/save_variant.rs
@@ -64,7 +64,7 @@ async fn save_variant(ctx: &mut DalContext) {
     .await
     .expect("unable to get asset authoring func");
 
-    let scaffold_func_name = format!("{}Scaffold_", asset_name);
+    let scaffold_func_name = format!("{asset_name}Scaffold_");
     assert!(func.name.contains(&scaffold_func_name));
     assert_eq!(func.kind, FuncKind::SchemaVariantDefinition);
     assert_eq!(

--- a/lib/dal/tests/integration_test/split_snapshot.rs
+++ b/lib/dal/tests/integration_test/split_snapshot.rs
@@ -65,7 +65,7 @@ async fn set_av_for_prop_for_component(ctx: &DalContext, component_id: Component
 #[ignore]
 async fn create_split_snapshot_workspace(ctx: &mut DalContext) -> Result<()> {
     const COMPONENTS_COUNT: usize = 25;
-    println!("test with {} components", COMPONENTS_COUNT);
+    println!("test with {COMPONENTS_COUNT} components");
 
     let mut legacy_components = vec![];
     let view_id = View::get_id_for_default(ctx).await?;

--- a/lib/dal/tests/integration_test/view.rs
+++ b/lib/dal/tests/integration_test/view.rs
@@ -252,7 +252,7 @@ async fn remove_view_with_exclusive_components(ctx: &mut DalContext) {
         )),
     ) = result
     else {
-        panic!("View removal did not error appropriately: {:?}", result);
+        panic!("View removal did not error appropriately: {result:?}");
     };
     assert_eq!(vec![Ulid::from(component.id())], orphans,);
 }

--- a/lib/data-warehouse-stream-client/src/lib.rs
+++ b/lib/data-warehouse-stream-client/src/lib.rs
@@ -46,9 +46,21 @@ pub enum DataWarehouseStreamClientError {
     #[error("firehose error: {0}")]
     Firehose(#[from] aws_sdk_firehose::Error),
     #[error("firehose build error: {0}")]
-    FirehoseBuild(#[from] aws_sdk_firehose::error::BuildError),
+    FirehoseBuild(#[from] Box<aws_sdk_firehose::error::BuildError>),
     #[error("firehose put record error: {0}")]
-    FirehosePutRecord(#[from] aws_sdk_firehose::error::SdkError<PutRecordError>),
+    FirehosePutRecord(#[from] Box<aws_sdk_firehose::error::SdkError<PutRecordError>>),
+}
+
+impl From<aws_sdk_firehose::error::BuildError> for DataWarehouseStreamClientError {
+    fn from(value: aws_sdk_firehose::error::BuildError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<aws_sdk_firehose::error::SdkError<PutRecordError>> for DataWarehouseStreamClientError {
+    fn from(value: aws_sdk_firehose::error::SdkError<PutRecordError>) -> Self {
+        Box::new(value).into()
+    }
 }
 
 type DataWarehouseStreamClientResult<T> = Result<T, DataWarehouseStreamClientError>;

--- a/lib/edda-core/src/nats.rs
+++ b/lib/edda-core/src/nats.rs
@@ -92,10 +92,7 @@ pub mod subject {
     ) -> Subject {
         nats_std::subject::prefixed(
             prefix,
-            format!(
-                "{REQUESTS_SUBJECT_PREFIX}.{}.{}",
-                workspace_id, change_set_id,
-            ),
+            format!("{REQUESTS_SUBJECT_PREFIX}.{workspace_id}.{change_set_id}",),
         )
     }
 
@@ -107,10 +104,7 @@ pub mod subject {
     ) -> Subject {
         nats_std::subject::prefixed(
             prefix,
-            format!(
-                "{TASKS_SUBJECT_PREFIX}.{}.{}.process",
-                workspace_id, change_set_id,
-            ),
+            format!("{TASKS_SUBJECT_PREFIX}.{workspace_id}.{change_set_id}.process",),
         )
     }
 

--- a/lib/edda-server/src/compressed_request.rs
+++ b/lib/edda-server/src/compressed_request.rs
@@ -545,7 +545,7 @@ mod tests {
                 assert_eq!(input.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -579,7 +579,7 @@ mod tests {
                 assert_eq!(inputs.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -601,7 +601,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -623,7 +623,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -655,7 +655,7 @@ mod tests {
                 assert_eq!(update.to_snapshot_address, to_snapshot_address);
                 assert_eq!(vec![update.change_batch_address], change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -689,7 +689,7 @@ mod tests {
                 assert_eq!(last_to, to_snapshot_address);
                 assert_eq!(addresses, change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -713,7 +713,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -740,7 +740,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -778,7 +778,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(addresses, change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -813,7 +813,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -850,7 +850,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -889,7 +889,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -929,7 +929,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -970,7 +970,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(addresses, change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1011,7 +1011,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(addresses, change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1037,7 +1037,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1062,7 +1062,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1097,7 +1097,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1134,7 +1134,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert!(change_batch_addresses.is_empty());
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1159,7 +1159,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1184,7 +1184,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1217,7 +1217,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(vec![ur.change_batch_address], change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1252,7 +1252,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(vec![ur.change_batch_address], change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1275,7 +1275,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1300,7 +1300,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1324,7 +1324,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1348,7 +1348,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1374,7 +1374,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1399,7 +1399,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1424,7 +1424,7 @@ mod tests {
             CompressedRequest::Rebuild { src_requests_count } => {
                 assert_eq!(requests.len(), src_requests_count);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1462,7 +1462,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(addresses, change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 
@@ -1500,7 +1500,7 @@ mod tests {
                 assert_eq!(ncsr.to_snapshot_address, to_snapshot_address);
                 assert_eq!(addresses, change_batch_addresses);
             }
-            _ => panic!("wrong variant for compressed request: {:?}", compressed),
+            _ => panic!("wrong variant for compressed request: {compressed:?}"),
         }
     }
 

--- a/lib/edda-server/src/compressing_stream.rs
+++ b/lib/edda-server/src/compressing_stream.rs
@@ -109,7 +109,7 @@ enum State {
         /// The [`Subject`] to be used on the compressed request ([`Option`] for `mem::take()`)
         subject: Option<Subject>,
         /// The message to be parsed ([`Option`] for `mem::take()`)
-        message: Option<jetstream::Message>,
+        message: Box<Option<jetstream::Message>>,
         /// The stream sequence number of the first message
         message_stream_sequence: u64,
         /// A [`Future`] that calculates the read window
@@ -365,7 +365,7 @@ where
                             // Set next state and continue loop
                             *this.state = State::CalculateReadWindow {
                                 subject,
-                                message: Some(message),
+                                message: Box::new(Some(message)),
                                 message_stream_sequence,
                                 calculate_read_window_fut: Box::pin(async move {
                                     let info: HashMap<_, _> = stream

--- a/lib/edda-server/tests/integration.rs
+++ b/lib/edda-server/tests/integration.rs
@@ -79,10 +79,7 @@ async fn multiple_updates() {
             assert_eq!(last_to, to_snapshot_address);
             assert_eq!(addresses, change_batch_addresses);
         }
-        _ => panic!(
-            "wrong variant for compressed request: {:?}",
-            compressed_request
-        ),
+        _ => panic!("wrong variant for compressed request: {compressed_request:?}"),
     }
 }
 
@@ -147,10 +144,7 @@ async fn updates_with_single_rebuild() {
         CompressedRequest::Rebuild { src_requests_count } => {
             assert_eq!(requests.len(), src_requests_count);
         }
-        _ => panic!(
-            "wrong variant for compressed request: {:?}",
-            compressed_request
-        ),
+        _ => panic!("wrong variant for compressed request: {compressed_request:?}"),
     }
 }
 

--- a/lib/frigg/src/lib.rs
+++ b/lib/frigg/src/lib.rs
@@ -645,7 +645,7 @@ mod kv_history {
                         let info = message.info().map_err(|err| {
                             WatcherError::Default(
                                 WatcherErrorKind::Other,
-                                format!("failed to parse message metadata: {}", err),
+                                format!("failed to parse message metadata: {err}"),
                             )
                         })?;
                         if info.pending == 0 {

--- a/lib/innit-client/src/lib.rs
+++ b/lib/innit-client/src/lib.rs
@@ -198,7 +198,7 @@ impl InnitClient {
 
     fn join_path(&self, base_segment: &str, path: &str) -> Result<Url> {
         let clean_path = path.trim_start_matches('/');
-        let full_path = format!("{}/{}", base_segment, clean_path);
+        let full_path = format!("{base_segment}/{clean_path}");
         Ok(self.base_url.join(&full_path)?)
     }
 

--- a/lib/innit-client/tests/integration_test/mod.rs
+++ b/lib/innit-client/tests/integration_test/mod.rs
@@ -278,7 +278,7 @@ mod integration_tests {
         // create two parameters in the same path
         client
             .create_parameter(
-                format!("{}/param1", path_prefix),
+                format!("{path_prefix}/param1"),
                 "path_test_value".to_string(),
             )
             .await
@@ -286,7 +286,7 @@ mod integration_tests {
 
         client
             .create_parameter(
-                format!("{}/param2", path_prefix),
+                format!("{path_prefix}/param2"),
                 "path_test_value".to_string(),
             )
             .await

--- a/lib/innit-server/src/routes/create_parameter.rs
+++ b/lib/innit-server/src/routes/create_parameter.rs
@@ -25,7 +25,7 @@ pub async fn create_parameter_route(
     Json(CreateParameterRequest { value }): Json<CreateParameterRequest>,
 ) -> Result<Json<CreateParameterResponse>, AppError> {
     let name = if !name.starts_with('/') {
-        format!("/{}", name)
+        format!("/{name}")
     } else {
         name.clone()
     };

--- a/lib/innit-server/src/routes/get_parameter.rs
+++ b/lib/innit-server/src/routes/get_parameter.rs
@@ -23,7 +23,7 @@ pub async fn get_parameter_route(
     }): State<AppState>,
 ) -> Result<Json<GetParameterResponse>, AppError> {
     let name = if !name.starts_with('/') {
-        format!("/{}", name)
+        format!("/{name}")
     } else {
         name.clone()
     };

--- a/lib/innit-server/src/routes/list_parameters.rs
+++ b/lib/innit-server/src/routes/list_parameters.rs
@@ -23,7 +23,7 @@ pub async fn list_parameters_route(
     }): State<AppState>,
 ) -> Result<Json<ListParametersResponse>, AppError> {
     let path = if !path.starts_with('/') {
-        format!("/{}", path)
+        format!("/{path}")
     } else {
         path
     };

--- a/lib/innit-server/src/server.rs
+++ b/lib/innit-server/src/server.rs
@@ -199,7 +199,7 @@ pub fn build_service(
                     tracing::error!(error = %err, "Unexpected error in request processing");
                     Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(format!("Internal server error: {}", err))
+                        .body(format!("Internal server error: {err}"))
                         .expect("Unable to build error response body")
                         .into_response()
                 }))

--- a/lib/luminork-server/src/lib.rs
+++ b/lib/luminork-server/src/lib.rs
@@ -90,9 +90,15 @@ pub enum ServerError {
     #[error("Failed to set up signal handler")]
     Signal(#[source] io::Error),
     #[error("Permissions error: {0}")]
-    SpiceDb(#[from] SpiceDbError),
+    SpiceDb(#[from] Box<SpiceDbError>),
     #[error("unix domain socket incoming stream error: {0}")]
     Uds(#[from] uds::UdsIncomingStreamError),
+}
+
+impl From<SpiceDbError> for ServerError {
+    fn from(value: SpiceDbError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 type ServerResult<T> = std::result::Result<T, ServerError>;

--- a/lib/luminork-server/src/routes.rs
+++ b/lib/luminork-server/src/routes.rs
@@ -155,7 +155,7 @@ pub fn routes(state: AppState) -> Router {
         let mut spec = serde_json::to_value(original_response.0).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("JSON conversion error: {}", e),
+                format!("JSON conversion error: {e}"),
             )
         })?;
 

--- a/lib/luminork-server/src/service/v1/actions/mod.rs
+++ b/lib/luminork-server/src/service/v1/actions/mod.rs
@@ -63,15 +63,15 @@ impl From<JsonRejection> for ActionsError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                ActionsError::Validation(format!("Invalid JSON data format: {}", rejection))
+                ActionsError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                ActionsError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                ActionsError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => ActionsError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => ActionsError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => ActionsError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }

--- a/lib/luminork-server/src/service/v1/change_sets/mod.rs
+++ b/lib/luminork-server/src/service/v1/change_sets/mod.rs
@@ -82,15 +82,15 @@ impl From<JsonRejection> for ChangeSetError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                ChangeSetError::Validation(format!("Invalid JSON data format: {}", rejection))
+                ChangeSetError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                ChangeSetError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                ChangeSetError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => ChangeSetError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => ChangeSetError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => ChangeSetError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }

--- a/lib/luminork-server/src/service/v1/components/execute_management_function.rs
+++ b/lib/luminork-server/src/service/v1/components/execute_management_function.rs
@@ -92,8 +92,7 @@ pub async fn execute_management_function(
             view.id()
         } else {
             return Err(ComponentsError::ViewNotFound(format!(
-                "View '{}' not found",
-                view_name
+                "View '{view_name}' not found"
             )));
         }
     } else {

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -187,8 +187,7 @@ pub async fn resolve_secret_id(
                         .find(|s| s.name() == value_str)
                         .ok_or_else(|| {
                             ComponentsError::SecretNotFound(format!(
-                                "Secret '{}' not found",
-                                value_str
+                                "Secret '{value_str}' not found"
                             ))
                         })?;
                     Ok(found_secret.id())
@@ -199,14 +198,13 @@ pub async fn resolve_secret_id(
                     .into_iter()
                     .find(|s| s.name() == value_str)
                     .ok_or_else(|| {
-                        ComponentsError::SecretNotFound(format!("Secret '{}' not found", value_str))
+                        ComponentsError::SecretNotFound(format!("Secret '{value_str}' not found"))
                     })?;
                 Ok(found_secret.id())
             }
         }
         _ => Err(ComponentsError::InvalidSecretValue(format!(
-            "Secret value must be a string containing ID or name, got: {}",
-            value
+            "Secret value must be a string containing ID or name, got: {value}"
         ))),
     }
 }
@@ -228,15 +226,15 @@ impl From<JsonRejection> for ComponentsError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                ComponentsError::Validation(format!("Invalid JSON data format: {}", rejection))
+                ComponentsError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                ComponentsError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                ComponentsError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => ComponentsError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => ComponentsError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => ComponentsError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }

--- a/lib/luminork-server/src/service/v1/funcs/mod.rs
+++ b/lib/luminork-server/src/service/v1/funcs/mod.rs
@@ -57,15 +57,15 @@ impl From<JsonRejection> for FuncsError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                FuncsError::Validation(format!("Invalid JSON data format: {}", rejection))
+                FuncsError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                FuncsError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                FuncsError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => FuncsError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => FuncsError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => FuncsError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }

--- a/lib/luminork-server/src/service/v1/management_funcs/mod.rs
+++ b/lib/luminork-server/src/service/v1/management_funcs/mod.rs
@@ -42,15 +42,15 @@ impl From<JsonRejection> for ManagementFuncsError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                ManagementFuncsError::Validation(format!("Invalid JSON data format: {}", rejection))
+                ManagementFuncsError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                ManagementFuncsError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                ManagementFuncsError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => ManagementFuncsError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => ManagementFuncsError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => ManagementFuncsError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }

--- a/lib/luminork-server/src/service/v1/schemas/mod.rs
+++ b/lib/luminork-server/src/service/v1/schemas/mod.rs
@@ -102,15 +102,15 @@ impl From<JsonRejection> for SchemaError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                SchemaError::Validation(format!("Invalid JSON data format: {}", rejection))
+                SchemaError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                SchemaError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                SchemaError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => SchemaError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => SchemaError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => SchemaError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }
@@ -495,7 +495,7 @@ fn build_prop_schema_from_maps(
 ) -> SchemaResult<PropSchemaV1> {
     let prop = props_map
         .get(&prop_id)
-        .ok_or_else(|| SchemaError::Validation(format!("Prop {} not found in map", prop_id)))?;
+        .ok_or_else(|| SchemaError::Validation(format!("Prop {prop_id} not found in map")))?;
 
     let prop_type = match prop.kind {
         PropKind::String => "string",

--- a/lib/luminork-server/src/service/v1/secrets/mod.rs
+++ b/lib/luminork-server/src/service/v1/secrets/mod.rs
@@ -72,15 +72,15 @@ impl From<JsonRejection> for SecretsError {
     fn from(rejection: JsonRejection) -> Self {
         match rejection {
             JsonRejection::JsonDataError(_) => {
-                SecretsError::Validation(format!("Invalid JSON data format: {}", rejection))
+                SecretsError::Validation(format!("Invalid JSON data format: {rejection}"))
             }
             JsonRejection::JsonSyntaxError(_) => {
-                SecretsError::Validation(format!("Invalid JSON syntax: {}", rejection))
+                SecretsError::Validation(format!("Invalid JSON syntax: {rejection}"))
             }
             JsonRejection::MissingJsonContentType(_) => SecretsError::Validation(
                 "Request must have Content-Type: application/json header".to_string(),
             ),
-            _ => SecretsError::Validation(format!("JSON validation error: {}", rejection)),
+            _ => SecretsError::Validation(format!("JSON validation error: {rejection}")),
         }
     }
 }

--- a/lib/module-index-client/src/lib.rs
+++ b/lib/module-index-client/src/lib.rs
@@ -293,7 +293,7 @@ impl ModuleIndexClient {
         let details_url = self
             .base_url
             .join("modules/")?
-            .join(&format!("{}", module_id))?;
+            .join(&format!("{module_id}"))?;
 
         let response = self.inner.get(details_url).send().await?;
 

--- a/lib/module-index-server/src/extract.rs
+++ b/lib/module-index-server/src/extract.rs
@@ -44,7 +44,7 @@ impl ExtractedS3Bucket {
 
     async fn get_url(self, object_key: String) -> Result<String, S3Error> {
         let download_url = if let Some(domain) = self.cloudfront_domain {
-            format!("https://{}/{}", domain, object_key)
+            format!("https://{domain}/{object_key}")
         } else {
             self.s3_bucket.presign_get(object_key, 60 * 5, None).await?
         };

--- a/lib/module-index-server/src/routes/upsert_workspace_route.rs
+++ b/lib/module-index-server/src/routes/upsert_workspace_route.rs
@@ -128,7 +128,7 @@ pub async fn upsert_workspace_route(
     };
 
     s3_bucket
-        .put_object(format!("{}.workspace_export", hash), &data)
+        .put_object(format!("{hash}.workspace_export"), &data)
         .await?;
 
     let _new_module: si_module::Model = dbg!(new_module.insert(&txn).await)?;

--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -341,7 +341,7 @@ pub fn build_service(
                     tracing::error!(error = %err, "Unexpected error in request processing");
                     Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(format!("Internal server error: {}", err))
+                        .body(format!("Internal server error: {err}"))
                         .expect("Unable to build error response body")
                         .into_response()
                 }))

--- a/lib/nats-multiplexer/src/lib.rs
+++ b/lib/nats-multiplexer/src/lib.rs
@@ -63,8 +63,6 @@ mod parsing;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum MultiplexerError {
-    #[error("broadcast send nats message error: {0}")]
-    BroadcastSentNatsMessage(#[from] broadcast::error::SendError<Message>),
     #[error("nats error: {0}")]
     Nats(#[from] si_data_nats::Error),
 }

--- a/lib/object-tree/src/graph.rs
+++ b/lib/object-tree/src/graph.rs
@@ -882,8 +882,7 @@ fn read_node_entry_lines<R: BufRead>(reader: &mut R) -> Result<Vec<NodeEntry>, G
 
         if !parts.is_empty() {
             return Err(GraphError::parse_custom(format!(
-                "entry line has more than 3 fields: {}",
-                line
+                "entry line has more than 3 fields: {line}"
             )));
         }
 

--- a/lib/pinga-core/src/nats.rs
+++ b/lib/pinga-core/src/nats.rs
@@ -52,10 +52,7 @@ pub mod subject {
     ) -> Subject {
         nats_std::subject::prefixed(
             prefix,
-            format!(
-                "{SUBJECT_PREFIX}.{}.{}.{}",
-                workspace_id, change_set_id, args,
-            ),
+            format!("{SUBJECT_PREFIX}.{workspace_id}.{change_set_id}.{args}",),
         )
     }
 }

--- a/lib/rebaser-core/src/nats.rs
+++ b/lib/rebaser-core/src/nats.rs
@@ -89,10 +89,7 @@ pub mod subject {
     ) -> Subject {
         nats_std::subject::prefixed(
             prefix,
-            format!(
-                "{REQUESTS_SUBJECT_PREFIX}.{}.{}",
-                workspace_id, change_set_id,
-            ),
+            format!("{REQUESTS_SUBJECT_PREFIX}.{workspace_id}.{change_set_id}",),
         )
     }
 
@@ -104,10 +101,7 @@ pub mod subject {
     ) -> Subject {
         nats_std::subject::prefixed(
             prefix,
-            format!(
-                "{TASKS_SUBJECT_PREFIX}.{}.{}.process",
-                workspace_id, change_set_id,
-            ),
+            format!("{TASKS_SUBJECT_PREFIX}.{workspace_id}.{change_set_id}.process",),
         )
     }
 }

--- a/lib/sdf-server/src/lib.rs
+++ b/lib/sdf-server/src/lib.rs
@@ -100,9 +100,15 @@ pub enum ServerError {
     #[error("Failed to set up signal handler")]
     Signal(#[source] io::Error),
     #[error("Permissions error: {0}")]
-    SpiceDb(#[from] SpiceDbError),
+    SpiceDb(#[from] Box<SpiceDbError>),
     #[error("unix domain socket incoming stream error: {0}")]
     Uds(#[from] uds::UdsIncomingStreamError),
+}
+
+impl From<SpiceDbError> for ServerError {
+    fn from(value: SpiceDbError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 type ServerResult<T> = std::result::Result<T, ServerError>;

--- a/lib/sdf-server/src/service/v2/audit_log.rs
+++ b/lib/sdf-server/src/service/v2/audit_log.rs
@@ -17,13 +17,31 @@ mod list_audit_logs;
 #[derive(Debug, Error)]
 pub enum AuditLogError {
     #[error("dal audit logging error: {0}")]
-    DalAuditLogging(#[from] dal::audit_logging::AuditLoggingError),
+    DalAuditLogging(#[from] Box<dal::audit_logging::AuditLoggingError>),
     #[error("dal change set error: {0}")]
-    DalChangeSet(#[from] dal::ChangeSetError),
+    DalChangeSet(#[from] Box<dal::ChangeSetError>),
     #[error("dal transactions error: {0}")]
-    DalTransactions(#[from] dal::TransactionsError),
+    DalTransactions(#[from] Box<dal::TransactionsError>),
     #[error("si db error: {0}")]
     SiDb(#[from] si_db::Error),
+}
+
+impl From<dal::audit_logging::AuditLoggingError> for AuditLogError {
+    fn from(value: dal::audit_logging::AuditLoggingError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<dal::ChangeSetError> for AuditLogError {
+    fn from(value: dal::ChangeSetError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<dal::TransactionsError> for AuditLogError {
+    fn from(value: dal::TransactionsError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type AuditLogResult<T> = Result<T, AuditLogError>;

--- a/lib/sdf-server/src/service/v2/change_set/apply.rs
+++ b/lib/sdf-server/src/service/v2/change_set/apply.rs
@@ -71,7 +71,7 @@ pub async fn apply(
         .await?;
 
         let actor = ctx.history_actor().email(&ctx).await?;
-        let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+        let change_set_url = format!("https://{host_name}/w/{workspace_pk}/{change_set_id}");
         let message = format!(
             "{} applied change set {} to HEAD: {}",
             actor, change_set_view.name, change_set_url

--- a/lib/sdf-server/src/service/v2/change_set/approve.rs
+++ b/lib/sdf-server/src/service/v2/change_set/approve.rs
@@ -139,7 +139,7 @@ pub async fn approve(
         .into_frontend_type(&ctx)
         .await?;
     let actor = ctx.history_actor().email(&ctx).await?;
-    let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+    let change_set_url = format!("https://{host_name}/w/{workspace_pk}/{change_set_id}");
     let message = format!(
         "{} {} merge of change set {}: {}",
         actor,

--- a/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
+++ b/lib/sdf-server/src/service/v2/change_set/cancel_approval_request.rs
@@ -68,7 +68,7 @@ pub async fn cancel_approval_request(
         .publish_on_commit(&ctx)
         .await?;
     let actor = ctx.history_actor().email(&ctx).await?;
-    let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+    let change_set_url = format!("https://{host_name}/w/{workspace_pk}/{change_set_id}");
     let message = format!(
         "{} withdrew approval request of change set {}: {}",
         actor,

--- a/lib/sdf-server/src/service/v2/change_set/request_approval.rs
+++ b/lib/sdf-server/src/service/v2/change_set/request_approval.rs
@@ -57,7 +57,7 @@ pub async fn request_approval(
         .await?;
 
     let actor = ctx.history_actor().email(&ctx).await?;
-    let change_set_url = format!("https://{}/w/{}/{}", host_name, workspace_pk, change_set_id);
+    let change_set_url = format!("https://{host_name}/w/{workspace_pk}/{change_set_id}");
     let message = format!(
         "{} requested an approval of change set {}: {}",
         actor,

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -146,7 +146,7 @@ pub enum FsError {
     #[error("func already unlocked: {0}")]
     FuncAlreadyUnlocked(FuncId),
     #[error("func api error: {0}")]
-    FuncApi(#[from] FuncAPIError),
+    FuncApi(#[from] Box<FuncAPIError>),
     #[error("func argument error: {0}")]
     FuncArgument(#[from] FuncArgumentError),
     #[error("func argument not found with name: {0}")]
@@ -195,6 +195,12 @@ pub enum FsError {
     WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
+}
+
+impl From<FuncAPIError> for FsError {
+    fn from(value: FuncAPIError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 pub type FsResult<T> = Result<T, FsError>;

--- a/lib/sdf-server/src/service/v2/management/generate_template.rs
+++ b/lib/sdf-server/src/service/v2/management/generate_template.rs
@@ -168,9 +168,7 @@ pub async fn generate_template(
             r#"
     const {variable_name}: Output["ops"]["create"][string] = {spec_body};
     specs.push({variable_name});
-"#,
-            variable_name = variable_name,
-            spec_body = spec_body
+"#
         );
         component_sync_code.push_str(&component_code);
     }

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -127,11 +127,14 @@ impl IntoResponse for ViewError {
             ViewError::DalDiagram(dal::diagram::DiagramError::ViewNotFound(_)) => {
                 (StatusCode::NOT_FOUND, self.to_string())
             }
-            ViewError::DalDiagram(dal::diagram::DiagramError::WorkspaceSnapshot(
-                WorkspaceSnapshotError::WorkspaceSnapshotGraph(
-                    WorkspaceSnapshotGraphError::ViewRemovalWouldOrphanItems(_),
-                ),
-            )) => (StatusCode::CONFLICT, self.to_string()),
+            ViewError::DalDiagram(dal::diagram::DiagramError::WorkspaceSnapshot(ref err)) => {
+                match err.as_ref() {
+                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                        WorkspaceSnapshotGraphError::ViewRemovalWouldOrphanItems(_),
+                    ) => (StatusCode::CONFLICT, self.to_string()),
+                    _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+                }
+            }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 

--- a/lib/sdf-v1-routes-diagram/src/delete_connection.rs
+++ b/lib/sdf-v1-routes-diagram/src/delete_connection.rs
@@ -175,7 +175,7 @@ pub async fn delete_connection(
             to_socket_id: request.to_socket_id,
             to_socket_name: to_socket_name.clone(),
         },
-        format!("{0}-{1}", to_component_name, to_socket_name),
+        format!("{to_component_name}-{to_socket_name}"),
     )
     .await?;
     track(

--- a/lib/sdf-v1-routes-module/src/lib.rs
+++ b/lib/sdf-v1-routes-module/src/lib.rs
@@ -200,8 +200,8 @@ pub async fn pkg_lookup(
 
 fn add_pkg_extension(to: &str, version: &str, attempts: usize) -> String {
     match attempts {
-        0 => format!("{}-{}.{}", to, version, PKG_EXTENSION),
-        more_than_zero => format!("{}-{}-{}.{}", to, version, more_than_zero, PKG_EXTENSION),
+        0 => format!("{to}-{version}.{PKG_EXTENSION}"),
+        more_than_zero => format!("{to}-{version}-{more_than_zero}.{PKG_EXTENSION}"),
     }
 }
 

--- a/lib/shuttle-server/tests/integration.rs
+++ b/lib/shuttle-server/tests/integration.rs
@@ -50,10 +50,10 @@ async fn integration() -> std::result::Result<(), Box<dyn error::Error>> {
 
     // Create both streams.
     let (source_stream, destination_stream) = {
-        let source_subject = Subject::from(format!("{}.shuttle.test.source.>", prefix));
-        let source_stream_name = format!("SHUTTLE_TEST_SOURCE_{}", prefix);
-        let destination_subject = Subject::from(format!("{}.shuttle.test.destination.>", prefix));
-        let destination_stream_name = format!("SHUTTLE_TEST_DESTINATION_{}", prefix);
+        let source_subject = Subject::from(format!("{prefix}.shuttle.test.source.>"));
+        let source_stream_name = format!("SHUTTLE_TEST_SOURCE_{prefix}");
+        let destination_subject = Subject::from(format!("{prefix}.shuttle.test.destination.>"));
+        let destination_stream_name = format!("SHUTTLE_TEST_DESTINATION_{prefix}");
 
         let source_stream = context
             .get_or_create_stream(Config {
@@ -80,10 +80,9 @@ async fn integration() -> std::result::Result<(), Box<dyn error::Error>> {
         match Shuttle::new(
             client,
             source_stream_clone,
-            Subject::from(format!("{}.shuttle.test.source.some.inner.*", prefix)),
+            Subject::from(format!("{prefix}.shuttle.test.source.some.inner.*")),
             Subject::from(format!(
-                "{}.shuttle.test.destination.some.inner.messages",
-                prefix
+                "{prefix}.shuttle.test.destination.some.inner.messages"
             )),
         )
         .await
@@ -101,10 +100,8 @@ async fn integration() -> std::result::Result<(), Box<dyn error::Error>> {
 
     // Publish messages on the source stream to ensure that shuttle works.
     {
-        let data_setup_subject = Subject::from(format!(
-            "{}.shuttle.test.source.some.inner.messages",
-            prefix
-        ));
+        let data_setup_subject =
+            Subject::from(format!("{prefix}.shuttle.test.source.some.inner.messages"));
 
         // Publish many messages to be shuttled.
         for index in 0..MESSAGE_COUNT {

--- a/lib/si-aws-config/src/lib.rs
+++ b/lib/si-aws-config/src/lib.rs
@@ -52,7 +52,7 @@ pub enum AwsConfigError {
 
 impl AwsConfigError {
     fn from_sdk_error<T: Debug>(error: SdkError<T>) -> Self {
-        AwsConfigError::Sts(format!("{:?}", error))
+        AwsConfigError::Sts(format!("{error:?}"))
     }
 }
 

--- a/lib/si-data-acmpca/src/lib.rs
+++ b/lib/si-data-acmpca/src/lib.rs
@@ -86,7 +86,7 @@ pub enum PrivateCertManagerClientError {
 
 impl PrivateCertManagerClientError {
     fn from_sdk_error<T: Debug>(error: SdkError<T>) -> Self {
-        PrivateCertManagerClientError::AwsPrivateCertManager(format!("{:?}", error))
+        PrivateCertManagerClientError::AwsPrivateCertManager(format!("{error:?}"))
     }
 }
 

--- a/lib/si-data-pg/src/lib.rs
+++ b/lib/si-data-pg/src/lib.rs
@@ -119,7 +119,7 @@ pub enum PgError {
     #[error("transaction not exclusively referenced when rollback attempted; arc_strong_count={0}")]
     TxnRollbackNotExclusive(usize),
     #[error("unexpected row returned: {0:?}")]
-    UnexpectedRow(PgRow),
+    UnexpectedRow(Box<PgRow>),
 }
 
 #[remain::sorted]
@@ -2537,7 +2537,7 @@ impl PgSharedTransaction {
         match self.inner.lock().await.borrow_txn().as_ref() {
             Some(txn) => match txn.query_opt(statement, params).await? {
                 None => Ok(()),
-                Some(row) => Err(PgError::UnexpectedRow(row)),
+                Some(row) => Err(PgError::UnexpectedRow(Box::new(row))),
             },
             None => {
                 unreachable!("txn is only consumed with commit/rollback--this is an internal bug")

--- a/lib/si-data-ssm/src/lib.rs
+++ b/lib/si-data-ssm/src/lib.rs
@@ -63,7 +63,7 @@ pub enum ParameterStoreClientError {
 
 impl ParameterStoreClientError {
     fn from_sdk_error<T: Debug>(error: SdkError<T>) -> Self {
-        ParameterStoreClientError::AwsParameterStore(format!("{:?}", error))
+        ParameterStoreClientError::AwsParameterStore(format!("{error:?}"))
     }
 }
 

--- a/lib/si-events-rs/src/xxhash_type.rs
+++ b/lib/si-events-rs/src/xxhash_type.rs
@@ -182,7 +182,7 @@ macro_rules! create_xxhash_type {
 
             impl [<$name Hasher>] {
                 pub fn new() -> Self {
-                    Self(Box::new(::xxhash_rust::xxh3::Xxh3::new()))
+                    Self(Box::default())
                 }
 
                 pub fn update(&mut self, input: &[u8]) {

--- a/lib/si-filesystem/src/lib.rs
+++ b/lib/si-filesystem/src/lib.rs
@@ -3102,7 +3102,7 @@ impl SiFileSystem {
                         log::trace!("invaliding changeset {change_set_id}");
                         self_clone.invalidate_change_set(change_set_id).await;
                     } else {
-                        log::error!("{:?}", err);
+                        log::error!("{err:?}");
                     }
                 }
             });

--- a/lib/si-firecracker/src/disk.rs
+++ b/lib/si-firecracker/src/disk.rs
@@ -100,7 +100,7 @@ impl FirecrackerDisk {
     }
 
     fn overlay_from_id(id: u32) -> String {
-        format!("{}{}", OVERLAY_PREFIX, id)
+        format!("{OVERLAY_PREFIX}{id}")
     }
 
     fn find_loop_device_by_backing_file(backing_file: &Path) -> Result<Option<OsString>> {
@@ -118,7 +118,7 @@ impl FirecrackerDisk {
                 let backing_file_path = path.join("loop").join("backing_file");
                 if let Ok(contents) = fs::read_to_string(&backing_file_path) {
                     if contents.trim() == backing_file.to_string_lossy() {
-                        return Ok(Some(OsString::from(format!("/dev/{}", loop_name))));
+                        return Ok(Some(OsString::from(format!("/dev/{loop_name}"))));
                     }
                 }
             }

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -1,9 +1,6 @@
 use std::{
     fs::Permissions,
-    io::{
-        Error,
-        ErrorKind,
-    },
+    io::Error,
     os::unix::fs::PermissionsExt,
     path::{
         Path,
@@ -96,8 +93,7 @@ impl FirecrackerJail {
             .map_err(FirecrackerJailError::Prepare)?;
 
         if !output.status.success() {
-            return Err(FirecrackerJailError::Prepare(Error::new(
-                ErrorKind::Other,
+            return Err(FirecrackerJailError::Prepare(Error::other(
                 String::from_utf8(output.stderr)
                     .unwrap_or_else(|_| "Failed to decode stderr".to_string()),
             )));
@@ -157,8 +153,7 @@ impl FirecrackerJail {
             // error enum with its own variants and make this a formal variant. Why? We may need
             // to provide more context and/or capture stdout here. Many script errors end with
             // empty stderr.
-            return Err(FirecrackerJailError::Setup(Error::new(
-                ErrorKind::Other,
+            return Err(FirecrackerJailError::Setup(Error::other(
                 String::from_utf8(output.stderr)
                     .unwrap_or_else(|_| "Failed to decode stderr".to_string()),
             )));

--- a/lib/si-firecracker/src/firecracker.rs
+++ b/lib/si-firecracker/src/firecracker.rs
@@ -66,15 +66,15 @@ impl FirecrackerJail {
             .arg("--exec-file")
             .arg("/usr/bin/firecracker")
             .arg("--uid")
-            .arg(format!("500{}", id))
+            .arg(format!("500{id}"))
             .arg("--gid")
             .arg("10000")
             .arg("--netns")
-            .arg(format!("/var/run/netns/jailer-{}", id))
+            .arg(format!("/var/run/netns/jailer-{id}"))
             .arg("--")
             .arg("--config-file")
             .arg("./firecracker.conf");
-        let socket = PathBuf::from(&format!("/srv/jailer/firecracker/{}/root/v.sock", id));
+        let socket = PathBuf::from(&format!("/srv/jailer/firecracker/{id}/root/v.sock"));
 
         Ok(Self {
             jailer: cmd,

--- a/lib/si-firecracker/src/stream.rs
+++ b/lib/si-firecracker/src/stream.rs
@@ -108,7 +108,7 @@ pub struct TcpStreamForwarder {
 impl TcpStreamForwarder {
     pub async fn new() -> Result<Self> {
         let port = DEFAULT_OTEL_PORT;
-        let addr = format!("127.0.0.1:{}", port);
+        let addr = format!("127.0.0.1:{port}");
         let source = TcpListener::bind(addr)
             .await
             .map_err(StreamForwarderError::Tcp)?;

--- a/lib/si-layer-cache/tests/integration_test/db/cas.rs
+++ b/lib/si-layer-cache/tests/integration_test/db/cas.rs
@@ -382,7 +382,7 @@ async fn stress_test() {
     let time = tokio::time::Instant::now();
     while let Some(res) = write_join_set.join_next().await {
         if let Err(e) = res {
-            panic!("Write failed {}", e);
+            panic!("Write failed {e}");
         }
     }
     println!("writes are all sent: {:?}", time.elapsed());
@@ -391,7 +391,7 @@ async fn stress_test() {
     while let Some(res) = read_join_set.join_next().await {
         if let Err(e) = res {
             println!("read failed: {:?}", time.elapsed());
-            panic!("Read failed {}", e);
+            panic!("Read failed {e}");
         }
         println!("read succeeded: {:?}", time.elapsed());
     }

--- a/lib/si-pkg/src/spec/attribute_value.rs
+++ b/lib/si-pkg/src/spec/attribute_value.rs
@@ -36,8 +36,8 @@ pub enum KeyOrIndex {
 impl fmt::Display for KeyOrIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let _ = match self {
-            KeyOrIndex::Key(key) => write!(f, "[{}]", key),
-            KeyOrIndex::Index(index) => write!(f, "[{}]", index),
+            KeyOrIndex::Key(key) => write!(f, "[{key}]"),
+            KeyOrIndex::Index(index) => write!(f, "[{index}]"),
         };
         Ok(())
     }
@@ -47,13 +47,13 @@ impl fmt::Display for AttributeValuePath {
         match self {
             AttributeValuePath::Prop { path, key_or_index } => {
                 if let Some(attribute_value_index_or_key) = key_or_index {
-                    write!(f, "{}{}", path, attribute_value_index_or_key)?
+                    write!(f, "{path}{attribute_value_index_or_key}")?
                 } else {
-                    write!(f, "{}", path)?
+                    write!(f, "{path}")?
                 }
             }
-            AttributeValuePath::InputSocket(path) => write!(f, "{}", path)?,
-            AttributeValuePath::OutputSocket(path) => write!(f, "{}", path)?,
+            AttributeValuePath::InputSocket(path) => write!(f, "{path}")?,
+            AttributeValuePath::OutputSocket(path) => write!(f, "{path}")?,
         };
         Ok(())
     }

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -110,7 +110,7 @@ pub enum LocalUdsInstanceError {
     ChildSpawn(#[source] io::Error),
     /// Cyclone client error.
     #[error(transparent)]
-    Client(#[from] ClientError),
+    Client(#[from] Box<ClientError>),
     /// Failed to build a container.
     #[error("failed to build a cyclone container: {0}")]
     ContainerBuild(#[source] Error),
@@ -150,7 +150,7 @@ pub enum LocalUdsInstanceError {
     TempSocket(#[source] io::Error),
     /// Cyclone client `watch` endpoint error.
     #[error(transparent)]
-    Watch(#[from] WatchError),
+    Watch(#[from] Box<WatchError>),
     /// Cyclone client `watch` session ended earlier than expected.
     #[error("server closed watch session before expected")]
     WatchClosed,
@@ -160,6 +160,18 @@ pub enum LocalUdsInstanceError {
     /// Cyclone client `watch` session shut down earlier than expected.
     #[error("watch session is shut down, cyclone server is considered unhealthy")]
     WatchShutDown,
+}
+
+impl From<ClientError> for LocalUdsInstanceError {
+    fn from(value: ClientError) -> Self {
+        Box::new(value).into()
+    }
+}
+
+impl From<WatchError> for LocalUdsInstanceError {
+    fn from(value: WatchError) -> Self {
+        Box::new(value).into()
+    }
 }
 
 type Result<T> = result::Result<T, LocalUdsInstanceError>;

--- a/lib/si-service/src/startup.rs
+++ b/lib/si-service/src/startup.rs
@@ -58,7 +58,7 @@ pub async fn startup(service: &str) -> Result<(), std::io::Error> {
         return Ok(());
     }
 
-    let metadata_candidates = match glob(&format!("/etc/nix-omnibus/{}/*/metadata.json", service)) {
+    let metadata_candidates = match glob(&format!("/etc/nix-omnibus/{service}/*/metadata.json")) {
         Ok(iter) => iter,
         Err(_) => {
             info!("metadata candidates could not be found for {}", service);

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -1481,7 +1481,7 @@ where
             return Err(SplitGraphError::TooManyEdgesOfKind(
                 from_id,
                 direction,
-                format!("{:?}", kind),
+                format!("{kind:?}"),
             ));
         }
 

--- a/lib/si-split-graph/src/tests/mod.rs
+++ b/lib/si-split-graph/src/tests/mod.rs
@@ -373,8 +373,7 @@ fn default_edges() -> SplitGraphResult<()> {
             } else {
                 assert!(
                     matches!(edge.0, TestEdgeWeight::EdgeB { is_default: true }),
-                    "{:?} should be default target",
-                    default_target
+                    "{default_target:?} should be default target"
                 );
                 hit_default = true;
             }

--- a/lib/veritech-server/src/server.rs
+++ b/lib/veritech-server/src/server.rs
@@ -123,7 +123,7 @@ impl Server {
         let nats = Self::connect_to_nats(config.nats()).await?;
         let mut nats_config = config.nats().clone();
         if let Some(name) = nats_config.connection_name {
-            nats_config.connection_name = Some(format!("{}-stream", name));
+            nats_config.connection_name = Some(format!("{name}-stream"));
         }
         let nats_jetstream = Self::connect_to_nats(&nats_config).await?;
 


### PR DESCRIPTION
A lot of updates, refactorings, changes, among the notables:

chore(deps): pin Deno to 2.2.12 until Hydra has newer pkg builds
---

Pin Deno to version 2.2.12 as this is the last version that successfully
built via Hydra. All newer versions revert to source-building which
takes way too long for every developer.

References: https://github.com/NixOS/nixpkgs/issues/417331
References: https://github.com/NixOS/nixpkgs/pull/384838

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdld2t6eHpkaHVrdXVud3d6Y2dycmhndnF6M2MweTNvYXFzeHlhdWtnMSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1APae5urZn7RydltMr/giphy.gif"/>

build(deps): update Nix dependencies (2025-W29)
---

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b1bebd0fe266bbd1820019612ead889e96a8fa2d' (2025-05-15)
  → 'github:NixOS/nixpkgs/fa64ec5c1ca6f17746f3defedb988b9248e97616' (2025-07-16)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/58160be7abad81f6f8cb53120d5b88c16e01c06d' (2025-05-14)
  → 'github:oxalica/rust-overlay/dc221f842e9ddc8c0416beae8d77f2ea356b91ae' (2025-07-17)

Notable software updates:

```
❯ for cmd in buck2 deno node pnpm reindeer rustc tilt; do
  command -v "$cmd" \
    | sed -e 's#^/nix/store/[[:alnum:]]\{1,\}-##' -e 's#/bin/.\{1,\}$##'
done
buck2-unstable-2025-05-06
deno-2.2.12
nodejs-20.19.3
pnpm-10.12.4
reindeer-2025.07.14.00
rust-minimal-1.88.0
tilt-0.35.0
```

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNmNwbnoydmx4ZG5ibWd3NW1hZGRwemtjN2pjM3R1dW80NnJhZDVmMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mD4Z5Iz80f0Kv1vC5H/giphy.gif"/>

style(lint): inline variables into format strings
---

See: <https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args>

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbjM3czVkOTN2MDA4YzJmYWxkdnJibzJhMzR3bWZ5MGN1cXRpaHh0bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IABMhrLIhPM3CecsNl/giphy.gif"/>

chore: box many nested errors to reduce their overall sizes
---

It's the Box-pocalypse!

As taken from the Clippy docs:

> A Result is at least as large as the Err-variant. While we expect that
> variant to be seldom used, the compiler needs to reserve and move that
> much memory every single time. Furthermore, errors are often simply
> passed up the call-stack, making use of the ?-operator and its
> type-conversion mechanics. If the Err-variant further up the call-stack
> stores the Err-variant in question (as library code often does), it
> itself needs to be at least as large, propagating the problem.

See: <https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err>

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOHVpcXI5aWJ0d3NhOGtsMm9lYzl6MGswM2ZxOHloeGVid3ZnNGp3ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QMHoU66sBXqqLqYvGO/giphy.gif"/>