### PR TITLE
feat(luminork): Unify the attributes API in luminork create / update and get component requests

### DIFF
--- a/lib/dal/src/attribute/attributes.rs
+++ b/lib/dal/src/attribute/attributes.rs
@@ -340,8 +340,14 @@ pub struct AttributeSources(
     #[serde(with = "tuple_vec_map")] pub Vec<(AttributeValueIdent, ValueOrSourceSpec)>,
 );
 
+impl AttributeSources {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 /// The source for a value
-#[derive(Serialize, Deserialize, Clone, Debug, derive_more::From)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, derive_more::From)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum Source {
     // { value: <value> } - set value (null is a valid value to set it to)

--- a/lib/luminork-server/src/service/v1/components/get_component.rs
+++ b/lib/luminork-server/src/service/v1/components/get_component.rs
@@ -33,16 +33,32 @@ pub struct GetComponentV1Response {
         "id": "01H9ZQD35JPMBGHH69BT0Q79AA",
         "schemaId": "01H9ZQD35JPMBGHH69BT0Q79VY",
         "schemaVariantId": "01H9ZQD35JPMBGHH69BT0Q79VZ",
-        "sockets": [{"id": "socket1", "name": "input", "direction": "input", "arity": "one", "value": null}],
-        "domainProps": [{"id": "01HAXYZF3GC9CYA6ZVSM3E4YAA", "propId": "01HAXYZF3GC9CYA6ZVSM3E4YBB", "value": "my-value", "path": "domain/path"}],
-        "resourceProps": [{"id": "01HAXYZF3GC9CYA6ZVSM3E4YCC", "propId": "01HAXYZF3GC9CYA6ZVSM3E4YDD", "value": "resource-value", "path": "resource/path"}],
+        "sockets": [],
+        "domainProps": [],
+        "resourceProps": [],
         "name": "My EC2 Instance",
         "resourceId": "i-1234567890abcdef0",
         "toDelete": false,
         "canBeUpgraded": true,
         "connections": [],
-        "views": [{"id": "01HAXYZF3GC9CYA6ZVSM3E4YEE", "name": "Default View", "isDefault": true}],
-        "sources": {"/domain/RouteTableId": {"component": "demo-component","propPath": "/resource_value/RouteTableId"}}
+        "views": [
+            {
+                "id": "01HAXYZF3GC9CYA6ZVSM3E4YEE",
+                "name": "Default View",
+                "isDefault": true
+            }
+        ],
+        "sources": [
+            ["/domain/RouteTableId", {
+                "$source": {
+                    "component": "demo-component",
+                    "path": "/resource_value/RouteTableId"
+                }
+            }],
+            ["/domain/region", {
+                "value": "us-east-1"
+            }]
+        ]
     }))]
     pub component: ComponentViewV1,
     #[schema(example = json!([

