### PR TITLE
Move description next to management func name

### DIFF
--- a/app/web/src/newhotness/ManagementFuncCard.vue
+++ b/app/web/src/newhotness/ManagementFuncCard.vue
@@ -9,9 +9,7 @@
     <StatusBox
       :kind="statusBoxKind"
       :text="func.name"
-      :subtitle="func.description ?? 'No description provided'"
-      :showSubtitle="showDescription"
-      @click="() => (showDescription = !showDescription)"
+      :description="func.description ?? 'No description provided'"
     >
       <template #right>
         <div class="flex gap-xs">
@@ -117,8 +115,6 @@ const managementExecutionStatus = computed(() => {
   if (dispatchedFunc.value) return "Running";
   return funcRunStatus(props.funcRun, managementFuncJobState.value?.state);
 });
-
-const showDescription = ref<boolean>(false);
 
 const statusBoxKind = computed(() => {
   if (managementExecutionStatus.value === "Running") return "loading";

--- a/app/web/src/newhotness/layout_components/StatusBox.vue
+++ b/app/web/src/newhotness/layout_components/StatusBox.vue
@@ -25,10 +25,25 @@
       <Icon
         v-if="iconName"
         :name="iconName"
-        :class="kind === 'success' && 'text-success-200'"
+        :class="
+          clsx(
+            kind === 'success' &&
+              themeClasses('text-success-500', 'text-success-200'),
+          )
+        "
         size="xs"
       />
-      <span class="text-sm">{{ text }}</span>
+
+      <TruncateWithTooltip class="text-sm">
+        {{ text }}
+      </TruncateWithTooltip>
+
+      <TruncateWithTooltip
+        v-if="description"
+        class="text-sm italic text-neutral-500"
+      >
+        {{ description }}
+      </TruncateWithTooltip>
 
       <!-- Slot for anything, but mainly for button(s) (do things like toggle the subtitle) -->
       <div class="ml-auto">
@@ -52,13 +67,18 @@
 </template>
 
 <script lang="ts" setup>
-import { Icon, themeClasses } from "@si/vue-lib/design-system";
+import {
+  Icon,
+  themeClasses,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed } from "vue";
 
 const props = defineProps<{
   kind: "loading" | "error" | "neutral" | "success";
   text: string;
+  description?: string;
   subtitle?: string;
   showSubtitle?: boolean;
 }>();


### PR DESCRIPTION
## Description

This change moves the description right next to the management func name, which makes it visible without having to click it. This functionality is available for all StatusBox users, including new truncation support.

In addition to these changes, the func card now is light-theme compatible.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMDF5b2g5NmNkcHRkNHBlYmswdHBnNnliOXNsOWNrOXBscDdqeXVvNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SfzHzeAQte2sl2RfK2/giphy.gif"/>

## Screenshot: New Description

<img width="903" height="262" alt="Screenshot 2025-07-25 at 6 46 55 PM" src="https://github.com/user-attachments/assets/61d6ff03-8fee-46e1-96f1-bfbfbf283212" />

## Screenshot: Truncation

<img width="1808" height="504" alt="image" src="https://github.com/user-attachments/assets/fdc1c283-9c18-47ff-bc4c-7119e53060a3" />

## Screenshot: Light Theme Fixes

<img width="922" height="285" alt="Screenshot 2025-07-25 at 6 48 43 PM" src="https://github.com/user-attachments/assets/0b7d4194-95c5-4eaf-88cb-ee4e774213f2" />
