### PR TITLE
feat: Clean up migration output

### DIFF
--- a/app/web/src/components/AdminDashboard/MigrateConnections.vue
+++ b/app/web/src/components/AdminDashboard/MigrateConnections.vue
@@ -18,11 +18,12 @@
     <Stack class="flex flex-col gap-xs p-xs w-full font-bold text-xs">
       <Stack>
         <div class="text-lg">
-          Migrateable Connections: {{ migrateable.length }}
+          {{ migrationRun?.dryRun ? "Migrateable" : "Migrated" }} Connections:
+          {{ migrateable.length }}
         </div>
-        <div v-for="migration of migrateable" :key="migration.message">
-          {{ migration.message }}
-        </div>
+        <pre v-for="migration of migrateable" :key="migration.message">{{
+          migration.message.replaceAll(" | ", "\n")
+        }}</pre>
       </Stack>
       <Stack v-if="unmigrateableBecause.length > 0">
         <div class="text-lg">
@@ -39,19 +40,8 @@
         >
           <div class="text-lg">{{ because }}: {{ migrations.length }}</div>
           <div v-for="migration in migrations" :key="migration.message">
-            {{ migration.message }}
+            {{ migration.message.replaceAll(" | ", "\n  ") }}
           </div>
-        </div>
-      </Stack>
-      <Stack
-        v-if="alreadyMigrated.length > 0"
-        class="flex flex-row gap-xs p-xs w-full"
-      >
-        <div class="text-lg">
-          Already Migrated Connections: {{ alreadyMigrated.length }}
-        </div>
-        <div v-for="migration of alreadyMigrated" :key="migration.message">
-          {{ migration.message }}
         </div>
       </Stack>
     </Stack>
@@ -90,19 +80,12 @@ const migrationsByIssue = computed(
     >,
 );
 const migrateable = computed(() => migrationsByIssue.value.migrateable ?? []);
-const alreadyMigrated = computed(
-  () => migrationsByIssue.value.destinationPropAlreadyHasValue ?? [],
-);
 const unmigrateableBecause = computed(() =>
   _.sortBy(
     Object.entries(migrationsByIssue.value),
     ([_, migrations]) => migrations.length,
   )
     .reverse()
-    .filter(
-      ([because, _]) =>
-        because !== "migrateable" &&
-        because !== "destinationPropAlreadyHasValue",
-    ),
+    .filter(([because, _]) => because !== "migrateable"),
 );
 </script>

