### PR TITLE
fix: Maintain attribute order in templates and PUT /attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ dependencies = [
  "ringmap",
  "serde",
  "serde-aux",
+ "serde-tuple-vec-map",
  "serde_json",
  "serde_with",
  "shuttle-server",
@@ -8082,6 +8083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-tuple-vec-map"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8539,6 +8549,7 @@ name = "si-generate-template"
 version = "0.1.0"
 dependencies = [
  "askama",
+ "pretty_assertions_sorted",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,9 +241,10 @@ rustls-pemfile = { version = "2.2.0" }
 sea-orm = { version = "1.1.2", features = ["debug-print", "macros", "runtime-tokio-rustls", "sqlx-postgres", "with-chrono"] }
 serde = { version = "1.0.216", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
+serde-tuple-vec-map = "1.0.1"
 serde_json = { version = "1.0.133", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
-serde_with = "3.11.0"
+serde_with = "3.14.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sodiumoxide = "0.2.7"
 spicedb-client = { version = "0.1.1", features = ["tls"] }

--- a/lib/dal/BUCK
+++ b/lib/dal/BUCK
@@ -71,6 +71,7 @@ rust_library(
         "//third-party/rust:ringmap",
         "//third-party/rust:serde",
         "//third-party/rust:serde-aux",
+        "//third-party/rust:serde-tuple-vec-map",
         "//third-party/rust:serde_json",
         "//third-party/rust:serde_with",
         "//third-party/rust:sodiumoxide",

--- a/lib/dal/Cargo.toml
+++ b/lib/dal/Cargo.toml
@@ -53,6 +53,7 @@ remain = { workspace = true }
 ringmap = { workspace = true }
 serde = { workspace = true }
 serde-aux = { workspace = true }
+serde-tuple-vec-map = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 shuttle-server = { path = "../../lib/shuttle-server" }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -1461,26 +1461,44 @@ impl Component {
         Ok(input_socket_ids)
     }
 
-    pub async fn subscription_sources(
-        ctx: &DalContext,
-        component_id: ComponentId,
-    ) -> ComponentResult<HashMap<AttributeValueIdent, Source>> {
-        let mut sources = Self::sources(ctx, component_id).await?;
-        sources.retain(|_, source| matches!(source, Source::Subscription { .. }));
-        Ok(sources)
-    }
-
+    /// Produce sources for every attribute that has them.
+    ///
+    /// - These are returned in the order they were defined / show up in the UI.
+    /// - If an AV is returned, its children will not be.
+    /// - Subscriptions and actual scalar values are returned.
+    ///
     pub async fn sources(
         ctx: &DalContext,
         component_id: ComponentId,
-    ) -> ComponentResult<HashMap<AttributeValueIdent, Source>> {
-        let mut sources = HashMap::new();
-        for (dest_av_id, _) in AttributeValue::tree_for_component(ctx, component_id).await? {
-            if let Some(source) = Self::attr_to_source(ctx, dest_av_id).await? {
-                let (_, dest_path) = AttributeValue::path_from_root(ctx, dest_av_id).await?;
-                sources.insert(dest_path.into(), source);
+    ) -> ComponentResult<Vec<(AttributeValueIdent, Source)>> {
+        let mut sources = vec![];
+        // Get the root attribute value and load it into the work queue.
+        let root_attribute_value_id = Component::root_attribute_value_id(ctx, component_id).await?;
+
+        let mut work_queue = Vec::from([root_attribute_value_id]);
+        while let Some(av_id) = work_queue.pop() {
+            // If this attribute value has a source, don't recurse into it.
+            if let Some(source) = Self::attr_to_source(ctx, av_id).await? {
+                let (_, dest_path) = AttributeValue::path_from_root(ctx, av_id).await?;
+                sources.push((dest_path.into(), source));
+            } else {
+                // Otherwise, push its children so we find their sources as well.
+                let children = AttributeValue::get_child_av_ids_in_order(ctx, av_id).await?;
+
+                // Load the children onto the end of the work queue, in reverse order, so that
+                // they will be processed first with pop().
+                work_queue.extend(children.into_iter().rev());
             }
         }
+        Ok(sources)
+    }
+
+    pub async fn subscription_sources(
+        ctx: &DalContext,
+        component_id: ComponentId,
+    ) -> ComponentResult<Vec<(AttributeValueIdent, Source)>> {
+        let mut sources = Self::sources(ctx, component_id).await?;
+        sources.retain(|(_, source)| matches!(source, Source::Subscription { .. }));
         Ok(sources)
     }
 

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -57,10 +57,7 @@ use crate::{
         },
     },
     attribute::{
-        attributes::{
-            AttributeValueIdent,
-            ValueOrSourceSpec,
-        },
+        attributes::AttributeSources,
         prototype::argument::{
             AttributePrototypeArgument,
             AttributePrototypeArgumentError,
@@ -277,7 +274,7 @@ pub struct ManagementUpdateConnections {
 #[serde(rename_all = "camelCase")]
 pub struct ManagementUpdateOperation {
     properties: Option<serde_json::Value>,
-    attributes: Option<HashMap<AttributeValueIdent, ValueOrSourceSpec>>,
+    attributes: Option<AttributeSources>,
     geometry: Option<HashMap<String, ManagementGeometry>>,
     connect: Option<ManagementUpdateConnections>,
     parent: Option<String>,
@@ -298,7 +295,7 @@ pub struct ManagementCreateOperation {
     kind: Option<String>,
     properties: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    attributes: Option<HashMap<AttributeValueIdent, ValueOrSourceSpec>>,
+    attributes: Option<AttributeSources>,
     geometry: Option<ManagementCreateGeometry>,
     connect: Option<Vec<ManagementConnection>>,
     parent: Option<String>,

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -381,7 +381,7 @@ impl ManagedComponent {
         Ok(Self {
             kind: kind.to_owned(),
             properties,
-            sources,
+            sources: sources.into_iter().collect(),
             geometry,
             incoming_connections,
         })

--- a/lib/sdf-server/src/service/v2/component/attributes.rs
+++ b/lib/sdf-server/src/service/v2/component/attributes.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use axum::{
     BoxError,
     Json,
@@ -23,8 +21,8 @@ use dal::{
     ComponentId,
     WorkspacePk,
     attribute::attributes::{
+        AttributeSources,
         AttributeValueIdent,
-        ValueOrSourceSpec,
     },
 };
 use sdf_core::{
@@ -71,7 +69,7 @@ async fn update_attributes(
     ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
     tracker: PosthogEventTracker,
     Path(ComponentIdFromPath { component_id }): Path<ComponentIdFromPath>,
-    Json(updates): Json<HashMap<AttributeValueIdent, ValueOrSourceSpec>>,
+    Json(updates): Json<AttributeSources>,
 ) -> Result<ForceChangeSetResponse<()>> {
     let force_change_set_id = ChangeSet::force_new(ctx).await?;
 

--- a/lib/si-generate-template/BUCK
+++ b/lib/si-generate-template/BUCK
@@ -14,6 +14,9 @@ rust_library(
         "askama.toml",
         "templates/**/*.ts",
     ]),
+    test_unit_deps = [
+        "//third-party/rust:pretty_assertions_sorted",
+    ],
     env = {
         "CARGO_MANIFEST_DIR": ".",
     }

--- a/lib/si-generate-template/Cargo.toml
+++ b/lib/si-generate-template/Cargo.toml
@@ -13,3 +13,6 @@ askama = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions_sorted = { workspace = true }

--- a/lib/si-generate-template/templates/run_template_mgmt_func.ts
+++ b/lib/si-generate-template/templates/run_template_mgmt_func.ts
@@ -15,12 +15,12 @@ async function main({
         kind: "{{ component.kind }}",
         attributes: {
             "/si/name": namePrefix + "{{ component.name }}",
-            {%- for attr in component.attributes_pruned_and_sorted() %}
+            {%- for attr in component.attributes %}
             {{ attr.dest_path | json }}:
             {%- match attr.value %}
               {%- when AttributeSource::Value with (val) %} {{ val | json(4) | indent(12) }},
               {%- when AttributeSource::Subscription with (sub) %} {
-                "$source": {
+                $source: {
                     component: {% match sub.variable %}
                     {%- when Some with (var_name) -%}
                       template.getComponentName({{ var_name }}),

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -17223,6 +17223,34 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "serde-tuple-vec-map",
+    actual = ":serde-tuple-vec-map-1.0.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "serde-tuple-vec-map-1.0.1.crate",
+    sha256 = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82",
+    strip_prefix = "serde-tuple-vec-map-1.0.1",
+    urls = ["https://static.crates.io/crates/serde-tuple-vec-map/1.0.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "serde-tuple-vec-map-1.0.1",
+    srcs = [":serde-tuple-vec-map-1.0.1.crate"],
+    crate = "tuple_vec_map",
+    crate_root = "serde-tuple-vec-map-1.0.1.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":serde-1.0.219"],
+)
+
 http_archive(
     name = "serde-value-0.7.0.crate",
     sha256 = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -6397,6 +6397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-tuple-vec-map"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7290,6 +7299,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde-aux",
+ "serde-tuple-vec-map",
  "serde_json",
  "serde_path_to_error",
  "serde_with",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -142,7 +142,7 @@ serde = { version = "1.0.216", features = ["derive", "rc"] }
 serde-aux = "4.5.0"
 serde_json = { version = "1.0.133", features = ["preserve_order"] }
 serde_path_to_error = { version = "0.1.16" }
-serde_with = "3.11.0"
+serde_with = "3.14.0"
 serde_yaml = "0.9.33" # NOTE(nick): this has been archived upstream
 sodiumoxide = "0.2.7"
 spicedb-client = { version = "0.1.1", features = ["tls"] }
@@ -176,6 +176,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json", "st
 tracing-tunnel = "0.1.0"
 trybuild = { version = "1.0.101", features = ["diff"] }
 tryhard = "0.5.1"
+serde-tuple-vec-map = "1.0.1"
 ulid = { version = "1.1.3", features = ["serde"] }
 url = { version = "2.5.4", features = ["serde"] }
 utoipa = { version = "5.3.1", features = ["axum_extras"] }


### PR DESCRIPTION
This makes the template generator output attributes in their original order (schema order + array order) rather than sorting them. On the other side, it honors that order in PUT /attributes. Before, templates would order `/domain/Array/10` before `/domain/Array/2`, which caused the PUT to fail.

<img width="531" height="522" alt="image" src="https://github.com/user-attachments/assets/b5ec34ce-2a43-4906-b002-077fe2860389" />

As a side effect, it also means we can support what the docs say the API does, and do multiple appends:

```PUT /attributes
{
  "/domain/Foo/-": 1,
  "/domain/Foo/-": 2,
  "/domain/Foo/-": 3,
}
```

This PR fixes the problem by serializing and deserializing the list of attribute updates using the `tuple_vec_crate` to preserve ordering and duplicates.

## Out of Scope

It might also be desirable to be *able* to handle attributes no matter what order they are specified in the template.

## How was it tested?

- [X] Integration tests pass
- [X] New integration test testing duplicates and ordering
- [X] Manual test: generate template with lots of array items, make sure they show up in the proper order
- [X] Manual test: generate template with subscriptions, make sure they still show up

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcXQ4dzRjdXh0aDNnbm1pa2VlbGtqZml1MGNhcXp4Y2VlaDM5Zmo2bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/zzebuOTbjWeYXPNLon/giphy.gif)
