### PR TITLE
fix(web): move router above watcher that references it

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -138,6 +138,9 @@ import { useChangeSets } from "./logic_composables/change_set";
 const tracer = trace.getTracer("si-vue");
 const navbarPanelLeftRef = ref<InstanceType<typeof NavbarPanelLeft>>();
 
+const route = useRoute();
+const router = useRouter();
+
 const props = defineProps<{
   workspacePk: string;
   changeSetId: string;
@@ -354,9 +357,6 @@ const compositionLink = computed(() => {
     params: props,
   };
 });
-
-const route = useRoute();
-const router = useRouter();
 
 const tokenFail = ref(false);
 


### PR DESCRIPTION
Fixes the following reference error:

<img width="384" height="83" alt="image" src="https://github.com/user-attachments/assets/f67a0b5e-19ea-478b-bfa8-dd5c6243eb2f" />