### PR TITLE
chore: don't load prop from CAS unless we need to

### DIFF
--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -59,7 +59,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
             },
         );
 
-        let maybe_prop = AttributeValue::prop_opt(ctx, av_id).await?;
+        let prop_id = AttributeValue::prop_id_opt(ctx, av_id).await?;
 
         // Build si_frontend_mv_types::AttributeValue & add to attribute_values HashMap.
         let key = AttributeValue::key_for_id(ctx, av_id).await?;
@@ -71,8 +71,8 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
                 .await?
             {
                 Some(value) => value,
-                None => match &maybe_prop {
-                    Some(prop) => Prop::default_value(ctx, prop.id)
+                None => match prop_id {
+                    Some(prop_id) => Prop::default_value(ctx, prop_id)
                         .await?
                         .unwrap_or(serde_json::Value::Null),
                     None => serde_json::Value::Null,
@@ -182,7 +182,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
 
         let av_mv = AttributeValueMv {
             id: av_id,
-            prop_id: maybe_prop.as_ref().map(|p| p.id),
+            prop_id,
             key,
             path: av_path,
             value,
@@ -196,11 +196,11 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
         };
         attribute_values.insert(av_id, av_mv);
 
-        if let Some(prop) = maybe_prop {
+        if let Some(prop_id) = prop_id {
             // If si_frontend_mv_types::Prop is not already in props HashMap, build & add.
-            if let std::collections::hash_map::Entry::Vacant(e) = props.entry(prop.id) {
+            if let std::collections::hash_map::Entry::Vacant(e) = props.entry(prop_id) {
                 let prop_mv =
-                    prop_tree::assemble_prop(ctx.clone(), prop.id(), schema_variant_id).await?;
+                    prop_tree::assemble_prop(ctx.clone(), prop_id, schema_variant_id).await?;
                 e.insert(prop_mv);
             }
         }

--- a/lib/dal/src/attribute/attributes.rs
+++ b/lib/dal/src/attribute/attributes.rs
@@ -318,8 +318,8 @@ async fn parent_prop_is_map_or_array(ctx: &DalContext, av_id: AttributeValueId) 
     let Some(parent_av_id) = AttributeValue::parent_id(ctx, av_id).await? else {
         return Ok(false);
     };
-    let parent_prop = AttributeValue::prop(ctx, parent_av_id).await?;
-    Ok(matches!(parent_prop.kind, PropKind::Map | PropKind::Array))
+    let parent_prop_kind = AttributeValue::prop_kind(ctx, parent_av_id).await?;
+    Ok(matches!(parent_prop_kind, PropKind::Map | PropKind::Array))
 }
 
 /// The source for a value

--- a/lib/dal/src/attribute/path.rs
+++ b/lib/dal/src/attribute/path.rs
@@ -118,8 +118,8 @@ async fn resolve_json_pointer(
     // Go through each segment of the JSON pointer (e.g. /foo/bar/0 = foo, bar, 0)
     // and look for its child
     for token in pointer {
-        let prop = AttributeValue::prop(ctx, parent_id).await?;
-        let child_av_id = match prop.kind {
+        let kind = AttributeValue::prop_kind(ctx, parent_id).await?;
+        let child_av_id = match kind {
             // Look up array index in ordering node
             PropKind::Array => match token.to_index() {
                 Ok(jsonptr::index::Index::Num(index)) => {
@@ -174,7 +174,7 @@ async fn vivify_json_pointer(
         //
         // Ensure the parent is si:setObject/si:setArray/si:setMap, so it can have children.
         //
-        let kind = AttributeValue::prop(ctx, parent_id).await?.kind;
+        let kind = AttributeValue::prop_kind(ctx, parent_id).await?;
         let prototype_id = AttributeValue::prototype_id(ctx, parent_id).await?;
         let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
         let intrinsic = Func::intrinsic_kind(ctx, func_id).await?;

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -3053,18 +3053,14 @@ impl Component {
     /// and there isn't any action already enqueued for this component, enqueue it!
     pub async fn enqueue_update_action_if_applicable(
         ctx: &DalContext,
-        modified_attribute_value_id: AttributeValueId,
+        modified_av_id: AttributeValueId,
     ) -> ComponentResult<Option<Action>> {
-        if let Some(prop_for_value) =
-            AttributeValue::prop_opt(ctx, modified_attribute_value_id).await?
-        {
-            if prop_for_value
-                .path(ctx)
+        if let Some(prop_id) = AttributeValue::prop_id_opt(ctx, modified_av_id).await? {
+            if Prop::path_by_id(ctx, prop_id)
                 .await?
                 .is_descendant_of(&PropPath::new(["root", "domain"]))
             {
-                let component_id =
-                    AttributeValue::component_id(ctx, modified_attribute_value_id).await?;
+                let component_id = AttributeValue::component_id(ctx, modified_av_id).await?;
                 if Component::resource_by_id(ctx, component_id)
                     .await?
                     .is_some()
@@ -3137,9 +3133,9 @@ impl Component {
                 .is_some()
             {
                 // this is a component specific prototype. Let's see what the input args would have been though
-                if let Some(prop) = AttributeValue::prop_opt(ctx, attribute_value_id).await? {
+                if let Some(prop_id) = AttributeValue::prop_id_opt(ctx, attribute_value_id).await? {
                     // get the schema variant defined prototype to see what it's potential inputs are
-                    let schema_prototype = Prop::prototype_id(ctx, prop.id()).await?;
+                    let schema_prototype = Prop::prototype_id(ctx, prop_id).await?;
                     let attribute_prototype_arg_ids =
                         AttributePrototypeArgument::list_ids_for_prototype(ctx, schema_prototype)
                             .await?;

--- a/lib/dal/src/validation.rs
+++ b/lib/dal/src/validation.rs
@@ -28,6 +28,7 @@ use crate::{
     ComponentId,
     DalContext,
     FuncError,
+    Prop,
     TransactionsError,
     attribute::value::AttributeValueError,
     func::{
@@ -319,9 +320,11 @@ impl ValidationOutput {
         ctx: &DalContext,
         attribute_value_id: AttributeValueId,
     ) -> ValidationResult<Option<String>> {
-        Ok(AttributeValue::prop_opt(ctx, attribute_value_id)
-            .await?
-            .and_then(|prop| prop.validation_format))
+        let validation_format = match AttributeValue::prop_id_opt(ctx, attribute_value_id).await? {
+            Some(prop_id) => Prop::get_by_id(ctx, prop_id).await?.validation_format,
+            None => None,
+        };
+        Ok(validation_format)
     }
 
     /// If an attribute value is for a [Prop](Prop) that has a `validation_format`, run a validation

--- a/lib/dal/tests/integration_test/component/property_order.rs
+++ b/lib/dal/tests/integration_test/component/property_order.rs
@@ -41,8 +41,7 @@ async fn attribute_value_names(
     let av_id = prop.attribute_value(ctx).await.id();
     let mut result = vec![];
     for child_av_id in AttributeValue::get_child_av_ids_in_order(ctx, av_id).await? {
-        let prop = AttributeValue::prop(ctx, child_av_id).await?;
-        result.push(prop.name);
+        result.push(AttributeValue::prop_name(ctx, child_av_id).await?);
     }
     Ok(result)
 }

--- a/lib/dal/tests/integration_test/pkg/mod.rs
+++ b/lib/dal/tests/integration_test/pkg/mod.rs
@@ -271,7 +271,7 @@ async fn child_av_names(
 ) -> Result<Vec<String>> {
     let mut result = vec![];
     for child_av_id in AttributeValue::get_child_av_ids_in_order(ctx, parent_av_id).await? {
-        let name = AttributeValue::prop(ctx, child_av_id).await?.name;
+        let name = AttributeValue::prop_name(ctx, child_av_id).await?;
         let name = match prefix {
             Some(prefix) => format!("{prefix}.{name}"),
             None => name.to_owned(),


### PR DESCRIPTION
`AttributeValue::prop[_opt]()` forces a CAS load of the Prop, which we don't need 99% of the time. This removes AV::prop and prop_opt, replacing most callers with the terser `prop_kind()` and `prop_name()`, and removing the full Prop CAS load from all but one caller (who needs validation_format).

## How was it tested?

- [X] Integration tests pass

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGNhbWFhZ3JsbHY5cjh5OXBzYnhmeHplNjBkazE0MHhzYXJsaHQxZiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/0GtVKtagi2GvWuY3vm/giphy.gif)
