### PR TITLE
fix(web): Ensure that we can restore a component queued for deletion

### DIFF
--- a/app/web/src/newhotness/composables/useComponentDeletion.ts
+++ b/app/web/src/newhotness/composables/useComponentDeletion.ts
@@ -12,6 +12,7 @@ export function useComponentDeletion(viewId?: string, skipNavigation = false) {
   const deleteApi = useApi();
   const eraseApi = useApi();
   const deleteEraseFromViewApi = useApi();
+  const restoreApi = useApi();
 
   const convertBifrostToComponentInList = (
     component: BifrostComponent,
@@ -112,7 +113,6 @@ export function useComponentDeletion(viewId?: string, skipNavigation = false) {
   };
 
   const restoreComponents = async (componentIds: ComponentId[]) => {
-    const restoreApi = useApi();
     const call = restoreApi.endpoint(routes.RestoreComponents);
     const { req, newChangeSetId } = await call.put({
       componentIds,


### PR DESCRIPTION
When called inside async functions or callbacks, the Vue context is lost, causing the inject<Context>("CONTEXT") to return undefined