### PR TITLE
fix: migration: show unmigrateable connections first

### DIFF
--- a/app/web/src/components/AdminDashboard/MigrateConnections.vue
+++ b/app/web/src/components/AdminDashboard/MigrateConnections.vue
@@ -16,15 +16,6 @@
 
     <!-- Show migrations -->
     <Stack class="flex flex-col gap-xs p-xs w-full font-bold text-xs">
-      <Stack>
-        <div class="text-lg">
-          {{ migrationRun?.dryRun ? "Migrateable" : "Migrated" }} Connections:
-          {{ migrateable.length }}
-        </div>
-        <pre v-for="migration of migrateable" :key="migration.message">{{
-          migration.message.replaceAll(" | ", "\n")
-        }}</pre>
-      </Stack>
       <Stack v-if="unmigrateableBecause.length > 0">
         <div class="text-lg">
           Unmigrateable Connections:
@@ -34,7 +25,7 @@
               .reduce((a, b) => a + b, 0)
           }}
         </div>
-        <div
+        <pre
           v-for="[because, migrations] in unmigrateableBecause"
           :key="because"
         >
@@ -42,7 +33,16 @@
           <div v-for="migration in migrations" :key="migration.message">
             {{ migration.message.replaceAll(" | ", "\n  ") }}
           </div>
+        </pre>
+      </Stack>
+      <Stack>
+        <div class="text-lg">
+          {{ migrationRun?.dryRun ? "Migrateable" : "Migrated" }} Connections:
+          {{ migrateable.length }}
         </div>
+        <pre v-for="migration of migrateable" :key="migration.message">{{
+          migration.message.replaceAll(" | ", "\n")
+        }}</pre>
       </Stack>
     </Stack>
   </Stack>


### PR DESCRIPTION
Unmigrateable connections are the more interesting information, and are also not showing in `<pre>`(so they look line one line instead of multiple).

## How was it tested?

- [X] Manual test: migration errors still show