### PR TITLE
chore(deps): Set the upper node engine to be <= 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "whichnode": "which node"
   },
   "engines": {
-    "node": ">=18 <19"
+    "node": ">=18 <=20"
   },
   "packageManager": "pnpm@10.0.0"
 }


### PR DESCRIPTION
Stops this warning in our nix environment:

```
 WARN  Unsupported engine: wanted: {"node":">=18 <19"} (current: {"node":"v20.19.1","pnpm":"10.0.0"})
 ```