### PR TITLE
feat: Retain the Explore page's filter and grouping options everywhere

### DIFF
--- a/app/web/src/newhotness/ActionCard.vue
+++ b/app/web/src/newhotness/ActionCard.vue
@@ -147,8 +147,6 @@ import ConfirmHoldModal from "@/components/Actions/ConfirmHoldModal.vue";
 import DetailsPanelMenuIcon from "@/newhotness/layout_components/DetailsPanelMenuIcon.vue";
 import ActionCardLayout from "@/mead-hall/ActionCardLayout.vue";
 import { routes, useApi } from "./api_composables";
-import { preserveExploreState } from "./util";
-import { SelectionsInQueryString } from "./Workspace.vue";
 
 const props = defineProps<{
   action: ActionProposedView;
@@ -176,9 +174,6 @@ const navigateToActionDetails = () => {
       changeSetId: route.params.changeSetId,
       actionId: props.action.id,
     },
-    query: preserveExploreState(
-      router.currentRoute.value?.query as SelectionsInQueryString,
-    ),
   });
 };
 
@@ -193,9 +188,6 @@ const navigateToComponent = () => {
       changeSetId: route.params.changeSetId,
       componentId: props.action.componentId,
     },
-    query: preserveExploreState(
-      router.currentRoute.value?.query as SelectionsInQueryString,
-    ),
   });
 };
 

--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -272,8 +272,6 @@ import { attributeEmitter, keyEmitter } from "./logic_composables/emitters";
 import CollapsingFlexItem from "./layout_components/CollapsingFlexItem.vue";
 import DelayedLoader from "./layout_components/DelayedLoader.vue";
 import { useApi, routes } from "./api_composables";
-import { preserveExploreState } from "./util";
-import { SelectionsInQueryString } from "./Workspace.vue";
 import QualificationPanel from "./QualificationPanel.vue";
 import ResourcePanel from "./ResourcePanel.vue";
 import CodePanel from "./CodePanel.vue";
@@ -388,9 +386,7 @@ const close = () => {
   router.push({
     name: "new-hotness",
     params,
-    query: preserveExploreState(
-      router.currentRoute.value?.query as SelectionsInQueryString,
-    ),
+    query: { retainSessionState: 1 },
   });
 };
 

--- a/app/web/src/newhotness/FuncRunDetails.vue
+++ b/app/web/src/newhotness/FuncRunDetails.vue
@@ -62,8 +62,6 @@ import { assertIsDefined, Context } from "./types";
 import { useApi, routes, funcRunTypes } from "./api_composables";
 import { keyEmitter } from "./logic_composables/emitters";
 import { FuncRun, funcRunStatus, FuncRunLog } from "./api_composables/func_run";
-import { preserveExploreState } from "./util";
-import { SelectionsInQueryString } from "./Workspace.vue";
 
 const props = defineProps<{
   funcRunId: string;
@@ -83,9 +81,7 @@ const back = () => {
   router.push({
     name: "new-hotness",
     params,
-    query: preserveExploreState(
-      router.currentRoute.value?.query as SelectionsInQueryString,
-    ),
+    query: { retainSessionState: 1 },
   });
 };
 
@@ -124,13 +120,12 @@ const retryAction = async () => {
 const navigateToComponent = () => {
   if (funcRun.value?.componentId) {
     const params = { ...router.currentRoute.value.params };
+    const query = { ...router.currentRoute.value.query };
     params.componentId = funcRun.value.componentId;
     router.push({
       name: "new-hotness-component",
       params,
-      query: preserveExploreState(
-        router.currentRoute.value?.query as SelectionsInQueryString,
-      ),
+      query,
     });
   }
 };

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -343,6 +343,7 @@ export type SelectionsInQueryString = Partial<{
   pinned: string;
   viewId: string;
   searchQuery: string;
+  retainSessionState: string; // If set, the component should load up with the last state it had on this tab. Used by Explore.vue
 }>;
 
 const compositionLink = computed(() => {

--- a/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
@@ -130,8 +130,6 @@ import CodeViewer from "@/components/CodeViewer.vue";
 import { FuncRun } from "../api_composables/func_run";
 import FuncRunStatusBadge from "../FuncRunStatusBadge.vue";
 import GridItemWithLiveHeader from "./GridItemWithLiveHeader.vue";
-import { preserveExploreState } from "../util";
-import { SelectionsInQueryString } from "../Workspace.vue";
 
 const props = defineProps<{
   funcRun: FuncRun;
@@ -155,9 +153,7 @@ const navigateBack = () => {
       workspacePk: route.params.workspacePk,
       changeSetId: route.params.changeSetId,
     },
-    query: preserveExploreState(
-      router.currentRoute.value?.query as SelectionsInQueryString,
-    ),
+    query: { retainSessionState: 1 },
   });
 };
 

--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -9,7 +9,6 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { AttributePath } from "@/api/sdf/dal/component";
 import { Toggle } from "./logic_composables/toggle_containers";
-import { SelectionsInQueryString } from "./Workspace.vue";
 
 export type BrandColorKey = keyof typeof BRAND_COLOR_FILTER_HEX_CODES;
 
@@ -93,24 +92,6 @@ export const findAvsAtPropPath = (data: AttributeTree, parts: string[]) => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const attributeValues = avIds.map((avId) => data.attributeValues[avId]!);
   return { prop, attributeValues };
-};
-
-export const preserveExploreState = (
-  currentQuery: SelectionsInQueryString,
-): Partial<SelectionsInQueryString> => {
-  const preservedQuery: Partial<SelectionsInQueryString> = {};
-
-  if (currentQuery.groupBy) preservedQuery.groupBy = currentQuery.groupBy;
-  if (currentQuery.sortBy) preservedQuery.sortBy = currentQuery.sortBy;
-
-  if (currentQuery.pinned) preservedQuery.pinned = currentQuery.pinned;
-
-  if (currentQuery.grid) preservedQuery.grid = currentQuery.grid;
-  if (currentQuery.map) preservedQuery.map = currentQuery.map;
-
-  if (currentQuery.viewId) preservedQuery.viewId = currentQuery.viewId;
-
-  return preservedQuery;
 };
 
 export const findAttributeValueInTree = (


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

<!-- Why: briefly what problem this solves and what the aim is as an overview -->
We had no easy way to retrieve the filter, grouping and sorting  values when coming back to the explore page from inner pages. This PR caches those values so we can use a redirect from anywhere, using the query key `retainSessionState` to re use that cached value. This way any page can go to the last seen explore page without needing to know any details of the implementation.

The cache is only retained per tab, and goes away when it's closed so we don't have any clashes with other sessions 




## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->


- [X] Manual test: Navigate back from component details
- [X] Manual test: Navigate back from func details
- [X] Manual regression test: Follow link, see it does NOT use the cached values

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExd3o5Z3liNGFoMWpzdGttdjg1ZXo3ajU4bHZncnJzam0yZGZ6eGFtcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/XXM6bQ91vZo7YTiZj6/giphy.gif)
