### PR TITLE
fix(web): Ensuring consistent page header layouts

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -353,7 +353,7 @@
         >
           <TextPill
             v-tooltip="componentCountTooltip"
-            class="flex-none rounded p-xs"
+            class="flex-none rounded p-xs text-sm"
             variant="key2"
           >
             Total: {{ componentList.length }}
@@ -363,7 +363,7 @@
             v-tooltip="resourceCountTooltip"
             :class="
               clsx(
-                'flex-none flex flex-row items-center gap-2xs rounded p-xs',
+                'flex-none flex flex-row items-center gap-2xs rounded p-xs text-sm',
                 themeClasses(
                   'border-success-400 bg-success-100 text-black',
                   'border-success-800 bg-success-900 text-white',

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -1,7 +1,12 @@
 <template>
   <div
     v-if="row.type === 'header'"
-    class="flex flex-row items-center bg-neutral-900 px-xs gap-xs"
+    :class="
+      clsx(
+        'flex flex-row items-center gap-xs px-xs',
+        themeClasses('bg-neutral-200', 'bg-neutral-800'),
+      )
+    "
     @click="emit('clickCollapse', row.title, !row.collapsed)"
   >
     <Icon :name="row.collapsed ? 'chevron--right' : 'chevron--down'" />
@@ -75,7 +80,8 @@
     :class="
       clsx(
         'flex flex-row items-start gap-sm',
-        row.insideSection && 'bg-neutral-900 px-xs',
+        row.insideSection && 'px-xs',
+        row.insideSection && themeClasses('bg-neutral-200', 'bg-neutral-800'),
       )
     "
   >
@@ -127,12 +133,27 @@
   </div>
   <div
     v-else-if="row.type === 'emptyRow'"
-    class="flex items-center justify-center bg-neutral-900 pb-xs px-xs"
+    class="flex items-center justify-center pb-xs px-xs"
   >
     <div
-      class="flex flex-col items-center justify-center gap-md bg-neutral-800 border border-neutral-600 grow h-full"
+      :class="
+        clsx(
+          'flex flex-col items-center justify-center gap-md grow h-full',
+          themeClasses(
+            'bg-neutral-100 border border-neutral-400',
+            'bg-neutral-800 border border-neutral-600',
+          ),
+        )
+      "
     >
-      <div class="bg-neutral-700 p-sm rounded-full">
+      <div
+        :class="
+          clsx(
+            'p-sm rounded-full',
+            themeClasses('bg-neutral-300', 'bg-neutral-700'),
+          )
+        "
+      >
         <Icon name="check-circle-outline" />
       </div>
       <span>

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -21,7 +21,7 @@
         clsx(
           h3class,
           'group/header',
-          'cursor-pointer text-lg font-bold flex-none h-lg',
+          'cursor-pointer text-lg font-bold flex-none h-lg flex items-center px-xs m-0',
           openState.open.value && 'border-b',
           themeClasses(
             'bg-white border-neutral-300 hover:bg-neutral-100',

--- a/app/web/src/newhotness/layout_components/ErrorBanner.vue
+++ b/app/web/src/newhotness/layout_components/ErrorBanner.vue
@@ -20,7 +20,7 @@
       "
     >
       <Icon name="x-circle" size="xs" />
-      <span>{{ text }}</span>
+      <span class="text-sm">{{ text }}</span>
 
       <!-- Slot for anything, but mainly a button for toggling the subtitle -->
       <div class="ml-auto">

--- a/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
@@ -11,17 +11,23 @@
     "
   >
     <header
-      class="flex flex-row items-center px-sm py-xs border-b border-neutral-700"
+      :class="
+        clsx(
+          'flex flex-row items-center px-sm py-xs border-t border-b border-neutral-600',
+          themeClasses('bg-neutral-200', 'bg-neutral-800'),
+        )
+      "
     >
-      <!-- Back button (smaller with no border) -->
-      <button
-        tabindex="-1"
-        class="text-neutral-400 hover:text-white mr-xs flex flex-row items-center justify-center"
-        aria-label="Back to actions list"
+      <IconButton
+        tooltip="Close (Esc)"
+        tooltipPlacement="top"
+        class="border-0 mr-2em"
+        icon="x"
+        size="sm"
+        iconIdleTone="shade"
+        iconTone="shade"
         @click="navigateBack"
-      >
-        <Icon name="arrow--left" size="sm" />
-      </button>
+      />
 
       <!-- Function info -->
       <div class="flex-1 flex flex-row items-center gap-xs">
@@ -36,7 +42,12 @@
         <!-- add a bit more "gap" to the first (dt) element, so the pairs have more space between them -->
         <!-- negative bottom margin to pull it down so all items are visually aligned -->
         <dl
-          class="text-sm text-neutral-400 flex flex-row items-center gap-2xs [&>dt]:ml-2xs mb-[-0.25em]"
+          :class="
+            clsx(
+              'text-sm flex flex-row items-center gap-2xs [&>dt]:ml-2xs mb-[-0.25em]',
+              themeClasses('text-neutral-600', 'text-neutral-400'),
+            )
+          "
         >
           <template v-if="funcRun?.functionKind">
             <dt><Icon name="func" size="xs" /></dt>
@@ -44,7 +55,7 @@
           </template>
 
           <template v-if="funcRun?.componentName">
-            <dt><Icon name="component" size="xs" /></dt>
+            <dt></dt>
             <dd>{{ funcRun.componentName }}</dd>
           </template>
 
@@ -63,10 +74,15 @@
     </header>
 
     <!-- Error banner for hinting -->
-    <ErrorBanner v-if="errorHint" class="mx-xs" :text="errorHint" />
+    <ErrorBanner v-if="errorHint" class="mx-xs mt-sm mb-xs" :text="errorHint" />
 
     <div
-      class="grid grid-cols-[1fr_1fr] grid-rows-[1fr_1fr_1fr] gap-xs p-xs h-full overflow-hidden"
+      :class="
+        clsx(
+          'grid grid-cols-[1fr_1fr] grid-rows-[1fr_1fr_1fr] gap-xs p-xs h-full overflow-hidden',
+          !errorHint && 'pt-xs',
+        )
+      "
     >
       <GridItemWithLiveHeader
         class="row-span-3"
@@ -126,7 +142,7 @@
 
 <script lang="ts" setup>
 import { computed, ref, watch } from "vue";
-import { Icon, themeClasses } from "@si/vue-lib/design-system";
+import { Icon, themeClasses, IconButton } from "@si/vue-lib/design-system";
 import { useRoute, useRouter } from "vue-router";
 import clsx from "clsx";
 import CodeViewer from "@/components/CodeViewer.vue";

--- a/app/web/src/newhotness/layout_components/GridItemWithLiveHeader.vue
+++ b/app/web/src/newhotness/layout_components/GridItemWithLiveHeader.vue
@@ -4,8 +4,8 @@
       clsx(
         'flex flex-col rounded overflow-hidden border',
         themeClasses(
-          'bg-shade-0 border-neutral-300',
-          'bg-neutral-800 border-transparent',
+          'bg-neutral-200 border-neutral-300',
+          'bg-neutral-800 border-neutral-600',
         ),
       )
     "
@@ -21,7 +21,14 @@
         Live
       </div>
     </div>
-    <div class="overflow-auto flex-1 text-sm">
+    <div
+      :class="
+        clsx(
+          'overflow-auto flex-1 text-sm',
+          themeClasses('bg-white', 'bg-[#0d1117]'),
+        )
+      "
+    >
       <slot></slot>
     </div>
   </div>

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
@@ -6,7 +6,9 @@
         'flex flex-row items-center p-2xs mb-[-1px] h-7',
         'font-mono text-[13px] text-left truncate relative',
         !noBorder && 'border',
-        highlightWhenModelValue && modelValueLabel && 'bg-action-900',
+        highlightWhenModelValue &&
+          modelValueLabel &&
+          themeClasses('bg-action-200', 'bg-action-900'),
         variant === 'navbar' && 'flex-1 font-bold min-w-[80px] max-w-fit',
         disabled
           ? [
@@ -54,7 +56,9 @@
           isFocus
             ? themeClasses('text-action-500', 'text-action-300')
             : themeClasses('text-neutral-400', 'text-neutral-600'),
-          highlightWhenModelValue && modelValueLabel && 'text-neutral-200',
+          highlightWhenModelValue &&
+            modelValueLabel &&
+            themeClasses('text-neutral-600', 'text-neutral-200'),
         )
       "
       name="chevron--down"


### PR DESCRIPTION
Component Details page needs it’s header to stretch and have the banners
below it

FuncRunDetailsLayout is the same