### PR TITLE
Ensure new dynamic AttributeValues are in the DVU roots when migrating SchemaVariants

### DIFF
--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1100,6 +1100,10 @@ impl Component {
                         )
                         .await?;
 
+                        // We need to make sure this AV makes its way into the DVU roots, even though
+                        // we would normally add it at the end of the match arm, because we're
+                        // skipping the rest of the match arm by continuing here.
+                        dvu_roots.push(DependentValueRoot::Unfinished(inserted_value.id().into()));
                         continue;
                     }
 


### PR DESCRIPTION
While migrating a `Component` from one `SchemaVariant` to another, if the old version of the `Component` had an `AttributeValue` that the new version did not have an equivalent for (but was still appropriate for the new `Prop` tree structure), and the old `AttributeValue` used a dynamic function through its (or its `Prop`'s) `AttributePrototype`, we would continue early in the match arm after creating the new `AttributeValue` and preserving the `AttributePrototype` information. This meant that the `AttributeValue` never ended up in the list of DVU roots that was being built as that happened in the skipped over portion of the match arm.

We now ensure that the newly created `AttributeValue` with the dynamic function makes it into the DVU roots to be re-evaluated as part of the migrated `Component`.