--- a/lib/luminork-server/src/service/v1/components/update_component.rs
+++ b/lib/luminork-server/src/service/v1/components/update_component.rs
@@ -9,6 +9,7 @@ use dal::{
     Component,
     Prop,
     WsEvent,
+    attribute::attributes::AttributeSources,
     prop::PropPath,
 };
 use serde::{
@@ -113,43 +114,8 @@ pub async fn update_component(
     let schema_variant = component.schema_variant(ctx).await?;
     let variant_id = schema_variant.id;
 
-    let av_id = component.domain_prop_attribute_value(ctx).await?;
-
-    let before_value = AttributeValue::view(ctx, av_id)
-        .await?
-        .unwrap_or(serde_json::Value::Null);
-
-    for (key, value) in payload.domain.clone().into_iter() {
-        let prop_id = key.prop_id(ctx, variant_id).await?;
-        let attribute_value_id =
-            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
-        let existing_value = AttributeValue::get_by_id(ctx, attribute_value_id)
-            .await?
-            .value(ctx)
-            .await?;
-        AttributeValue::update(ctx, attribute_value_id, Some(value.clone())).await?;
-        if existing_value != value.into() {
-            // If the values have changed then we should enqueue an update action
-            // if the values haven't changed then we can skip this update action as it is usually a no-op
-            Component::enqueue_update_action_if_applicable(ctx, attribute_value_id).await?;
-        }
-    }
-
-    for (key, value) in payload.secrets.clone().into_iter() {
-        let prop_id = key.prop_id(ctx, variant_id).await?;
-
-        let secret_id = resolve_secret_id(ctx, &value).await?;
-
-        let attribute_value_id =
-            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
-        dal::Secret::attach_for_attribute_value(ctx, attribute_value_id, Some(secret_id)).await?;
-    }
-
-    for unset in payload.unset.iter() {
-        let prop_id = unset.prop_id(ctx, variant_id).await?;
-        let attribute_value_id =
-            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
-        AttributeValue::use_default_prototype(ctx, attribute_value_id).await?;
+    if !payload.attributes.is_empty() {
+        dal::update_attributes(ctx, component_id, payload.attributes.clone()).await?;
     }
 
     if let Some(resource_id) = payload.resource_id {
@@ -168,11 +134,41 @@ pub async fn update_component(
         .await?;
     }
 
-    let after_value = AttributeValue::view(ctx, av_id)
-        .await?
-        .unwrap_or(serde_json::Value::Null);
-
     let component_list = Component::list_ids(ctx).await?;
+
+    for (key, value) in payload.secrets.clone().into_iter() {
+        let prop_id = key.prop_id(ctx, variant_id).await?;
+
+        let secret_id = resolve_secret_id(ctx, &value).await?;
+
+        let attribute_value_id =
+            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
+        dal::Secret::attach_for_attribute_value(ctx, attribute_value_id, Some(secret_id)).await?;
+    }
+
+    for (key, value) in payload.domain.clone().into_iter() {
+        let prop_id = key.prop_id(ctx, variant_id).await?;
+        let attribute_value_id =
+            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
+        let existing_value = AttributeValue::get_by_id(ctx, attribute_value_id)
+            .await?
+            .value(ctx)
+            .await?;
+        AttributeValue::update(ctx, attribute_value_id, Some(value.clone())).await?;
+        if existing_value != value.into() {
+            // If the values have changed then we should enqueue an update action
+            // if the values haven't changed then we can skip this update action as it is usually a no-op
+            Component::enqueue_update_action_if_applicable(ctx, attribute_value_id).await?;
+        }
+    }
+
+    for unset in payload.unset.iter() {
+        let prop_id = unset.prop_id(ctx, variant_id).await?;
+        let attribute_value_id =
+            Component::attribute_value_for_prop_id(ctx, component_id, prop_id).await?;
+        AttributeValue::use_default_prototype(ctx, attribute_value_id).await?;
+    }
+
     if !payload.connection_changes.add.is_empty() || !payload.connection_changes.remove.is_empty() {
         for connection in payload.connection_changes.add.iter() {
             handle_connection(
@@ -197,7 +193,7 @@ pub async fn update_component(
             )
             .await?;
         }
-    };
+    }
 
     for (av_to_set, sub) in payload.subscriptions.clone().into_iter() {
         handle_subscription(ctx, av_to_set, &sub, component_id, &component_list).await?;
@@ -218,8 +214,8 @@ pub async fn update_component(
         AuditLogKind::UpdateComponent {
             component_id: updated_component.id(),
             component_name: new_name.clone(),
-            before_domain_tree: Some(before_value),
-            after_domain_tree: Some(after_value),
+            before_domain_tree: None,
+            after_domain_tree: None,
             added_connections: None,
             deleted_connections: None,
             added_secrets: payload.secrets.len(),
@@ -254,28 +250,65 @@ pub struct UpdateComponentV1Request {
     #[schema(example = "MyUpdatedComponentName")]
     pub name: Option<String>,
 
-    #[schema(example = json!({"propId1": "value1", "path/to/prop": "value2"}))]
-    #[serde(default)]
-    pub domain: HashMap<ComponentPropKey, serde_json::Value>,
-
     #[schema(example = "i-12345678")]
     pub resource_id: Option<String>,
 
-    #[schema(example = json!({"secretDefinitionName": "secretId", "secretDefinitionName": "secretName"}))]
     #[serde(default)]
+    #[schema(
+        value_type = std::collections::BTreeMap<String, serde_json::Value>,
+        example = json!({
+            "/domain/VpcId": {
+                "$source": {
+                    "component": "01K0WRC69ZPEMD6SMTKC84FBWC",
+                    "path": "/resource_value/VpcId"
+                }
+            },
+            "/domain/SubnetId": {
+                "$source": {
+                    "component": "01K0WRC69ZPEMD6SMTKC84FBWD",
+                    "path": "/resource_value/SubnetId"
+                }
+            },
+            "/domain/Version": "1.2.3",
+            "/domain/Version": {
+                "$source": null
+            }
+        })
+    )]
+    pub attributes: AttributeSources,
+
+    #[deprecated(
+        note = "Secrets deprecated in favour of using attributes parameter and will be removed in a future version of the API"
+    )]
+    #[schema(example = json!({}))]
     pub secrets: HashMap<SecretPropKey, serde_json::Value>,
 
-    #[schema(value_type = Vec<String>, example = json!(["propId1", "path/to/prop"]))]
+    #[deprecated(
+        note = "Domain deprecated in favour of using attributes parameter and will be removed in a future version of the API"
+    )]
+    #[schema(example = json!({}))]
+    #[serde(default)]
+    pub domain: HashMap<ComponentPropKey, serde_json::Value>,
+
+    #[deprecated(
+        note = "Unset deprecated in favour of using attributes parameter and will be removed in a future version of the API"
+    )]
+    #[schema(example = json!({}))]
     #[serde(default)]
     pub unset: Vec<ComponentPropKey>,
 
