### PR TITLE
fix(web): TanStack Query keys need to be reactive

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -315,7 +315,7 @@ const componentQuery = useQuery<BifrostComponent | undefined>({
 });
 
 const attributeTreeQuery = useQuery<AttributeTree | undefined>({
-  queryKey: key(EntityKind.AttributeTree, componentId.value),
+  queryKey: key(EntityKind.AttributeTree, componentId),
   queryFn: async (queryContext) =>
     (await bifrost<AttributeTree>(
       args(EntityKind.AttributeTree, componentId.value),

--- a/app/web/src/newhotness/ManagementPanel.vue
+++ b/app/web/src/newhotness/ManagementPanel.vue
@@ -73,10 +73,11 @@ const mgmtFuncs = computed(
 const key = useMakeKey();
 const args = useMakeArgs();
 
-const componentId = computed(() => props.component?.id);
+const componentId = computed(() => props.component?.id ?? "");
 
 const mgmtConnectionsQuery = useQuery<ManagementConnections | null>({
-  queryKey: key(EntityKind.ManagementConnections, componentId.value),
+  enabled: () => componentId.value !== "",
+  queryKey: key(EntityKind.ManagementConnections, componentId),
   queryFn: async () => {
     return await bifrost<ManagementConnections>(
       args(EntityKind.ManagementConnections, componentId.value),


### PR DESCRIPTION
Fixes https://linear.app/system-initiative/issue/BUG-902/not-updating-attribute-tree-when-changing-between-components-in

I also did a pass at which query keys aren't reactive and updated ManagementPanel.vue as well.

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Manual test: switching components doesn't show the wrong data!

## In short: [:link:](https://giphy.com/)
<div><img src="https://media4.giphy.com/media/BYoRqTmcgzHcL9TCy1/giphy.gif?cid=5a38a5a25whss47z92v62tuzlqovrnjnnm7sc6dzdqb1kf6i&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:303px;width:300px"/><br/>via <a href="https://giphy.com/gifs/thank-you-thanks-thumbs-up-BYoRqTmcgzHcL9TCy1">GIPHY</a></div>