### PR TITLE
Refresh actions can run in change sets

### DIFF
--- a/app/web/src/newhotness/ActionsPanel.vue
+++ b/app/web/src/newhotness/ActionsPanel.vue
@@ -22,83 +22,23 @@
       v-for="actionPrototypeView in actionPrototypeViews"
       :key="actionPrototypeView.id"
       :actionPrototypeView="actionPrototypeView"
-      :actionId="actionByPrototype[actionPrototypeView.id]"
+      :actionId="actionByPrototype[actionPrototypeView.id]?.id"
       :component="props.component"
     />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { useQuery } from "@tanstack/vue-query";
-import { computed, inject } from "vue";
-import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
-import {
-  ActionPrototypeViewList,
-  BifrostActionViewList,
-  BifrostComponent,
-  EntityKind,
-} from "@/workers/types/entity_kind_types";
-import { ActionId, ActionPrototypeId } from "@/api/sdf/dal/action";
+import { BifrostComponent } from "@/workers/types/entity_kind_types";
 import ActionWidget from "./ActionWidget.vue";
 import EmptyState from "./EmptyState.vue";
-import { assertIsDefined, Context } from "./types";
+import { useComponentActions } from "./logic_composables/component_actions";
 
 const props = defineProps<{
   component: BifrostComponent;
 }>();
 
-// The code below is the same as in AssetActionsDetails in the mead hall
-
-// This is the core materialized view for this component. We need it to know what action prototypes
-// are available for the given component.
-const makeKey = useMakeKey();
-const makeArgs = useMakeArgs();
-
-const ctx = inject<Context>("CONTEXT");
-assertIsDefined(ctx);
-
-const queryKeyForActionPrototypeViews = makeKey(
-  EntityKind.ActionPrototypeViewList,
-  props.component.schemaVariant.id,
+const { actionPrototypeViews, actionByPrototype } = useComponentActions(
+  () => props.component,
 );
-const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
-  enabled: ctx.queriesEnabled,
-  queryKey: queryKeyForActionPrototypeViews,
-  queryFn: async () =>
-    await bifrost<ActionPrototypeViewList>(
-      makeArgs(
-        EntityKind.ActionPrototypeViewList,
-        props.component.schemaVariant.id,
-      ),
-    ),
-});
-const actionPrototypeViews = computed(
-  () => actionPrototypeViewsRaw.data.value?.actionPrototypes ?? [],
-);
-
-// Use the materialized view for actions to know what actions exist for a given prototype and the
-// selected component.
-const queryKeyForActionViewList = makeKey(EntityKind.ActionViewList);
-const actionViewList = useQuery<BifrostActionViewList | null>({
-  queryKey: queryKeyForActionViewList,
-  queryFn: async () =>
-    await bifrost<BifrostActionViewList>(makeArgs(EntityKind.ActionViewList)),
-});
-const actionByPrototype = computed(() => {
-  if (!actionViewList.data.value?.actions) return {};
-  if (actionViewList.data.value.actions.length < 1) return {};
-
-  const result: Record<ActionPrototypeId, ActionId> = {};
-  for (const action of actionViewList.data.value.actions) {
-    if (action.componentId === props.component.id) {
-      // NOTE(nick): this assumes that there can be one action for a given prototype and component.
-      // As of the time of writing, this is true, but multiple actions per prototype and component
-      // aren't disallowed from the underlying graph's perspective. Theorhetically, you could
-      // enqueue two refreshes back-to-back. What then? I don't think we'll expose an interface to
-      // do that for awhile, so this should be sufficient.
-      result[action.prototypeId] = action.id;
-    }
-  }
-  return result;
-});
 </script>

--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -369,6 +369,18 @@
         <CollapsingFlexItem expandable>
           <template #header><span class="text-sm">Resource</span></template>
           <template #headerIcons>
+            <VButton
+              v-if="refreshEnabled"
+              size="xs"
+              class="font-normal p-0 h-md mt-[1px] [&>div]:top-[-2px]"
+              tone="neutral"
+              label="Refresh"
+              :loading="refreshActionRunning"
+              loadingIcon="loader"
+              loadingText="Refreshing..."
+              :disabled="refreshBifrosting"
+              @click.stop="executeRefresh"
+            />
             <Icon
               v-if="component.hasResource"
               name="check-hex"