-    #[schema(example = json!({}))]
     #[serde(default)]
-    #[deprecated]
+    #[deprecated(
+        note = "Connection changes - socket connections no longer supported and will be removed in a future version of the API"
+    )]
+    #[schema(example = json!({}))]
     pub connection_changes: ConnectionDetails,
 
+    #[deprecated(
+        note = "Subscriptions deprecated in favour of using attributes parameter and will be removed in a future version of the API"
+    )]
+    #[schema(example = json!({}))]
     #[serde(default)]
-    #[schema(example = json!({"/prop/path/on/this/component": {"component": "OtherComponentName", "propPath": "/prop/path/on/other/component", "keepOtherSubscriptions": true}}))]
     pub subscriptions: HashMap<AttributeValueIdent, Subscription>,
 }
 
@@ -300,16 +333,32 @@ pub struct UpdateComponentV1Response {
         "id": "01H9ZQD35JPMBGHH69BT0Q79AA",
         "schemaId": "01H9ZQD35JPMBGHH69BT0Q79VY",
         "schemaVariantId": "01H9ZQD35JPMBGHH69BT0Q79VZ",
-        "sockets": [{"id": "socket1", "name": "input", "direction": "input", "arity": "one", "value": null}],
-        "domainProps": [{"id": "01HAXYZF3GC9CYA6ZVSM3E4YAA", "propId": "01HAXYZF3GC9CYA6ZVSM3E4YBB", "value": "updated-value", "path": "domain/path"}],
-        "resourceProps": [{"id": "01HAXYZF3GC9CYA6ZVSM3E4YCC", "propId": "01HAXYZF3GC9CYA6ZVSM3E4YDD", "value": "updated-resource-value", "path": "resource/path"}],
-        "name": "My Updated EC2 Instance",
+        "sockets": [],
+        "domainProps": [],
+        "resourceProps": [],
+        "name": "My EC2 Instance",
         "resourceId": "i-1234567890abcdef0",
         "toDelete": false,
         "canBeUpgraded": true,
-        "connections": [{"incoming": {"fromComponentId": "01H9ZQD35JPMBGHH69BT0Q79BB", "fromComponentName": "Other Component", "from": "output1", "to": "input1"}}],
-        "views": [{"id": "01HAXYZF3GC9CYA6ZVSM3E4YEE", "name": "Default View", "isDefault": true}],
-        "sources": {"/domain/RouteTableId": {"component": "demo-component","propPath": "/resource_value/RouteTableId"}}
+        "connections": [],
+        "views": [
+            {
+                "id": "01HAXYZF3GC9CYA6ZVSM3E4YEE",
+                "name": "Default View",
+                "isDefault": true
+            }
+        ],
+        "sources": [
+            ["/domain/RouteTableId", {
+                "$source": {
+                    "component": "demo-component",
+                    "path": "/resource_value/RouteTableId"
+                }
+            }],
+            ["/domain/region", {
+                "value": "us-east-1"
+            }]
+        ]
     }))]
     pub component: ComponentViewV1,
 }


### PR DESCRIPTION
We can now pass a set of parameters like:

```
            "attributes": {
                "/domain/Template/Default/Values/Name": 
                "paul-demo-from-api", "/secrets/AWS Credential": {
                    "$source": {
                        "component": "demo-credential",
                        "path": "/secrets/AWS Credential"
                    }
                },
                "/domain/extra/Region": {
                    "$source": {
                        "component": "us-east-1",
                        "path": "/domain/region"
                    }
                }
            }
```

This will deprecate the use of all of the other parameter types for 
setting values:

The response from the API is as follows:

```
{
  "component": {
    "id": "01K18Q6WEE5RSQEZ9SX0NGF893",
    "schemaId": "01J1QZDXCGJV29YF0FTW61A7R0",
    "schemaVariantId": "01K07XRNB89H0388173PY4N3GN",
    "sockets": [],
    "domainProps": [],
    "resourceProps": [],
    "name": "demo-comp",
    "resourceId": "",
    "toDelete": false,
    "canBeUpgraded": false,
    "connections": [],
    "views": [
      {
        "id": "01K07X0RGR6YQFXGSCSZ22XWKZ",
        "name": "DEFAULT",
        "isDefault": true
      }
    ],
    "sources": [
      [
        "/si/name",
        {
          "value": "demo-comp"
        }
      ],
      [
        "/si/type",
        {
          "value": "configurationFrameDown"
        }
      ],
      [
        "/domain/region",
        {
          "value": "us-east-1"
        }
      ]
    ]
  }
}
```