--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -356,7 +356,6 @@ export interface ConnectionMigrationPropConnection {
 export type ConnectionUnmigrateableBecause =
   | { type: "connectionPrototypeHasMultipleArgs" }
   | { type: "destinationIsNotInputSocket" }
-  | { type: "destinationPropAlreadyHasValue" }
   | { type: "destinationSocketArgumentNotBoundToProp" }
   | { type: "destinationSocketBoundToPropWithNoValue"; destPropId: PropId }
   | { type: "destinationSocketHasMultipleBindings" }

--- a/lib/dal/src/attribute/prototype/argument/static_value.rs
+++ b/lib/dal/src/attribute/prototype/argument/static_value.rs
@@ -92,4 +92,18 @@ impl StaticArgumentValue {
 
         Ok(StaticArgumentValue::assemble(id, inner))
     }
+
+    /// Get the value, formatted for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, id: StaticArgumentValueId) -> String {
+        Self::fmt_title_fallible(ctx, id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+
+    async fn fmt_title_fallible(
+        ctx: &DalContext,
+        id: StaticArgumentValueId,
+    ) -> AttributePrototypeArgumentResult<String> {
+        Ok(format!("{}", Self::get_by_id(ctx, id).await?.value))
+    }
 }

--- a/lib/dal/src/attribute/value/subscription.rs
+++ b/lib/dal/src/attribute/value/subscription.rs
@@ -5,6 +5,7 @@ use super::{
     AttributeValueResult,
 };
 use crate::{
+    Component,
     DalContext,
     attribute::path::AttributePath,
 };
@@ -32,5 +33,31 @@ impl ValueSubscription {
     pub async fn validate(&self, ctx: &DalContext) -> AttributeValueResult<()> {
         let prop_id = AttributeValue::prop_id(ctx, self.attribute_value_id).await?;
         self.path.validate(ctx, prop_id).await
+    }
+
+    /// Get the value, formatted for debugging/display.
+    pub async fn fmt_title(&self, ctx: &DalContext) -> String {
+        self.fmt_title_fallible(ctx)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+    pub async fn fmt_title_fallible(&self, ctx: &DalContext) -> AttributeValueResult<String> {
+        // If the subscription somehow isn't to a root attribute value, make it so.
+        let (root_id, child_path) =
+            AttributeValue::path_from_root(ctx, self.attribute_value_id).await?;
+        let component_id = AttributeValue::component_id(ctx, root_id).await?;
+        if root_id != self.attribute_value_id {
+            return Ok(format!(
+                "subscription to {} on (child AV {} on {})",
+                self.path,
+                child_path,
+                Component::fmt_title(ctx, component_id).await,
+            ));
+        }
+        Ok(format!(
+            "subscription to {} on {}",
+            self.path,
+            Component::fmt_title(ctx, component_id).await,
+        ))
     }
 }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -4646,6 +4646,27 @@ impl Component {
         self.into_frontend_type(ctx, Some(&geometry), change_status, diagram_sockets)
             .await
     }
+
+    /// Get a short, human-readable title suitable for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, component_id: ComponentId) -> String {
+        Self::fmt_title_fallible(ctx, component_id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+
+    async fn fmt_title_fallible(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<String> {
+        let schema_variant_id = Self::schema_variant_id(ctx, component_id).await?;
+
+        Ok(format!(
+            "{} {} ({})",
+            SchemaVariant::fmt_title(ctx, schema_variant_id).await,
+            Self::name_by_id(ctx, component_id).await?,
+            component_id
+        ))
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -857,6 +857,16 @@ impl Func {
         .join("\n");
         Ok(types)
     }
+
+    /// Get a short, human-readable title suitable for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, id: FuncId) -> String {
+        Self::fmt_title_fallible(ctx, id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+    async fn fmt_title_fallible(ctx: &DalContext, id: FuncId) -> FuncResult<String> {
+        Ok(Self::node_weight(ctx, id).await?.name)
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, Eq, PartialEq)]

--- a/lib/dal/src/func/intrinsics.rs
+++ b/lib/dal/src/func/intrinsics.rs
@@ -16,9 +16,12 @@ use strum::{
     IntoEnumIterator,
 };
 
-use crate::func::{
-    FuncError,
-    FuncResult,
+use crate::{
+    PropKind,
+    func::{
+        FuncError,
+        FuncResult,
+    },
 };
 
 #[remain::sorted]
@@ -58,6 +61,25 @@ impl IntrinsicFunc {
             | IntrinsicFunc::ResourcePayloadToValue
             | IntrinsicFunc::Validation => true,
         }
+    }
+
+    /// If this is a si:setXXX, returns the PropKind it is a setter for.
+    pub fn set_func(&self) -> Option<PropKind> {
+        Some(match self {
+            IntrinsicFunc::SetArray => PropKind::Array,
+            IntrinsicFunc::SetBoolean => PropKind::Boolean,
+            IntrinsicFunc::SetInteger => PropKind::Integer,
+            IntrinsicFunc::SetFloat => PropKind::Float,
+            IntrinsicFunc::SetJson => PropKind::Json,
+            IntrinsicFunc::SetMap => PropKind::Map,
+            IntrinsicFunc::SetObject => PropKind::Object,
+            IntrinsicFunc::SetString => PropKind::String,
+            IntrinsicFunc::Identity
+            | IntrinsicFunc::NormalizeToArray
+            | IntrinsicFunc::ResourcePayloadToValue
+            | IntrinsicFunc::Validation
+            | IntrinsicFunc::Unset => return None,
+        })
     }
 
     pub fn pkg_spec() -> FuncResult<PkgSpec> {

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -1233,6 +1233,17 @@ impl Prop {
     pub async fn ts_type(ctx: &DalContext, prop_id: PropId) -> PropResult<String> {
         ctx.workspace_snapshot()?.ts_type(prop_id).await
     }
+
+    /// Get the value, formatted for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, prop_id: PropId) -> String {
+        Self::fmt_title_fallible(ctx, prop_id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+
+    async fn fmt_title_fallible(ctx: &DalContext, prop_id: PropId) -> PropResult<String> {
+        Ok(Self::get_by_id(ctx, prop_id).await?.name)
+    }
 }
 
 impl From<AttributePrototypeError> for PropError {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -2516,6 +2516,20 @@ impl SchemaVariant {
 
         Ok(schema_variants.into_values().collect())
     }
+
+    /// Get a short, human-readable title suitable for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, id: SchemaVariantId) -> String {
+        Self::fmt_title_fallible(ctx, id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+    pub async fn fmt_title_fallible(
+        ctx: &DalContext,
+        id: SchemaVariantId,
+    ) -> SchemaVariantResult<String> {
+        let variant = Self::get_by_id(ctx, id).await?;
+        Ok(variant.display_name.to_string())
+    }
 }
 
 impl From<AttributePrototypeArgumentError> for SchemaVariantError {

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -845,6 +845,21 @@ impl Secret {
 
         Ok(Self::assemble(secret_node_weight, updated))
     }
+
+    /// Get the value, formatted for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, secret_id: SecretId) -> String {
+        Self::fmt_title_fallible(ctx, secret_id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+
+    async fn fmt_title_fallible(ctx: &DalContext, secret_id: SecretId) -> SecretResult<String> {
+        Ok(format!(
+            "{} ({})",
+            Self::get_by_id(ctx, secret_id).await?.name,
+            secret_id
+        ))
+    }
 }
 
 /// The [`EncryptedSecret`] corresponding to an individual [`Secret`]. It contains sensitive, but

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -360,6 +360,18 @@ impl InputSocket {
                 .id,
         )
     }
+
+    /// Get a short, human-readable title suitable for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, id: InputSocketId) -> String {
+        Self::fmt_title_fallible(ctx, id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+
+    async fn fmt_title_fallible(ctx: &DalContext, id: InputSocketId) -> InputSocketResult<String> {
+        let socket = Self::get_by_id(ctx, id).await?;
+        Ok(socket.name)
+    }
 }
 
 impl From<InputSocket> for frontend_types::InputSocket {

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -564,6 +564,20 @@ impl OutputSocket {
                 .id,
         )
     }
+
+    /// Get a short, human-readable title suitable for debugging/display.
+    pub async fn fmt_title(ctx: &DalContext, id: OutputSocketId) -> String {
+        Self::fmt_title_fallible(ctx, id)
+            .await
+            .unwrap_or_else(|e| e.to_string())
+    }
+    async fn fmt_title_fallible(
+        ctx: &DalContext,
+        id: OutputSocketId,
+    ) -> OutputSocketResult<String> {
+        let socket = Self::get_by_id(ctx, id).await?;
+        Ok(socket.name)
+    }
 }
 
 impl From<OutputSocket> for frontend_types::OutputSocket {

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1454,13 +1454,10 @@ impl WorkspaceSnapshot {
     pub async fn connection_migrations(
         &self,
         inferred_connections: impl IntoIterator<Item = SocketConnection>,
-    ) -> WorkspaceSnapshotResult<Vec<(graph::validator::connections::ConnectionMigration, String)>>
-    {
-        Ok(
-            graph::validator::connections::connection_migrations_with_text(
-                &self.working_copy().await,
-                inferred_connections,
-            ),
-        )
+    ) -> WorkspaceSnapshotResult<Vec<graph::validator::connections::ConnectionMigration>> {
+        Ok(graph::validator::connections::connection_migrations(
+            &self.working_copy().await,
+            inferred_connections,
+        ))
     }
 }

--- a/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/func_node_weight.rs
@@ -31,8 +31,8 @@ pub struct FuncNodeWeight {
     pub lineage_id: LineageId,
     content_address: ContentAddress,
     merkle_tree_hash: MerkleTreeHash,
-    name: String,
-    func_kind: FuncKind,
+    pub name: String,
+    pub func_kind: FuncKind,
 }
 
 impl FuncNodeWeight {

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -130,7 +130,7 @@ pub enum FsError {
     #[error("attribute input bound to neither input socket nor prop")]
     AttributeInputNotBound,
     #[error("attribute prototype argument error: {0}")]
-    AttributePrototypeArgument(#[from] AttributePrototypeArgumentError),
+    AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("no attribute protototype argument found for func argument {0}")]
     AttributePrototypeArgumentMissingForFuncArg(FuncArgumentId),
     #[error("cached module error: {0}")]
@@ -199,6 +199,11 @@ pub enum FsError {
 
 impl From<FuncAPIError> for FsError {
     fn from(value: FuncAPIError) -> Self {
+        Box::new(value).into()
+    }
+}
+impl From<AttributePrototypeArgumentError> for FsError {
+    fn from(value: AttributePrototypeArgumentError) -> Self {
         Box::new(value).into()
     }
 }


### PR DESCRIPTION
Right now, the migration output is messy for several reasons:

1. It forever shows all inferred connections, even if they are already set up as prop <-> prop subscriptions.
2. It leaves socket connections around if the corresponding prop already has a value (and forever shows them as "already migrated")
3. The actual output doesn't show socket names, making it hard to figure out what's going on
4. The output shows each socket connection and prop connection all on one bigass line, making it hard to see what is converting to what

## How the system changes

* Migration removes socket connections even if all the corresponding props have values (since the socket connection cannot have any affect
* If there is nothing to do (i.e. already-migrated inferred socket connections), it does not report 
* Output includes human-readable names and is split into multiple lines for readability

To reduce the chance this will break something, it minimizes changes to the actual migration plan: the inferred/explicit socket connection list, and suggested prop connections, remain exactly the same, *except* now we don't report an issue if the prop already has a value.
 
#### Screenshots:

<img width="1441" height="132" alt="image" src="https://github.com/user-attachments/assets/d56d3860-76a9-49e0-a2da-5fdb692d6fde" />

## How was it tested?

- [X] Manual test: make sure dry run is still dry run, migration still migrates
- [X] Manual test: explicit connections still migrate, and then don't show up in subsequent runs
- [X] Manual test: inferred connections still migrate, and then don't show up in subsequent runs
- [X] Manual test: actual errors don't migrate, and continue to show up, but everything else still migrates

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDc3cHdkanZmeXV4ajd0aGR5b3c3MzEyeGVyeDcwd2FzbjBvaXY4NyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/o7lhOIWax9hQs/giphy.gif)