@@ -443,6 +455,7 @@ import MinimizedComponentQualificationStatus from "./MinimizedComponentQualifica
 import { useComponentDeletion } from "./composables/useComponentDeletion";
 import { useComponentUpgrade } from "./composables/useComponentUpgrade";
 import { useManagementFuncJobState } from "./logic_composables/management";
+import { useComponentActions } from "./logic_composables/component_actions";
 
 const props = defineProps<{
   componentId: string;
@@ -505,6 +518,10 @@ const hasResourceValueProps = computed(() => {
 
 const component = computed(() => componentQuery.data.value);
 
+// Actions composable - reactive to component changes
+const { refreshEnabled, refreshActionRunning, runRefreshHandler } =
+  useComponentActions(component);
+const { executeRefresh, bifrosting: refreshBifrosting } = runRefreshHandler();
 const mgmtFuncs = computed(
   () => component.value?.schemaVariant.mgmtFunctions ?? [],
 );

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -266,7 +266,7 @@ const ctx = computed<Context>(() => {
     changeSet,
     approvers,
     user: authStore.user,
-    onHead: computed(() => activeChangeSet.value?.id === headChangeSetId.value),
+    onHead: computed(() => activeChangeSet.value?.isHead ?? false),
     headChangeSetId: _headChangeSetId,
     outgoingCounts,
     componentDetails,

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -39,6 +39,7 @@ export enum routes {
   FuncRunLogs = "FuncRunLogs",
   GetFuncRunsPaginated = "GetFuncRunsPaginated",
   GetPublicKey = "GetPublicKey",
+  RefreshAction = "RefreshAction",
   RestoreComponents = "RestoreComponents",
   MgmtFuncRun = "MgmtFuncRun",
   MgmtFuncGetJobState = "MgmtFuncGetJobState",
@@ -66,6 +67,7 @@ const CAN_MUTATE_ON_HEAD: readonly routes[] = [
   routes.CreateChangeSet,
   routes.AbandonChangeSet,
   routes.EnqueueAttributeValue,
+  routes.RefreshAction,
 ] as const;
 
 const COMPRESSED_ROUTES: readonly routes[] = [
@@ -94,6 +96,7 @@ const _routes: Record<routes, string> = {
   FuncRunLogs: "/funcs/runs/<id>/logs",
   GetFuncRunsPaginated: "/funcs/runs/paginated",
   GetPublicKey: "/components/<id>/secret/public_key",
+  RefreshAction: "/action/refresh/<componentId>",
   RestoreComponents: "/components/restore",
   MgmtFuncRun: "/management/prototype/<prototypeId>/<componentId>/<viewId>",
   MgmtFuncGetJobState: "/management/state/<funcRunId>",

--- a/app/web/src/newhotness/logic_composables/component_actions.ts
+++ b/app/web/src/newhotness/logic_composables/component_actions.ts
@@ -1,0 +1,265 @@
+import { computed, inject, MaybeRefOrGetter, ref, toValue } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import { useRoute } from "vue-router";
+import {
+  ActionId,
+  ActionKind,
+  ActionPrototypeId,
+  ActionState,
+} from "@/api/sdf/dal/action";
+import {
+  BifrostComponent,
+  ActionPrototypeView,
+  EntityKind,
+  ActionPrototypeViewList,
+  BifrostActionViewList,
+  ComponentInList,
+} from "@/workers/types/entity_kind_types";
+import {
+  bifrost,
+  useMakeArgs,
+  useMakeArgsForHead,
+  useMakeKey,
+  useMakeKeyForHead,
+} from "@/store/realtime/heimdall";
+import { ActionProposedView } from "@/store/actions.store";
+import { routes, useApi } from "../api_composables";
+import { assertIsDefined, Context } from "../types";
+
+export const useComponentActions = (
+  componentRef: MaybeRefOrGetter<
+    BifrostComponent | ComponentInList | undefined
+  >,
+) => {
+  const makeKey = useMakeKey();
+  const makeKeyForHead = useMakeKeyForHead();
+  const makeArgs = useMakeArgs();
+  const makeArgsForHead = useMakeArgsForHead();
+  const ctx = inject<Context>("CONTEXT");
+  assertIsDefined(ctx);
+  const route = useRoute();
+
+  const component = computed(() => toValue(componentRef));
+  const schemaVariantId = computed(() => {
+    const comp = component.value;
+    if (!comp) return "";
+
+    // Handle both string (ComponentInList) and WeakReference (BifrostComponent) types
+    const variantId = comp.schemaVariantId;
+    if (typeof variantId === "string") {
+      return variantId;
+    }
+
+    return variantId.id;
+  });
+  const queryKeyForActionPrototypeViews = makeKey(
+    EntityKind.ActionPrototypeViewList,
+    schemaVariantId,
+  );
+
+  const actionPrototypeViewsRaw = useQuery<ActionPrototypeViewList | null>({
+    enabled: computed(() => ctx.queriesEnabled.value && !!component.value),
+    queryKey: queryKeyForActionPrototypeViews,
+    queryFn: async () => {
+      if (!schemaVariantId.value) return null;
+      return await bifrost<ActionPrototypeViewList>(
+        makeArgs(EntityKind.ActionPrototypeViewList, schemaVariantId.value),
+      );
+    },
+  });
+  const actionPrototypeViews = computed(
+    () => actionPrototypeViewsRaw.data.value?.actionPrototypes ?? [],
+  );
+
+  const queryKeyForComponentOnHead = makeKeyForHead(
+    EntityKind.ComponentInList,
+    component.value?.id,
+  );
+  const componentOnHeadRaw = useQuery<ComponentInList | null>({
+    enabled: computed(() => ctx.queriesEnabled.value && !!component.value),
+    queryKey: queryKeyForComponentOnHead,
+    queryFn: async () => {
+      if (!component.value) return null;
+      return await bifrost<ComponentInList>(
+        makeArgsForHead(EntityKind.ComponentInList, component.value.id),
+      );
+    },
+  });
+  const componentExistsOnHead = computed(() => !!componentOnHeadRaw.data.value);
+
+  // Use the materialized view for actions to know what actions exist for a given prototype and the
+  // selected component.
+  const queryKeyForActionViewList = makeKey(EntityKind.ActionViewList);
+  const actionViewList = useQuery<BifrostActionViewList | null>({
+    queryKey: queryKeyForActionViewList,
+    queryFn: async () =>
+      await bifrost<BifrostActionViewList>(makeArgs(EntityKind.ActionViewList)),
+  });
+
+  const actionByPrototype = computed(() => {
+    if (!actionViewList.data.value?.actions?.length || !component.value?.id) {
+      return {};
+    }
+
+    const result: Record<ActionPrototypeId, ActionProposedView> = {};
+    for (const action of actionViewList.data.value.actions) {
+      if (action.componentId === component.value.id) {
+        // NOTE(nick): this assumes that there can be one action for a given prototype and component.
+        // As of the time of writing, this is true, but multiple actions per prototype and component
+        // aren't disallowed from the underlying graph's perspective. Theorhetically, you could
+        // enqueue two refreshes back-to-back. What then? I don't think we'll expose an interface to
+        // do that for awhile, so this should be sufficient.
+        result[action.prototypeId] = action;
+      }
+    }
+    return result;
+  });
+
+  const actionIsRunning = (actionId?: ActionId | null) => {
+    if (!actionId) return false;
+    const state = actionViewList.data.value?.actions.find(
+      (action) => action.id === actionId,
+    )?.state;
+    if (!state) return false;
+    return [ActionState.Dispatched, ActionState.Running].includes(state);
+  };
+
+  // Helpers for Refresh Actions specifically
+  const refreshActionPrototype = computed(() => {
+    return (
+      actionPrototypeViews.value.find(
+        (action: ActionPrototypeView) => action.kind === ActionKind.Refresh,
+      ) ?? null
+    );
+  });
+
+  const refreshAction = computed(() => {
+    if (!refreshActionPrototype.value?.id) return null;
+    return actionByPrototype.value[refreshActionPrototype.value.id] ?? null;
+  });
+
+  const refreshActionRunning = computed(() => {
+    return refreshAction.value
+      ? actionIsRunning(refreshAction.value?.id)
+      : false;
+  });
+
+  const refreshEnabled = computed(
+    () =>
+      !!(
+        refreshActionPrototype.value &&
+        component.value?.hasResource &&
+        componentExistsOnHead.value
+      ),
+  );
+
+  const runRefreshHandler = () => {
+    const directRefreshApi = useApi();
+
+    const executeRefresh = async () => {
+      if (!component.value?.id || refreshActionRunning.value) return;
+      const call = directRefreshApi.endpoint(routes.RefreshAction, {
+        componentId: component.value.id,
+      });
+      directRefreshApi.setWatchFn(() => refreshAction.value?.state);
+      await call.put({});
+    };
+
+    const bifrosting = computed(() => directRefreshApi.bifrosting.value);
+
+    return {
+      executeRefresh,
+      bifrosting,
+    };
+  };
+
+  const toggleActionHandler = (
+    actionPrototypeView: ActionPrototypeView,
+    actionId?: MaybeRefOrGetter<ActionId | undefined>,
+  ) => {
+    const removeApi = useApi();
+    const addApi = useApi();
+    const refreshApi = useApi();
+    // Track which API is currently active as we could call 3 different APIs and need to propagate
+    // the bifrosting status reactively for the correct one
+    const activeApi = ref(addApi);
+
+    const handleToggle = async () => {
+      if (!component.value) return;
+      const action = toValue(actionId);
+
+      if (action) {
+        activeApi.value = removeApi;
+        // Removing/canceling existing action
+        const call = removeApi.endpoint(routes.ActionCancel, {
+          id: action,
+        });
+        removeApi.setWatchFn(() => toValue(actionId));
+        await call.put({});
+      } else {
+        // Adding new action - check if it's a refresh action
+        const onHead = ctx.onHead.value;
+        const isRefresh = actionPrototypeView.kind === ActionKind.Refresh;
+        if (onHead && isRefresh) {
+          // For refresh actions on HEAD, we enqueue using another route until we can get rid of Force Change Set
+          if (!component.value?.id || actionIsRunning(toValue(actionId)))
+            return;
+          activeApi.value = refreshApi;
+          const call = refreshApi.endpoint(routes.RefreshAction, {
+            componentId: component.value.id,
+          });
+          refreshApi.setWatchFn(() => toValue(actionId));
+          await call.put({});
+        } else {
+          // Handle regular action add
+          const call = addApi.endpoint(routes.ActionAdd);
+          addApi.setWatchFn(() => toValue(actionId));
+          const { req, newChangeSetId } = await call.post<{
+            componentId: string;
+            prototypeId: string;
+          }>({
+            componentId: component.value.id,
+            prototypeId: actionPrototypeView.id,
+          });
+          if (newChangeSetId && addApi.ok(req)) {
+            addApi.navigateToNewChangeSet(
+              {
+                name: "new-hotness-component",
+                params: {
+                  workspacePk: route.params.workspacePk,
+                  changeSetId: newChangeSetId,
+                  componentId: component.value.id,
+                },
+              },
+              newChangeSetId,
+            );
+          }
+        }
+      }
+    };
+
+    const bifrosting = computed(() => activeApi.value.bifrosting ?? false);
+
+    return {
+      handleToggle,
+      bifrosting,
+    };
+  };
+
+  return {
+    // Lists for the component
+    actionPrototypeViews,
+    actionByPrototype,
+
+    // Whether an action is currently running
+    actionIsRunning,
+
+    // Specific refresh action properties
+    refreshActionRunning,
+    refreshEnabled,
+
+    // Click Handlers for toggling actions and refreshing a resource
+    toggleActionHandler,
+    runRefreshHandler,
+  };
+};

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -689,6 +689,18 @@ export const prune = async (
   await db.pruneAtomsForClosedChangeSet(workspaceId, changeSetId);
 };
 
+export const useMakeArgsForHead = () => {
+  const ctx: Context | undefined = inject("CONTEXT");
+  return <K = Gettable>(kind: EntityKind, id?: string) => {
+    return {
+      workspaceId: ctx?.workspacePk.value ?? "",
+      changeSetId: ctx?.headChangeSetId.value ?? "",
+      kind: kind as K,
+      id: id ?? ctx?.workspacePk.value ?? "",
+    };
+  };
+};
+
 export const useMakeArgs = () => {
   const ctx: Context | undefined = inject("CONTEXT");
 
@@ -726,6 +738,20 @@ export const useMakeKey = () => {
     computed<[string?, string?, (ComputedRef<K> | K)?, string?]>(() => [
       ctx?.workspacePk.value,
       ctx?.changeSetId.value,
+      toValue(kind),
+      toValue(id ?? ctx?.workspacePk),
+    ]);
+};
+
+export const useMakeKeyForHead = () => {
+  const ctx: Context | undefined = inject("CONTEXT");
+  return <K = Gettable>(
+    kind: MaybeRefOrGetter<K>,
+    id?: MaybeRefOrGetter<string>,
+  ) =>
+    computed<[string?, string?, (ComputedRef<K> | K)?, string?]>(() => [
+      ctx?.workspacePk.value,
+      ctx?.headChangeSetId.value,
       toValue(kind),
       toValue(id ?? ctx?.workspacePk),
     ]);

--- a/lib/dal-test/src/test_exclusive_schemas/mod.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/mod.rs
@@ -279,6 +279,7 @@ fn build_management_func(code: &str, fn_name: &str) -> BuiltinsResult<FuncSpec> 
             FuncSpecData::builder()
                 .name(fn_name)
                 .code_plaintext(code)
+                .display_name(fn_name.to_string())
                 .handler("main")
                 .backend_kind(FuncSpecBackendKind::Management)
                 .response_type(FuncSpecBackendResponseType::Management)


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
When importing resources, it is quite painful to have to apply a change set in order to propagate resource_values to use in downstream components. Similarly, if you know a resource has changed, it is unnecessary to have to force a new change set to get the updated values. 

Users get two key benefits from these changes: 
1. A user can import a full suite of resources, and create connections as they go, without having to do the apply/open new change set dance.
2. A user can trigger a refresh from their change set, and see the results flow back to the change set (as opposed to switching to head, hitting the button, then going back to your change set)

## SDF Changes
A new route was added to SDF that handles refresh actions **only** with the following logic: 
1. If refresh was triggered on head, enqueue the action
2. If there's already a failed/on hold refresh action for that component, re-enqueue it 
3. If refresh was triggered in an open change set (NOT head), check if the component exists on head. If it does, we enqueue the refresh action on head (and upon completion the updates will be replayed back to the change set). If it does NOT exist on head, we hide the button entirely (NOTE: we are not actually preventing this from dispatching via SDF. If the same checks hold (component doesn't exist on head, has a resource), SDF will enqueue it, mark it as dispatched, and dispatch it directly from the change set! 

## Management Func Job Changes
In the management function job, if we're running an Import function, and we're NOT on head, AND the component we're running import for does not exist on head, we will now dispatch that refresh action job from the change set so that we can set the resource and propagate values as needed.

## Frontend Changes
Added a `Refresh` Button to the Resource Tab in ComponentDetails which calls the new SDF route: 
<img width="335" height="37" alt="image" src="https://github.com/user-attachments/assets/60a4f149-a47b-47a1-a6c5-3960e0655427" />
(yes, I know, all this for one button). 

As there was lots of duplication for handling the various places we show actions, I created a new composable `useComponentActions` which pulls all of this logic into one place, and is consumed where needed. 
 
In order to hide the refresh button if a component doesn't exist on head, I've made 2 new composables that allow us to make args/keys for queries for head from other change sets. We'll see if this is a good idea or not. 

## To Do Still
This should probably be hooked up to be able to multi-select components and enqueue them all for refresh. Did not do that yet. 

Also did not touch the map at all, we might want to consider something there?

## How was it tested?
Manual testing via the UI - NOTE: there seems to be a reactivity issue with our front end Context, punting this problem to look into separately
Adding dal integration tests to cover the various scenarios - NOTE: Some of these *might* be flaky, as it's a lot of "commit this change and wait exactly long enough to check that all the side effects have completed".  Something to keep an eye on. 

<div><img src="https://media2.giphy.com/media/huHHuZ1JS9vyg/giphy.gif?cid=5a38a5a2i4bwe022wt9o7q97tye7d1ke97yhbiwfnvtw6thv&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g&amp;epb=ad.kevel.802a6990f70b" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/anchormanmovie/">Anchorman Movie</a> on <a href="https://giphy.com/gifs/anchormanmovie-will-ferrell-anchorman-ron-burgundy-huHHuZ1JS9vyg">GIPHY</a></div>