### PR TITLE
Enable admins to trigger migrations and snapshot validations

### DIFF
--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -195,7 +195,7 @@ export const useAdminStore = () => {
         ) {
           return new ApiRequest<unknown>({
             method: options?.dryRun ? "get" : "post",
-            url: `v2/workspaces/${workspaceId}/change-sets/${changeSetId}/migrate_connections`,
+            url: `v2/admin/workspaces/${workspaceId}/change_sets/${changeSetId}/migrate_connections`,
           });
         },
         async VALIDATE_SNAPSHOT(
@@ -205,7 +205,7 @@ export const useAdminStore = () => {
         ) {
           return new ApiRequest<ValidateSnapshotResponse>({
             method: options?.fixIssues ? "post" : "get",
-            url: `v2/workspaces/${workspaceId}/change-sets/${changeSetId}/validate_snapshot`,
+            url: `v2/admin/workspaces/${workspaceId}/change_sets/${changeSetId}/validate_snapshot`,
             onSuccess: (response) => {
               this.validateSnapshotResponse = response;
             },

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -43,31 +43,19 @@ mod cancel_approval_request;
 mod create;
 mod force_apply;
 mod list;
-mod migrate_connections;
 mod rename;
 mod reopen;
 mod request_approval;
-mod validate_snapshot;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("attribute prototype error: {0}")]
-    AttributePrototype(#[from] dal::attribute::prototype::AttributePrototypeError),
-    #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(
-        #[from] dal::attribute::prototype::argument::AttributePrototypeArgumentError,
-    ),
-    #[error("attribute value error: {0}")]
-    AttributeValue(#[from] dal::attribute::value::AttributeValueError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] dal::ChangeSetError),
     #[error("change set apply error: {0}")]
     ChangeSetApply(#[from] dal::ChangeSetApplyError),
     #[error("change set approval error: {0}")]
     ChangeSetApproval(#[from] dal::change_set::approval::ChangeSetApprovalError),
-    #[error("component error: {0}")]
-    Component(#[from] dal::component::ComponentError),
     #[error("dal wrapper error: {0}")]
     DalWrapper(#[from] sdf_core::dal_wrapper::DalWrapperError),
     #[error("dependent value root error: {0}")]
@@ -222,28 +210,12 @@ pub fn change_set_routes(state: AppState) -> Router<AppState> {
                 permissions::Permission::Approve,
             )),
         )
-        .route(
-            "/migrate_connections",
-            get(migrate_connections::migrate_connections_dry_run),
-        )
-        .route(
-            "/migrate_connections",
-            post(migrate_connections::migrate_connections),
-        )
         .route("/rename", post(rename::rename))
         // Consider how we make it editable again after it's been rejected
         .route("/reopen", post(reopen::reopen))
         .route(
             "/request_approval",
             post(request_approval::request_approval),
-        )
-        .route(
-            "/validate_snapshot",
-            get(validate_snapshot::validate_snapshot),
-        )
-        .route(
-            "/validate_snapshot",
-            post(validate_snapshot::validate_and_fix_snapshot),
         )
         .nest("/index", super::index::v2_change_set_routes())
 }


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
This creates 2 new routes nested under /admin for the dry run and the actual migration.  I'm using the same internals as the existing routes to limit the blast for now. During cleanup we can decide if the old routes need to stay around or not. 

Also updated the admin store to use these new routes
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Manual test: I can click the button still, and it does the dry run/migration!

## In short: [:link:](https://giphy.com/)
<div><img src="https://media0.giphy.com/media/S99uqwwvMY6Yw/giphy.gif?cid=5a38a5a2q2e9ep6mgfxt6zojf9yfk74neajitjpzg2c9lloe&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:225px;width:300px"/><br/>via <a href="https://giphy.com/challenger/">Challenger</a> on <a href="https://giphy.com/gifs/challenger-challenger23-government-fbi-S99uqwwvMY6Yw">GIPHY</a></div>