### PR TITLE
Use new func run status badge icons

### DIFF
--- a/app/web/src/newhotness/FuncRunStatusBadge.vue
+++ b/app/web/src/newhotness/FuncRunStatusBadge.vue
@@ -1,78 +1,59 @@
 <template>
   <div
-    v-if="computedStatus"
-    class="flex items-center rounded-sm px-1.5 py-0.5"
-    :class="computedClasses"
+    :class="
+      clsx(
+        'flex flex-row gap-2xs items-center border rounded-sm px-2xs py-3xs',
+        themeClasses(
+          'text-neutral-800 bg-neutral-50',
+          'text-neutral-100 bg-neutral-900',
+        ),
+        status === 'Success' &&
+          themeClasses('border-success-500', 'border-success-800'),
+        status === 'Failure' &&
+          themeClasses('border-destructive-500', 'border-destructive-600'),
+        (status === 'Running' || status === 'Unknown') && 'border-neutral-600',
+      )
+    "
   >
-    <StatusIndicatorIcon
-      :status="computedStatus"
-      type="management"
-      :size="size"
-      class="mr-1.5"
+    <Icon
+      size="2xs"
+      :name="iconName"
+      :class="
+        clsx(
+          status === 'Success' && 'text-success-400',
+          status === 'Failure' && 'text-destructive-400',
+        )
+      "
     />
-    <span class="text-xs font-medium">{{ computedStatus }}</span>
+    <span class="text-xs">{{ status }}</span>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { IconSizes, themeClasses } from "@si/vue-lib/design-system";
+import { Icon, themeClasses } from "@si/vue-lib/design-system";
 import { computed } from "vue";
 import clsx from "clsx";
-import { tw } from "@si/vue-lib";
-import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { FuncRunState } from "@/store/func_runs.store";
 
-const props = withDefaults(
-  defineProps<{
-    status: string | FuncRunState | null | undefined;
-    type?: string;
-    size?: IconSizes;
-  }>(),
-  {
-    type: "management",
-    size: "xs",
-  },
-);
+const props = defineProps<{
+  status: string | FuncRunState | null | undefined;
+}>();
 
-// Make sure we have a valid status value
-const computedStatus = computed<string | null>(() => {
-  if (!props.status) return null;
+type Status = "Success" | "Failure" | "Running" | "Unknown";
 
-  // Return the status string if it's valid
-  return props.status;
+const status = computed<Status>(() => {
+  if (props.status === "Success") return "Success";
+  if (props.status === "Failure" || props.status === "ActionFailure")
+    return "Failure";
+  if (props.status === "Running" || props.status === "Postprocessing")
+    return "Running";
+  return "Unknown";
 });
 
-const computedClasses = computed(() => {
-  const status = computedStatus.value ?? "";
-
-  return clsx(
-    "border",
-    (status === "Failure" || status === "ActionFailure") &&
-      themeClasses(
-        tw`bg-destructive-200 border-destructive-400 text-destructive-700`,
-        tw`bg-destructive-900 border-destructive-700 text-destructive-400`,
-      ),
-    status === "Success" &&
-      themeClasses(
-        tw`bg-success-200 border-success-400 text-success-700`,
-        tw`bg-success-900 border-success-700 text-success-400`,
-      ),
-    (status === "Running" || status === "Postprocessing") &&
-      themeClasses(
-        tw`bg-action-200 border-action-400 text-action-700`,
-        tw`bg-action-900 border-action-700 text-action-400`,
-      ),
-    ![
-      "Failure",
-      "Success",
-      "Running",
-      "Postprocessing",
-      "ActionFailure",
-    ].includes(status) &&
-      themeClasses(
-        tw`bg-neutral-200 border-neutral-400 text-neutral-700`,
-        tw`bg-neutral-900 border-neutral-700 text-neutral-400`,
-      ),
-  );
+const iconName = computed(() => {
+  if (status.value === "Success") return "circle-full";
+  if (status.value === "Failure") return "triangle";
+  if (status.value === "Running") return "loader";
+  return "question-circle";
 });
 </script>

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -120,6 +120,7 @@ import MaterialSymbolsShiftLockOutline from "~icons/material-symbols/shift-lock-
 import MaterialSymbolsAddLink from "~icons/material-symbols/add-link";
 import MaterialSymbolsLink from "~icons/material-symbols/link";
 import Map from "~icons/heroicons/map";
+import MdiTriangle from "~icons/mdi/triangle";
 
 import TdesignLinkUnlink from "~icons/tdesign/link-unlink";
 import PhTestTubeFill from "~icons/ph/test-tube-fill";
@@ -407,6 +408,7 @@ export const ICONS = Object.freeze({
   trash: Trash,
   "trash-restore": TrashRestore,
   "tree-parents": TreeParents,
+  triangle: MdiTriangle,
   unlink: TdesignLinkUnlink,
   "user-circle": UserCircle,
   x: X,


### PR DESCRIPTION
## Description

This change introduces new func run status icons based on our polished designs. This reduces reliance on an old component and solely uses the Icon component with simpler logic.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzUzdHc4NG1zOWZxdjM5b2JzYmJicnViZ3RxZ3poeGFtaXo4M2dhciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/LmZmWJk6GtN9FSZpOv/giphy.gif"/>

## Screenshot: Dark Theme (all shown)

<img width="1806" height="92" alt="image" src="https://github.com/user-attachments/assets/f03f91ab-faa0-4e67-acb9-d850494d26a3" />

## Screenshot: Light Theme (all shown)

<img width="1828" height="112" alt="image" src="https://github.com/user-attachments/assets/402ebedd-ebdd-44cd-9cbe-59665dc60afd" />
