### PR TITLE
feature: si-mcp-server

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -130,6 +130,7 @@ deno_workspace(
         "//lib/jsr-systeminit/cf-db:deno.json",
         "//lib/jsr-systeminit/ai-agent:deno.json",
         "//bin/si-luminork-api-tests:deno.json",
+        "//bin/si-mcp-server:deno.json",
     ],
     visibility = ["PUBLIC"],
 )

--- a/bin/si-mcp-server/.gitignore
+++ b/bin/si-mcp-server/.gitignore
@@ -1,0 +1,1 @@
+si-mcp-server

--- a/bin/si-mcp-server/BUCK
+++ b/bin/si-mcp-server/BUCK
@@ -1,0 +1,51 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "alias",
+    "docker_image",
+    "export_file",
+)
+load(
+    "@prelude-si//:deno.bzl",
+    "deno_compile",
+    "deno_format",
+    "deno_test",
+)
+
+export_file(
+    name = "deno.json",
+)
+
+deno_compile(
+    name = "build",
+    main = "main.ts",
+    out = "si-mcp-server",
+    srcs = glob([
+        "src/**/*.ts",
+        "main.ts",
+    ]),
+    permissions = [
+        "allow-all",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+deno_format(
+    name = "fix-format",
+    srcs = glob(["**/*.ts"]),
+    ignore = ["node_modules"],
+)
+
+deno_format(
+    name = "check-format",
+    srcs = glob(["**/*.ts"]),
+    check = True,
+)
+
+deno_test(
+    name = "test-unit",
+    srcs = glob(["src/**/*_test.ts"]),
+    ignore = ["node_modules"],
+    permissions = [
+        "allow-all",
+    ],
+)

--- a/bin/si-mcp-server/Dockerfile
+++ b/bin/si-mcp-server/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM denoland/deno:2.4.2 AS builder
+
+WORKDIR /app
+
+# Copy source files
+COPY . .
+
+RUN ls *
+
+# Compile the application
+RUN deno compile --allow-env --allow-net --output=si-mcp-server main.ts
+
+# Runtime stage - use deno alpine image for compatibility
+FROM denoland/deno:alpine
+
+# Copy the compiled binary from builder stage
+COPY --from=builder /app/si-mcp-server /si-mcp-server
+
+# Set the entrypoint to run the binary with stdio argument
+ENTRYPOINT ["/si-mcp-server", "stdio"]

--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -1,0 +1,23 @@
+{
+  "tasks": {
+    "dev": "deno run -A --watch main.ts stdio",
+    "inspector": "npx @modelcontextprotocol/inspector deno run -A ./main.ts stdio",
+    "docker:build": "docker build -t si-mcp-server .",
+    "docker:run": "docker run --rm -i si-mcp-server"
+  },
+  "imports": {
+    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.16.0",
+    "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/encoding": "jsr:@std/encoding@^1.0.10",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.0.3",
+    "@systeminit/cf-db": "jsr:@systeminit/cf-db@^0.1.4",
+    "axios": "npm:axios@^1.6.1",
+    "jwt-decode": "npm:jwt-decode@^4.0.0",
+    "lodash": "npm:lodash@^4.17.21",
+    "ulid": "npm:ulid@^3.0.1",
+    "zod": "npm:zod@^3.21.4",
+    "zod-to-json-schema": "npm:zod-to-json-schema@^3.24.6"
+  }
+}

--- a/bin/si-mcp-server/main.ts
+++ b/bin/si-mcp-server/main.ts
@@ -1,0 +1,5 @@
+import { run } from "./src/cli.ts";
+
+if (import.meta.main) {
+  await run();
+}

--- a/bin/si-mcp-server/src/cli.ts
+++ b/bin/si-mcp-server/src/cli.ts
@@ -1,0 +1,36 @@
+import { Command } from "@cliffy/command";
+import { start_stdio } from "./stdio_transport.ts";
+import { createServer } from "./server.ts";
+
+export async function run() {
+  const command = new Command()
+    .name("si-mcp-server")
+    .version("0.1.0")
+    .description("MCP Server for System Initiative")
+    .globalEnv(
+      "SI_API_TOKEN=<string>",
+      "The System Initiative API Token",
+    )
+    .globalEnv(
+      "SI_WORKSPACE_ID=<string>",
+      "The System Initiative Workspace to connect the MCP Server to",
+    )
+    .globalEnv(
+      "SI_BASE_URI=<string>",
+      "The base URI for System Initiative. Defaults to https://api.systeminit.com",
+    )
+    .action(() => {
+      command.showHelp();
+      Deno.exit(1);
+    })
+    .command(
+      "stdio",
+      "Start the SI MCP Server over the stdio transport",
+    )
+    .action(async () => {
+      const server = createServer();
+      await start_stdio(server);
+    });
+
+  await command.parse(Deno.args);
+}

--- a/bin/si-mcp-server/src/data/actions.ts
+++ b/bin/si-mcp-server/src/data/actions.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const ActionSchemaRaw = {
+  actionId: z.string().describe("the action id"),
+  componentId: z.string().describe("the component id the action is on"),
+  componentName: z.string().describe("the component name the action is on"),
+  funcRunId: z.string().nullable().optional().describe(
+    "the function run id for the last executed function for this action",
+  ),
+  schemaName: z.string().describe(
+    "the schema name of the component the action is on",
+  ),
+  name: z.string().describe("The name of the Action"),
+  kind: z.string().describe("the kind of action"),
+  state: z.enum(["Dispatched", "Failed", "OnHold", "Queued", "Running"])
+    .describe(
+      "the current state of the action. 'Dispatched' means the action is eligible to run, and has been sent to the job queue for execution. 'Failed' means the action failed during execution. 'OnHold' means that the action is queued to run, but has been manually paused this action won't run, nor will any dependent actions, until the action is put back into the Queued state. 'Queued' means the action is elgible to run once all of its prerequisite actions have succeeded. 'Running' means the action has been dispatched, and has the job is being executed.",
+    ),
+};
+export const ActionSchema = z.object(ActionSchemaRaw);
+
+export type ActionList = z.infer<typeof ActionSchema>;

--- a/bin/si-mcp-server/src/data/cfDb.ts
+++ b/bin/si-mcp-server/src/data/cfDb.ts
@@ -1,0 +1,315 @@
+// deno-lint-ignore-file no-explicit-any
+import { getServiceByName, loadCfDatabase } from "@systeminit/cf-db";
+import { logger } from "../logger.ts";
+import { z } from "zod";
+
+logger.debug("Loading AWS CloudFormation Database");
+await loadCfDatabase({});
+
+export const ServiceDocumentationSchemaRaw = {
+  description: z.string().describe("A high level overview of the schema"),
+  link: z.string().optional().describe(
+    "A URL you can look up on the web to gain more information about the service",
+  ),
+};
+export const ServiceDocumentationSchema = z.object(
+  ServiceDocumentationSchemaRaw,
+).describe("Documentation about a schema");
+type ServiceDocumentation = z.infer<typeof ServiceDocumentationSchema>;
+
+export function getDocumentationForService(
+  serviceName: string,
+): ServiceDocumentation {
+  try {
+    const cfSchema = getServiceByName(serviceName);
+    const result: ServiceDocumentation = {
+      description: cfSchema.description,
+    };
+    if (
+      cfSchema.documentationUrl && typeof cfSchema.documentationUrl === "string"
+    ) {
+      result.link = cfSchema.documentationUrl;
+    } else if (
+      cfSchema.resourceLink && typeof cfSchema.resourceLink === "string"
+    ) {
+      result.link = cfSchema.resourceLink;
+    }
+    return result;
+  } catch (_error) {
+    return {
+      description: `No documentation available for ${serviceName}`,
+    };
+  }
+}
+
+const AttributesForServiceSchema = z.array(
+  z.object({
+    name: z.string().describe("the attributes name"),
+    path: z.string().describe(
+      "the absolute path of the attribute, which you can use to look up its documentation",
+    ),
+    required: z.boolean().describe("if this attribute is required"),
+  }).describe("an attribute"),
+).describe("array of attributes");
+type AttributesForService = z.infer<typeof AttributesForServiceSchema>;
+
+export function getAttributesForService(
+  serviceName: string,
+): AttributesForService {
+  try {
+    const cfSchema = getServiceByName(serviceName);
+    const attributes: AttributesForService = [];
+
+    // Get required properties from schema
+    const createOnlyProps = new Set(cfSchema.createOnlyProperties || []);
+    const readOnlyProps = new Set(cfSchema.readOnlyProperties || []);
+    const writeOnlyProps = new Set(cfSchema.writeOnlyProperties || []);
+
+    // deno-lint-ignore no-inner-declarations
+    function isRequired(path: string, localRequired: string[] = []): boolean {
+      return createOnlyProps.has(path) ||
+        readOnlyProps.has(path) ||
+        writeOnlyProps.has(path) ||
+        localRequired.includes(path.split("/").pop() || "");
+    }
+
+    // deno-lint-ignore no-inner-declarations
+    function walkProperties(
+      obj: any,
+      basePath: string,
+      requiredProps: string[] = [],
+    ): void {
+      if (!obj || typeof obj !== "object") return;
+
+      for (const [key, value] of Object.entries(obj)) {
+        if (!value || typeof value !== "object") continue;
+
+        const currentPath = `${basePath}/${key}`;
+        const prop = value as any;
+
+        if (prop.type === "array") {
+          // Handle arrays - use [array] in path for array elements
+          const arrayPath = `${currentPath}/[array]`;
+
+          if (prop.items?.type === "object" && prop.items.properties) {
+            // Array of objects - recurse into object properties
+            walkProperties(
+              prop.items.properties,
+              arrayPath,
+              prop.items.required || [],
+            );
+          } else {
+            // Simple array - add the array property itself
+            attributes.push({
+              name: key,
+              path: currentPath,
+              required: isRequired(currentPath, requiredProps),
+            });
+          }
+        } else if (prop.type === "object") {
+          if (
+            prop.additionalProperties &&
+            typeof prop.additionalProperties === "object"
+          ) {
+            // Handle maps - use '[map]' in path for map values
+            const mapPath = `${currentPath}/[map]`;
+            const mapValueType = prop.additionalProperties;
+
+            if (mapValueType.type === "object" && mapValueType.properties) {
+              walkProperties(
+                mapValueType.properties,
+                mapPath,
+                mapValueType.required || [],
+              );
+            } else {
+              attributes.push({
+                name: key,
+                path: currentPath,
+                required: isRequired(currentPath, requiredProps),
+              });
+            }
+          } else if (prop.properties) {
+            // Regular nested object
+            walkProperties(prop.properties, currentPath, prop.required || []);
+          }
+        } else {
+          // Simple property (string, integer, boolean, etc.)
+          attributes.push({
+            name: key,
+            path: currentPath,
+            required: isRequired(currentPath, requiredProps),
+          });
+        }
+      }
+    }
+
+    // Start walking from the root properties with /domain prefix
+    if (cfSchema.properties) {
+      walkProperties(cfSchema.properties, "/domain");
+    }
+
+    return attributes;
+  } catch (error) {
+    logger.error(`Failed to get attributes for service ${serviceName}:`, error);
+    return [];
+  }
+}
+
+export function getSchemaAttributeDocumentation(
+  schemaName: string,
+  schemaAttributePath: string,
+): string | null {
+  try {
+    const cfSchema = getServiceByName(schemaName);
+
+    // Remove /domain prefix from path for traversal
+    const path = schemaAttributePath.startsWith("/domain/")
+      ? schemaAttributePath.slice("/domain".length)
+      : schemaAttributePath;
+
+    // Split path into segments, filtering out empty strings
+    const pathSegments = path.split("/").filter((segment) =>
+      segment.length > 0
+    );
+
+    if (pathSegments.length === 0 || !cfSchema.properties) {
+      return null;
+    }
+
+    // deno-lint-ignore no-inner-declarations
+    function traversePath(
+      obj: any,
+      segments: string[],
+      currentPath: string,
+    ): string | null {
+      if (!obj || typeof obj !== "object") return null;
+
+      if (segments.length === 0) {
+        return obj.description || null;
+      }
+
+      const [currentSegment, ...remainingSegments] = segments;
+      const nextProperty = obj[currentSegment];
+
+      if (!nextProperty) return null;
+
+      // Handle array traversal
+      if (currentSegment === "[array]") {
+        // We're looking for documentation on array items
+        if (remainingSegments.length === 0) {
+          return obj.description || null;
+        }
+
+        if (obj.items && obj.items.properties) {
+          return traversePath(
+            obj.items.properties,
+            remainingSegments,
+            `${currentPath}/[array]`,
+          );
+        }
+        return null;
+      }
+
+      // Handle map traversal
+      if (currentSegment === "[map]") {
+        if (remainingSegments.length === 0) {
+          return obj.description || null;
+        }
+
+        if (obj.additionalProperties && obj.additionalProperties.properties) {
+          return traversePath(
+            obj.additionalProperties.properties,
+            remainingSegments,
+            `${currentPath}/[map]`,
+          );
+        }
+        return null;
+      }
+
+      // Regular property traversal
+      if (nextProperty.type === "array") {
+        if (remainingSegments.length === 0) {
+          return nextProperty.description || null;
+        }
+
+        // Check if next segment is [array]
+        if (remainingSegments[0] === "[array]") {
+          return traversePath(
+            nextProperty,
+            remainingSegments,
+            `${currentPath}/${currentSegment}`,
+          );
+        }
+
+        // If looking for a specific field within array items but no [array] specified,
+        // fall back to the array's documentation
+        return nextProperty.description || null;
+      } else if (nextProperty.type === "object") {
+        if (remainingSegments.length === 0) {
+          return nextProperty.description || null;
+        }
+
+        // Handle maps (objects with additionalProperties)
+        if (
+          nextProperty.additionalProperties && remainingSegments[0] === "[map]"
+        ) {
+          return traversePath(
+            nextProperty,
+            remainingSegments,
+            `${currentPath}/${currentSegment}`,
+          );
+        }
+
+        // Regular nested object
+        if (nextProperty.properties) {
+          const result = traversePath(
+            nextProperty.properties,
+            remainingSegments,
+            `${currentPath}/${currentSegment}`,
+          );
+
+          // If we couldn't find documentation for the specific field, fall back to the parent object
+          if (result === null && nextProperty.description) {
+            return nextProperty.description;
+          }
+
+          return result;
+        }
+
+        return nextProperty.description || null;
+      } else {
+        // Simple property
+        if (remainingSegments.length === 0) {
+          return nextProperty.description || null;
+        }
+
+        // Path continues but this is a simple property - invalid path
+        return null;
+      }
+    }
+
+    const result = traversePath(cfSchema.properties, pathSegments, "");
+
+    // If we couldn't find specific documentation, try to find fallback documentation
+    // by traversing up the path for array/map containers
+    if (
+      result === null &&
+      (schemaAttributePath.includes("[array]") ||
+        schemaAttributePath.includes("[map]"))
+    ) {
+      // Try to find the parent array or map documentation
+      const parentPath = schemaAttributePath.split("/").slice(0, -1).join("/");
+      if (parentPath !== schemaAttributePath) {
+        return getSchemaAttributeDocumentation(schemaName, parentPath);
+      }
+    }
+
+    return result;
+  } catch (error) {
+    logger.error(
+      `Failed to get documentation for ${schemaName} path ${schemaAttributePath}:`,
+      error,
+    );
+    return null;
+  }
+}

--- a/bin/si-mcp-server/src/data/cfDb_test.ts
+++ b/bin/si-mcp-server/src/data/cfDb_test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "jsr:@std/assert";
+import { getAttributesForService } from "./cfDb.ts";
+
+Deno.test("getAttributesForService - basic properties", () => {
+  // Test with a known AWS service that should have properties
+  const attributes = getAttributesForService("AWS::EC2::Instance");
+
+  // Should return an array
+  assertEquals(Array.isArray(attributes), true);
+
+  // Should have some attributes
+  assertEquals(attributes.length > 0, true);
+
+  // Each attribute should have required structure
+  for (const attr of attributes) {
+    assertEquals(typeof attr.name, "string");
+    assertEquals(typeof attr.path, "string");
+    assertEquals(typeof attr.required, "boolean");
+    assertEquals(attr.path.startsWith("/domain"), true);
+  }
+});
+
+Deno.test("getAttributesForService - invalid service", () => {
+  // Test with non-existent service
+  const attributes = getAttributesForService("Invalid::Service::Name");
+
+  // Should return empty array for invalid service
+  assertEquals(attributes, []);
+});
+
+Deno.test("getAttributesForService - path format", () => {
+  const attributes = getAttributesForService("AWS::EC2::Instance");
+
+  // Find some expected properties and verify path format
+  const instanceTypeAttr = attributes.find((attr) =>
+    attr.name === "InstanceType"
+  );
+  if (instanceTypeAttr) {
+    assertEquals(instanceTypeAttr.path, "/domain/InstanceType");
+  }
+
+  // All paths should start with /domain
+  for (const attr of attributes) {
+    assertEquals(attr.path.startsWith("/domain/"), true);
+  }
+});
+
+Deno.test("getAttributesForService debugging", () => {
+  const attributes = getAttributesForService("AWS::EC2::Instance");
+  console.log(attributes);
+  assertEquals("poop", "canoe");
+});

--- a/bin/si-mcp-server/src/data/changeSets.ts
+++ b/bin/si-mcp-server/src/data/changeSets.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const ChangeSetSchemaRaw = {
+  id: z.string().describe("Change Set ID"),
+  isHead: z.boolean().describe("True if the change set is HEAD; false if not"),
+  name: z.string().describe("The name of the Change Set"),
+  status: z.enum([
+    "Abandoned",
+    "Applied",
+    "Approved",
+    "Failed",
+    "NeedsApproval",
+    "Open",
+    "Rejected",
+  ]).describe(
+    "The status of the change set. 'Abandoned' means it is no longer accessible. 'Applied' means it has been applied to HEAD. 'Approved' means any neccessary approvals have been applied. 'Failed' means a snapshot migrations has failed. 'NeedsApproval' means applying to HEAD is desired, but approvals are required first. 'Open' means it is available for users to modify. 'Rejected' means a request to apply with approval was rejected.",
+  ),
+};
+export const ChangeSetSchema = z.object(ChangeSetSchemaRaw);
+
+export type ChangeSet = z.infer<typeof ChangeSetSchema>;

--- a/bin/si-mcp-server/src/data/components.ts
+++ b/bin/si-mcp-server/src/data/components.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const AttributesSchema = z.record(
+  z.union([
+    z.object({
+      $source: z.union([
+        z.null().describe(
+          "unset the value, regardless of it is a subscription; any value can be unset in this way, and will revert to its default value. This can also be used to remove array or map elements.",
+        ),
+        z.object({
+          "component": z.string().describe(
+            "the componentName or componentId; prefer the componentId",
+          ),
+          "path": z.string().describe(
+            "the schema path for this subscription, replacing [array] or [map] with the correct index or key, respectively",
+          ),
+          "func": z.string().optional().describe(
+            "a function id to be used as a transformation before setting the value",
+          ),
+        }).describe("the component and path to source the value from"),
+      ]).describe("create or unset a subscription"),
+    }).describe(
+      "a subscription to a source attribute on another component",
+    ),
+    z.string().describe("a string value"),
+    z.array(z.any()).describe("an array of values"),
+    z.boolean().describe("a boolean value"),
+    z.record(z.any()).describe("an object value"),
+    z.number().describe("a number value"),
+  ]),
+).describe(
+  "the attributes of the component; the desired state of the resource",
+);

--- a/bin/si-mcp-server/src/logger.ts
+++ b/bin/si-mcp-server/src/logger.ts
@@ -1,0 +1,33 @@
+import { ConsoleStream, Level, Logger, LogRecord } from "@onjara/optic";
+import { TokenReplacer } from "@onjara/optic/formatters";
+
+class StderrStream extends ConsoleStream {
+  override log(msg: string): void {
+    console.error(msg);
+  }
+
+  override handle(logRecord: LogRecord): boolean {
+    if (this.minLevel > logRecord.level) return false;
+    const msg = this.format(logRecord);
+
+    if (logRecord.level >= Level.Error) {
+      console.error(msg);
+    } else if (logRecord.level >= Level.Warn) {
+      console.error(msg);
+    } else if (logRecord.level >= Level.Info) {
+      console.error(msg);
+    } else if (logRecord.level >= Level.Debug) {
+      console.error(msg);
+    } else {
+      console.error(msg);
+    }
+
+    return true;
+  }
+}
+
+export const logger = new Logger()
+  .addStream(new StderrStream().withFormat(
+    new TokenReplacer(),
+  ))
+  .withMinLogLevel(Level.Debug);

--- a/bin/si-mcp-server/src/server.ts
+++ b/bin/si-mcp-server/src/server.ts
@@ -1,0 +1,40 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { validateCredentialsTool } from "./tools/validateCredentials.ts";
+import { changeSetListTool } from "./tools/changeSetList.ts";
+import { changeSetCreateTool } from "./tools/changeSetCreate.ts";
+import { changeSetUpdateTool } from "./tools/changeSetUpdateStatus.ts";
+import { schemaFindTool } from "./tools/schemaFind.ts";
+import { schemaAttributesListTool } from "./tools/schemaAttributesList.ts";
+import { schemaAttributesDocumentationTool } from "./tools/schemaAttributesDocumentation.ts";
+import { actionListTool } from "./tools/actionList.ts";
+import { actionUpdateTool } from "./tools/actionUpdateStatus.ts";
+import { funcRunGetTool } from "./tools/funcRunGet.ts";
+import { componentListTool } from "./tools/componentList.ts";
+import { componentGetTool } from "./tools/componentGet.ts";
+import { componentCreateTool } from "./tools/componentCreate.ts";
+import { componentUpdateTool } from "./tools/componentUpdate.ts";
+import { componentEnqueueActionTool } from "./tools/componentEnqueueAction.ts";
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "si-server",
+    version: "0.1.0",
+  });
+  validateCredentialsTool(server);
+  changeSetListTool(server);
+  changeSetCreateTool(server);
+  changeSetUpdateTool(server);
+  schemaFindTool(server);
+  schemaAttributesListTool(server);
+  schemaAttributesDocumentationTool(server);
+  actionListTool(server);
+  actionUpdateTool(server);
+  funcRunGetTool(server);
+  componentListTool(server);
+  componentGetTool(server);
+  componentCreateTool(server);
+  componentUpdateTool(server);
+  componentEnqueueActionTool(server);
+
+  return server;
+}

--- a/bin/si-mcp-server/src/si_client.ts
+++ b/bin/si-mcp-server/src/si_client.ts
@@ -1,0 +1,36 @@
+import { Configuration } from "@systeminit/api-client";
+import { logger } from "./logger.ts";
+import { jwtDecode } from "jwt-decode";
+
+interface SIJwtPayload {
+  workspaceId: string;
+  userId: string;
+  [key: string]: unknown;
+}
+
+const apiToken = Deno.env.get("SI_API_TOKEN");
+if (!apiToken) {
+  logger.error(
+    "SI_API_TOKEN is not defined; re-run the MCP server with your authentication token set in the environment",
+  );
+  Deno.exit(10);
+}
+const baseUrl = Deno.env.get("SI_BASE_URL") || "https://api.systeminit.com";
+export const apiConfig = new Configuration({
+  basePath: baseUrl,
+  accessToken: apiToken,
+  baseOptions: {
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+    },
+  },
+});
+const decoded = jwtDecode<SIJwtPayload>(apiToken);
+export const WORKSPACE_ID = decoded.workspaceId;
+if (!WORKSPACE_ID) {
+  logger.error(
+    `Tried to extract workspace ID from API Token, but failed. Your token is likely malformed! The decoded token follows:\n\n${
+      JSON.stringify(decoded, null, 2)
+    }`,
+  );
+}

--- a/bin/si-mcp-server/src/stdio_transport.ts
+++ b/bin/si-mcp-server/src/stdio_transport.ts
@@ -1,0 +1,14 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { logger } from "./logger.ts";
+
+export async function start_stdio(server: McpServer) {
+  const transport = new StdioServerTransport();
+  try {
+    await server.connect(transport);
+    logger.info("System Initiative MCP server started");
+  } catch (error) {
+    logger.error(`Error starting mcp server: ${error}`);
+    Deno.exit(2);
+  }
+}

--- a/bin/si-mcp-server/src/tools/actionList.ts
+++ b/bin/si-mcp-server/src/tools/actionList.ts
@@ -1,0 +1,140 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import {
+  ActionsApi,
+  ChangeSetsApi,
+  ComponentsApi,
+  SchemasApi,
+} from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { ActionList, ActionSchema } from "../data/actions.ts";
+import { ChangeSet } from "../data/changeSets.ts";
+
+const name = "action-list";
+const title = "List actions";
+const description =
+  `<description>Lists all actions. Returns an array of actions with actionId, componentId, Name, kind, and state. On failure, returns error details</description><usage>Use this tool when the user asks what actions are present.</usage>`;
+
+const ListActionsInputSchemaRaw = {
+  changeSetId: z.string().optional().describe(
+    "The change set to look up actions in; if not provided, HEAD will be used",
+  ),
+};
+
+const ListActionsOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.array(ActionSchema).optional().describe("The list of actions"),
+};
+const ListActionsOutputSchema = z.object(
+  ListActionsOutputSchemaRaw,
+);
+
+export function actionListTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "actionsListResponse",
+        ListActionsOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: ListActionsInputSchemaRaw,
+      outputSchema: ListActionsOutputSchemaRaw,
+    },
+    async ({ changeSetId }): Promise<CallToolResult> => {
+      if (!changeSetId) {
+        const changeSetsApi = new ChangeSetsApi(apiConfig);
+        try {
+          const changeSetList = await changeSetsApi.listChangeSets({
+            workspaceId: WORKSPACE_ID,
+          });
+          const changeSets = changeSetList.data.changeSets as ChangeSet[];
+          const head = changeSets.find((cs) => cs.isHead);
+          if (!head) {
+            return errorResponse({
+              message: "Could not find HEAD change set",
+            });
+          }
+          changeSetId = head.id;
+        } catch (error) {
+          return errorResponse({
+            message:
+              `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+          });
+        }
+      }
+      const siApi = new ActionsApi(apiConfig);
+      try {
+        const response = await siApi.getActions({
+          workspaceId: WORKSPACE_ID,
+          changeSetId: changeSetId,
+        });
+        const actionList: Array<ActionList> = [];
+        for (const action of response.data.actions) {
+          let compName: string;
+          let compSchemaName: string;
+          try {
+            const compApi = new ComponentsApi(apiConfig);
+            const comp = await compApi.getComponent({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+              componentId: action.componentId,
+            });
+            compName = comp.data.component.name;
+            const compSchemaId = comp.data.component.schemaId;
+            try {
+              const schemaApi = new SchemasApi(apiConfig);
+              const schema = await schemaApi.getSchema({
+                workspaceId: WORKSPACE_ID,
+                changeSetId,
+                schemaId: compSchemaId,
+              });
+              compSchemaName = schema.data.name;
+            } catch (error) {
+              return errorResponse({
+                message:
+                  `Error getting schema for extra details while listing actions; bug! ${error}`,
+              });
+            }
+          } catch (error) {
+            return errorResponse({
+              message:
+                `Error getting component for extra details while listing actions; bug! ${error}`,
+            });
+          }
+          actionList.push({
+            actionId: action.id,
+            componentId: action.componentId,
+            componentName: compName,
+            schemaName: compSchemaName,
+            name: action.name,
+            kind: action.kind,
+            funcRunId: action.funcRunId,
+            state: action.state as ActionList["state"],
+          });
+        }
+        return successResponse(
+          actionList,
+          "'Failed' actions can be retried, and you can learn more about the function execution ysing the func-run-get tool with the funcRunId",
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/actionUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/actionUpdateStatus.ts
@@ -1,0 +1,110 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ActionsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+
+const name = "action-update-status";
+const title = "Update the status of an action";
+const description =
+  `<description>Update the status of an action. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to set an Action to 'on-hold' (ensuring it does not execute, nor will any dependent actions; puts it in the 'OnHold' status), to take it off hold 'off-hold' (puts it in the 'Queued' status), 'retry' to try the action again, etiher after it has failed or been put on hold, or 'remove' to remove if from the list of actions for this change set.</usage>`;
+
+const UpdateActionInputSchemaRaw = {
+  newStatus: z.enum(["on-hold", "off-hold", "retry", "remove"]).describe(
+    "'on-hold' will set the action state to OnHold, ensuring it won't run. 'off-hold' will move the action back to the queue (taking it from OnHold to Queued). 'retry' will schedule an action to try again, either after it has failed or has been put on hold (effectively taking it 'off-hold' as well). 'remove' will remove the action from the queue for this change set.",
+  ),
+  changeSetId: z.string().describe(
+    "the ID of the change set to maniplate the action queue of",
+  ),
+  actionId: z.string().describe("the ID of the action to change the state of"),
+};
+
+const UpdateActionOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({ "success": z.boolean().describe("will always be true") })
+    .describe("will be true if the request succeeds"),
+};
+const UpdateActionOutputSchema = z.object(
+  UpdateActionOutputSchemaRaw,
+);
+
+export function actionUpdateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "actionUpdateResponse",
+        UpdateActionOutputSchema,
+      ),
+      annotations: {
+        destructiveHint: true,
+      },
+      inputSchema: UpdateActionInputSchemaRaw,
+      outputSchema: UpdateActionOutputSchemaRaw,
+    },
+    async ({ changeSetId, newStatus, actionId }): Promise<CallToolResult> => {
+      if (!changeSetId) {
+        return errorResponse({
+          message:
+            "Must provide a change set id; ensure you get one from the user!",
+        });
+      }
+      if (!newStatus) {
+        return errorResponse({
+          message:
+            "Must provide a new status for the action; ensure you get one from the user!",
+        });
+      }
+
+      const siApi = new ActionsApi(apiConfig);
+      try {
+        // Confirm the change set you want to manipulate isn't HEAD
+        if (newStatus == "on-hold") {
+          const response = await siApi.putOnHold({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+            actionId,
+          });
+          return successResponse(
+            response.data,
+          );
+        } else if (newStatus == "off-hold" || newStatus == "retry") {
+          const response = await siApi.retryAction({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+            actionId,
+          });
+          return successResponse(
+            response.data,
+          );
+        } else if (newStatus == "remove") {
+          const response = await siApi.cancelAction({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+            actionId,
+          });
+          return successResponse(
+            response.data,
+          );
+        } else {
+          return errorResponse({
+            message:
+              `Invalid status '${newStatus}'. Must be one of: on-hold, off-hold, retry, remove`,
+          });
+        }
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/changeSetCreate.ts
+++ b/bin/si-mcp-server/src/tools/changeSetCreate.ts
@@ -1,0 +1,69 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ChangeSetsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { ChangeSetSchema } from "../data/changeSets.ts";
+
+const name = "change-set-create";
+const title = "Create change set";
+const description =
+  `<description>Creates a change set. Returns the ID, Name and Status of the change set. On failure, returns error details</description><usage>Use this tool to create a new change set.</usage>`;
+
+const CreateChangeSetInputSchemaRaw = {
+  changeSetName: z.string().describe(
+    "the name of the change set; should be descriptive for the intent of the change.",
+  ),
+};
+
+const CreateChangeSetOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: ChangeSetSchema.optional().describe("The new change set"),
+};
+const CreateChangeSetOutputSchema = z.object(
+  CreateChangeSetOutputSchemaRaw,
+);
+
+export function changeSetCreateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "changeSetCreateResponse",
+        CreateChangeSetOutputSchema,
+      ),
+      inputSchema: CreateChangeSetInputSchemaRaw,
+      outputSchema: CreateChangeSetOutputSchemaRaw,
+    },
+    async ({ changeSetName }): Promise<CallToolResult> => {
+      if (!changeSetName) {
+        return errorResponse({
+          message:
+            "Must provide a change set name; ensure you get one from the user!",
+        });
+      }
+      const siApi = new ChangeSetsApi(apiConfig);
+      try {
+        const response = await siApi.createChangeSet({
+          workspaceId: WORKSPACE_ID,
+          createChangeSetV1Request: { changeSetName },
+        });
+        return successResponse(
+          response.data.changeSet,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/changeSetList.ts
+++ b/bin/si-mcp-server/src/tools/changeSetList.ts
@@ -1,0 +1,61 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ChangeSetsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { ChangeSetSchema } from "../data/changeSets.ts";
+
+const name = "change-set-list";
+const title = "List change sets";
+const description =
+  `<description>Lists change sets. Returns the ID, Name and Status of the change set. On failure, returns error details</description><usage>Use this tool when you need to know what change sets are available in the workspace.</usage>`;
+const hints =
+  "Apply, Force-Apply, and Abandon change sets using their 'id' and the change-set-status-update tool.";
+
+const ListChangeSetsOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.array(ChangeSetSchema).optional().describe("The list of change sets"),
+};
+const ListChangeSetsOutputSchema = z.object(
+  ListChangeSetsOutputSchemaRaw,
+);
+
+export function changeSetListTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "changeSetListResponse",
+        ListChangeSetsOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      outputSchema: ListChangeSetsOutputSchemaRaw,
+    },
+    async (): Promise<CallToolResult> => {
+      const siApi = new ChangeSetsApi(apiConfig);
+      try {
+        const response = await siApi.listChangeSets({
+          workspaceId: WORKSPACE_ID,
+        });
+        return successResponse(
+          response.data.changeSets,
+          hints,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
@@ -1,0 +1,134 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ChangeSetsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+
+const name = "change-set-update-status";
+const title = "Update the status of a change set";
+const description =
+  `<description>Update the status of a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon (or 'delete') a change set, Apply a change set, or Force Apply the change set (ignoring all approvals). You may *never* update the status of the HEAD change set.</usage>`;
+
+const UpdateChangeSetInputSchemaRaw = {
+  newStatus: z.enum(["abandon", "apply", "force-apply"]).describe(
+    "'abandon' will abandon this change set, effectively deleting it. 'apply' will attempt to apply this change set, pending any approval requirements. 'force-apply' will apply the change set *ignoring* all approval requirements.",
+  ),
+  changeSetId: z.string().describe(
+    "the ID of the change set to update the status of",
+  ),
+};
+
+const UpdateChangeSetOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({ "success": z.boolean().describe("will always be true") })
+    .describe("will be true if the request succeeds"),
+};
+const UpdateChangeSetOutputSchema = z.object(
+  UpdateChangeSetOutputSchemaRaw,
+);
+
+export function changeSetUpdateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "changeSetUpdateResponse",
+        UpdateChangeSetOutputSchema,
+      ),
+      annotations: {
+        destructiveHint: true,
+      },
+      inputSchema: UpdateChangeSetInputSchemaRaw,
+      outputSchema: UpdateChangeSetOutputSchemaRaw,
+    },
+    async ({ changeSetId, newStatus }): Promise<CallToolResult> => {
+      if (!changeSetId) {
+        return errorResponse({
+          message:
+            "Must provide a change set id; ensure you get one from the user!",
+        });
+      }
+      if (!newStatus) {
+        return errorResponse({
+          message:
+            "Must provide a new status for the change set; ensure you get one from the user!",
+        });
+      }
+
+      const siApi = new ChangeSetsApi(apiConfig);
+      try {
+        const response = await siApi.getChangeSet({
+          workspaceId: WORKSPACE_ID,
+          changeSetId,
+        });
+        if (response.data.changeSet.isHead) {
+          return errorResponse({
+            message:
+              "You may not change the status of the HEAD change set. Inform the user that HEAD is immutable, and they should not try and change its status. Call them a cheeky monkey.",
+          });
+        }
+      } catch (error) {
+        return errorResponse(error);
+      }
+
+      try {
+        // Confirm the change set you want to manipulate isn't HEAD
+        if (newStatus == "abandon") {
+          const response = await siApi.abandonChangeSet({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+          });
+          return successResponse(
+            response.data,
+          );
+        } else if (newStatus == "apply") {
+          const response = await siApi.requestApproval({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+          });
+          try {
+            const newResponse = await siApi.getChangeSet({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+            });
+            if (newResponse.data.changeSet.status == "NeedsApproval") {
+              return successResponse(
+                response.data,
+                "Tell the user that while the request was successful, the Change Set requires review and explicit Approval.",
+              );
+            } else {
+              return successResponse(response.data);
+            }
+          } catch (error) {
+            return errorResponse(error);
+          }
+        } else if (newStatus == "force-apply") {
+          const response = await siApi.forceApply({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+          });
+          return successResponse(
+            response.data,
+          );
+        } else {
+          return errorResponse({
+            message:
+              `Invalid status '${newStatus}'. Must be one of: abandon, apply, force-apply`,
+          });
+        }
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/commonBehavior.ts
+++ b/bin/si-mcp-server/src/tools/commonBehavior.ts
@@ -1,0 +1,92 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ZodTypeAny } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export function generateDescription(
+  desc: string,
+  schemaName: string,
+  schema: ZodTypeAny,
+): string {
+  const jsonSchema = JSON.stringify(zodToJsonSchema(schema, schemaName));
+
+  return `${desc}\n\nThe response will be structured JSON between a <response></response> tag, and may include hints for other useful tool calls for the data between a <hints></hints> tag. The response will conform to the following JSON schema:\n\n${jsonSchema}`;
+}
+
+export function successResponse(
+  // deno-lint-ignore no-explicit-any
+  rawResponse: any,
+  hints?: string,
+): CallToolResult {
+  const structuredResponse = {
+    status: "success",
+    data: rawResponse,
+  };
+  let textResponse = `<response>${
+    JSON.stringify(structuredResponse)
+  }</response>`;
+  if (hints) {
+    textResponse += `\n<hints>${hints}</hints>`;
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: textResponse,
+      },
+    ],
+    structuredContent: structuredResponse,
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+export function errorResponse(error: any): CallToolResult {
+  if (error.response) {
+    const errorResponse = {
+      status: "failure",
+      errorMessage: `Error Status: ${error.response.status}\nError Data: ${
+        JSON.stringify(error.response.data)
+      }\nMessage:${error.message}`,
+    };
+    return {
+      content: [
+        {
+          type: "text",
+          text: `<response>${JSON.stringify(errorResponse)}</response>`,
+        },
+      ],
+      structuredContent: errorResponse,
+      isError: true,
+    };
+  } else if (error.request) {
+    const errorResponse = {
+      status: "failure",
+      errorMessage: `No response recieved, but request failed`,
+    };
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(errorResponse),
+        },
+      ],
+      structuredContent: errorResponse,
+      isError: true,
+    };
+  } else {
+    const errorResponse = {
+      status: "failure",
+      errorMessage: `Error setting up request: ${error.message}`,
+    };
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(errorResponse),
+        },
+      ],
+      structuredContent: errorResponse,
+      isError: true,
+    };
+  }
+}

--- a/bin/si-mcp-server/src/tools/componentCreate.ts
+++ b/bin/si-mcp-server/src/tools/componentCreate.ts
@@ -1,0 +1,83 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ComponentsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { AttributesSchema } from "../data/components.ts";
+
+const name = "component-create";
+const title = "Create a new component for a given schema";
+const description =
+  `<description>Create a new component for a given schema name, with a name and the attributes provided. Returns the componentName, componentId, schemaName of the component. On failure, returns error details. Always break attribute values down to their end path - *always* prefer /domain/Foo/Bar with a value 'Baz' to setting /domain/Foo to the object '{ Bar: baz }'.</description><usage>Use this tool to create a new component for a given schema in a change set. Use the schema-find tool to understand the paths that are available for setting attributes. For array attributes, replace the [array] in the schema path with a 0 indexed array position - ensure all array entries are accounted for in order (no gaps). For [map], do the same with the string key for the map. To see all of its information after it has been created, use the component-get tool.</usage>`;
+
+const CreateComponentInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to create the component in; components cannot be created on the HEAD change set",
+  ),
+  schemaName: z.string().describe("the schema name of the component to create"),
+  componentName: z.string().describe("the name of the component to create"),
+  attributes: AttributesSchema,
+};
+
+const CreateComponentOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    componentId: z.string().describe("the component id"),
+    componentName: z.string().describe("the components name"),
+    schemaName: z.string().describe("the schema for the component"),
+  }),
+};
+const CreateComponentOutputSchema = z.object(
+  CreateComponentOutputSchemaRaw,
+);
+
+type CreateComponentResult = z.infer<typeof CreateComponentOutputSchema>["data"];
+
+export function componentCreateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "componentCreateResponse",
+        CreateComponentOutputSchema,
+      ),
+      inputSchema: CreateComponentInputSchemaRaw,
+      outputSchema: CreateComponentOutputSchemaRaw,
+    },
+    async ({ changeSetId, componentName, schemaName, attributes }): Promise<CallToolResult> => {
+      const siApi = new ComponentsApi(apiConfig);
+      try {
+        const response = await siApi.createComponent({
+          workspaceId: WORKSPACE_ID,
+          changeSetId: changeSetId,
+          createComponentV1Request: {
+            name: componentName,
+            schemaName,
+            attributes,
+          }
+        });
+        const result: CreateComponentResult = {
+          componentId: response.data.component.id,
+          componentName: response.data.component.name,
+          schemaName: schemaName,
+        };
+
+        return successResponse(
+          result,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/componentEnqueueAction.ts
+++ b/bin/si-mcp-server/src/tools/componentEnqueueAction.ts
@@ -1,0 +1,76 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ComponentsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import _ from "lodash";
+
+const name = "component-enqueue-action";
+const title = "Enqueue an action to run for a component in a change set";
+const description =
+  `<description>Enqueues an action to run for a component in a change set. Actions other than 'Refresh' will not be run until the change set is applied (refresh will be runn immediately).  Returns success if the action is enqueued. On failure, returns error details</description><usage>*Always* look up the correct action name by using the 'get-component' tool first. Use this tool when the user wants to enqueue an action for a component. 'Create' and 'Update' actions are automatically enqueued, so you don't need to enqueue them explicitly (but you can if the user requests it directly.) 'Refresh' functions are executed automatically rather than enqueued.</usage>`;
+
+const EnqueueActionComponentInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to enqueue the action in",
+  ),
+  componentId: z.string().describe("the compoonent to enqueue the action for"),
+  actionName: z.string().describe("the name of the action to enqueue; can be listed with the component-get tool"),
+};
+
+const EnqueueActionComponentOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    success: z.boolean().describe("true if the action is successfully enqueued"),
+  }).describe("the component data"),
+};
+const EnqueueActionComponentOutputSchema = z.object(
+  EnqueueActionComponentOutputSchemaRaw,
+);
+
+export function componentEnqueueActionTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "componentEnqueueActionResponse",
+        EnqueueActionComponentOutputSchema,
+      ),
+      inputSchema: EnqueueActionComponentInputSchemaRaw,
+      outputSchema: EnqueueActionComponentOutputSchemaRaw,
+    },
+    async (
+      { changeSetId, componentId, actionName },
+    ): Promise<CallToolResult> => {
+      const siApi = new ComponentsApi(apiConfig);
+      try {
+        const response = await siApi.addAction({
+          workspaceId: WORKSPACE_ID,
+          changeSetId: changeSetId,
+          componentId,
+          addActionV1Request: {
+            action: {
+              function: actionName,
+            }
+          }
+        });
+        return successResponse(
+          response.data,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}
+

--- a/bin/si-mcp-server/src/tools/componentGet.ts
+++ b/bin/si-mcp-server/src/tools/componentGet.ts
@@ -1,0 +1,214 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ComponentsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import _ from "lodash";
+import { AttributesSchema } from "../data/components.ts";
+
+const name = "component-get";
+const title = "Get the details of a component";
+const description =
+  `<description>Get the details about a component in a change set. Returns the componentName, componentId, schemaName, list of actions that can be taken, list of management functions that can be run, resourceId if it is set, raw resource data if it is set (useful for troubleshooting), and the attributes of the component. Optionally include qualifications and code generation (if requested). On failure, returns error details</description><usage>Use this tool when you want to understand how a component is configured. It contains all of its attributes (and where they come from; either directly set our sourced from a subscription), actions, management functions, and resource values.</usage>`;
+
+const GetComponentInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to look up the component in",
+  ),
+  componentId: z.string().describe("the compoonent id to look up"),
+  qualifications: z.boolean().optional().describe(
+    "include information about the qualifications for this component; useful when you are debugging why it might not be working as intended. if any qualifications are failing, that means the component is likely to fail when applied. can be verbose, so only include if you need it.",
+  ),
+  code: z.boolean().optional().describe(
+    "include information about code generation functions for this component; useful when troubleshooting that a representation needed by a cloud provider (such as AWS cloudformation) is correct. Can be verbose, so only include it if you need it.",
+  ),
+};
+
+const GetComponentOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    componentId: z.string().describe("the component id"),
+    componentName: z.string().describe("the components name"),
+    resourceId: z.string().describe(
+      "the resource id this component maps to in the real world; frequently the primary identifier for a cloud service, like AWS",
+    ),
+    attributes: AttributesSchema,
+    resource: z.object({
+      status: z.enum(["ok", "error", "warning"]).describe(
+        "if 'ok', the resource exists and is ok. if 'warning', the resource exists but may have a problem. if 'error', then the resource may exist, but there is an error.",
+      ),
+      resourceData: z.any().optional().describe(
+        "the raw resource data returned from the cloud provider; likely a JSON object, but not guaranteed",
+      ),
+      lastSynced: z.string().describe(
+        "the last time the resource was refreshed",
+      ),
+    }).optional().describe(
+      "the raw resource data, as returned from the cloud provider. the real state of the resource.",
+    ),
+    code: z.record(
+      z.string().describe("the name of the code generator function"),
+      z.object({
+        code: z.string().describe("the generated source code"),
+        format: z.string().describe(
+          "the language/format of the generated code",
+        ),
+      }).describe("the generated code"),
+    ).optional().describe(
+      "optional code generation output; useful when troubleshooting",
+    ),
+    qualifications: z.record(
+      z.string().describe("the name of the qualification"),
+      z.object({
+        result: z.enum(["failure", "success", "unknown", "warning"]).describe(
+          "'failure' means the qualification has failed, and there is a problem; 'success' means there is no problem; 'unknown' means we don't know the state of the qualification; and 'warning' means there may be a problem",
+        ),
+        message: z.string().describe("the message about this qualification"),
+      }).describe("the qualification result and message"),
+    ).optional().describe("optional qualification results"),
+    actions: z.array(
+      z.object({ actionName: z.string().describe("the action function name") }),
+    ).describe("the list of actions this component supports"),
+    management: z.array(
+      z.object({
+        managementName: z.string().describe("the management function name"),
+      }),
+    ).describe("the list of management functions this component supports"),
+  }).describe("the component data"),
+};
+const GetComponentOutputSchema = z.object(
+  GetComponentOutputSchemaRaw,
+);
+
+type GetComponentResult = z.infer<typeof GetComponentOutputSchema>["data"];
+
+export function componentGetTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "componentGetResponse",
+        GetComponentOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: GetComponentInputSchemaRaw,
+      outputSchema: GetComponentOutputSchemaRaw,
+    },
+    async (
+      { changeSetId, componentId, code, qualifications },
+    ): Promise<CallToolResult> => {
+      const siApi = new ComponentsApi(apiConfig);
+      try {
+        const response = await siApi.getComponent({
+          workspaceId: WORKSPACE_ID,
+          changeSetId: changeSetId,
+          componentId,
+        });
+        // _.pickBy(response.data.component.attributes, (_value, key) => key.includes('/code'))
+        const attributes = _.pickBy(
+          response.data.component.attributes,
+          (_value: unknown, key: string) =>
+            key.startsWith("/domain") || key.startsWith("/si/name") ||
+            key.startsWith("/resource_value") || key.startsWith("/secrets"),
+        );
+        const result: GetComponentResult = {
+          componentId: response.data.component.id,
+          componentName: response.data.component.name,
+          resourceId: response.data.component.resourceId,
+          attributes: attributes as GetComponentResult["attributes"],
+          actions: response.data.actionFunctions.map((af) => {
+            return { actionName: af.funcName };
+          }),
+          management: response.data.managementFunctions.map((mf) => {
+            return { managementName: mf.funcName };
+          }),
+        };
+        if (code) {
+          const codeAttributes = _.pickBy(
+            response.data.component.attributes,
+            (_value: unknown, key: string) => key.startsWith("/code"),
+          );
+          const code: NonNullable<GetComponentResult['code']> = {};
+          for (const [path, codeValue] of Object.entries(codeAttributes)) {
+            const match = path.match(/^\/code\/([^\/]+)\/([^\/]+)/);
+            if (match) {
+              if (!code[match[1]]) {
+                code[match[1]] = { code: "", format: "" };
+              }
+              if (match[2] === "code" || match[2] === "format") {
+                code[match[1]][match[2] as "code" | "format"] = codeValue as string;
+              }
+            }
+          }
+          result["code"] = code;
+        }
+        if (qualifications) {
+          const qualAttributes = _.pickBy(
+            response.data.component.attributes,
+            (_value: unknown, key: string) => key.startsWith("/qualification"),
+          );
+          const qualifications: NonNullable<GetComponentResult['qualifications']> = {};
+          for (const [path, qualValue] of Object.entries(qualAttributes)) {
+            const match = path.match(/^\/qualification\/([^\/]+)\/([^\/]+)/);
+            if (match) {
+              if (!qualifications[match[1]]) {
+                qualifications[match[1]] = { result: "unknown", message: "" };
+              }
+              if (match[2] === "result") {
+                qualifications[match[1]]["result"] = qualValue as "failure" | "success" | "unknown" | "warning";
+              } else if (match[2] === "message") {
+                qualifications[match[1]]["message"] = qualValue as string;
+              }
+            }
+          }
+          result["qualifications"] = qualifications;
+        }
+        const resourceAttributes = _.pickBy(
+          response.data.component.attributes,
+          (_value: unknown, key: string) => key.startsWith("/resource/"),
+        );
+        const resource: {
+          status?: "ok" | "error" | "warning";
+          resourceData?: unknown;
+          lastSynced?: string;
+        } = {};
+        for (
+          const [path, resourceValue] of Object.entries(resourceAttributes)
+        ) {
+          if (path == "/resource/status") {
+            resource["status"] = resourceValue as "ok" | "error" | "warning";
+          } else if (path == "/resource/payload") {
+            resource["resourceData"] = resourceValue;
+          } else if (path == "/resource/last_synced") {
+            resource["lastSynced"] = resourceValue as string;
+          }
+        }
+        if (!_.isEmpty(resource) && resource.status && resource.lastSynced) {
+          result["resource"] = resource as {
+            status: "ok" | "error" | "warning";
+            lastSynced: string;
+            resourceData?: unknown;
+          };
+        }
+
+        return successResponse(
+          result,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/componentList.ts
+++ b/bin/si-mcp-server/src/tools/componentList.ts
@@ -1,0 +1,143 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import {
+  ChangeSetsApi,
+  ComponentsApi,
+  ComponentsApiListComponentsRequest,
+  Configuration,
+} from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { ChangeSet } from "../data/changeSets.ts";
+
+const name = "component-list";
+const title = "List components";
+const description =
+  `<description>Lists all components. Returns an array of components with componentId, component name, and the schema name. On failure, returns error details</description><usage>Use this tool to understand what components are present in a change set in the workspace, and to find their componentId or schemaName in order to work with them.</usage>`;
+
+const ListComponentsInputSchemaRaw = {
+  changeSetId: z.string().optional().describe(
+    "The change set to look up components in; if not provided, HEAD will be used",
+  ),
+};
+
+const ListComponentsOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.array(
+    z.object({
+      componentId: z.string().describe("the component id"),
+      componentName: z.string().describe("the component name"),
+      schemaName: z.string().describe("the schema name for the component"),
+    }).describe("an individual component"),
+  )
+    .describe("the list of components"),
+};
+const ListComponentsOutputSchema = z.object(
+  ListComponentsOutputSchemaRaw,
+);
+type ListComponents = z.infer<typeof ListComponentsOutputSchema>;
+
+export function componentListTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "componentListResponse",
+        ListComponentsOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: ListComponentsInputSchemaRaw,
+      outputSchema: ListComponentsOutputSchemaRaw,
+    },
+    async ({ changeSetId }): Promise<CallToolResult> => {
+      if (!changeSetId) {
+        const changeSetsApi = new ChangeSetsApi(apiConfig);
+        try {
+          const changeSetList = await changeSetsApi.listChangeSets({
+            workspaceId: WORKSPACE_ID,
+          });
+          const changeSets = changeSetList.data.changeSets as ChangeSet[];
+          const head = changeSets.find((cs) => cs.isHead);
+          if (!head) {
+            return errorResponse({
+              message: "Could not find HEAD change set",
+            });
+          }
+          changeSetId = head.id;
+        } catch (error) {
+          return errorResponse({
+            message:
+              `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+          });
+        }
+      }
+      try {
+        const response = await listAllComponents(apiConfig, changeSetId);
+        return successResponse(
+          response,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}
+
+async function listAllComponents(
+  apiConfig: Configuration,
+  changeSetId: string,
+  cursor?: string,
+  componentList?: Array<ListComponents["data"][number]>,
+): Promise<Array<ListComponents["data"][number]>> {
+  if (!componentList) {
+    componentList = [];
+  }
+  const siApi = new ComponentsApi(apiConfig);
+  let args: ComponentsApiListComponentsRequest;
+  if (cursor) {
+    args = {
+      workspaceId: WORKSPACE_ID,
+      changeSetId: changeSetId,
+      limit: "300",
+      cursor,
+    };
+  } else {
+    args = {
+      workspaceId: WORKSPACE_ID,
+      changeSetId: changeSetId,
+      limit: "300",
+    };
+  }
+
+  const response = await siApi.listComponents(args);
+  for (const component of response.data.componentDetails) {
+    componentList.push({
+      componentId: component.componentId,
+      componentName: component.name,
+      schemaName: component.schemaName,
+    });
+  }
+  if (response.data.nextCursor) {
+    componentList = await listAllComponents(
+      apiConfig,
+      changeSetId,
+      response.data.nextCursor,
+      componentList,
+    );
+  }
+  return componentList;
+}

--- a/bin/si-mcp-server/src/tools/componentUpdate.ts
+++ b/bin/si-mcp-server/src/tools/componentUpdate.ts
@@ -1,0 +1,78 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ComponentsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { AttributesSchema } from "../data/components.ts";
+
+const name = "component-update";
+const title = "Update a component";
+const description =
+  `<description>Update a component for a given componentId. Update only the attributes that need to be changed; existing attributes will remain. Returns the 'success' on successful update. On failure, returns error details. Always break attribute values down to their end path - *always* prefer /domain/Foo/Bar with a value 'Baz' to setting /domain/Foo to the object '{ Bar: baz }'.</description><usage>Use this tool to update a in a change set. Use the schema-find tool to understand the paths that are available for setting attributes. For array attributes, replace the [array] in the schema path with a 0 indexed array position - ensure all array entries are accounted for in order (no gaps). For [map], do the same with the string key for the map. To see all of its information after it has been updated, use the component-get tool.</usage>`;
+
+const UpdateComponentInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to update the component in; components cannot be created on the HEAD change set",
+  ),
+  componentId: z.string().describe("the component id to update"),
+  attributes: AttributesSchema,
+};
+
+const UpdateComponentOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    success: z.boolean().describe("a successful update"),
+  }),
+};
+const UpdateComponentOutputSchema = z.object(
+  UpdateComponentOutputSchemaRaw,
+);
+
+type UpdateComponentResult = z.infer<typeof UpdateComponentOutputSchema>["data"];
+
+export function componentUpdateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "componentCreateResponse",
+        UpdateComponentOutputSchema,
+      ),
+      inputSchema: UpdateComponentInputSchemaRaw,
+      outputSchema: UpdateComponentOutputSchemaRaw,
+    },
+    async ({ changeSetId, attributes, componentId }): Promise<CallToolResult> => {
+      const siApi = new ComponentsApi(apiConfig);
+      try {
+        await siApi.updateComponent({
+          workspaceId: WORKSPACE_ID,
+          changeSetId: changeSetId,
+          componentId,
+          updateComponentV1Request: {
+            attributes,
+          }
+        });
+        const result: UpdateComponentResult = {
+          success: true,
+        };
+
+        return successResponse(
+          result,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}
+

--- a/bin/si-mcp-server/src/tools/funcRunGet.ts
+++ b/bin/si-mcp-server/src/tools/funcRunGet.ts
@@ -1,0 +1,153 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { FuncsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { decodeBase64 } from "@std/encoding/base64";
+
+const name = "func-run-get";
+const title = "Get a function run information";
+const description =
+  `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
+
+const GetFuncRunInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to look up actions in",
+  ),
+  funcRunId: z.string().describe("the func run id to look up"),
+  logs: z.boolean().optional().describe(
+    "the logs for the function run; logs can be very long, and you should only request them when you are sure you need them for analysis.",
+  ),
+  code: z.boolean().optional().describe(
+    "the function body; this can be very long, and you should only request it if you need it for analysis.",
+  ),
+};
+
+const GetFuncRunOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    funcRunId: z.string().describe("the func run id"),
+    funcRunState: z.enum([
+      "Created",
+      "Dispatched",
+      "Killed",
+      "Running",
+      "PostProcessing",
+      "Failure",
+      "Success",
+    ]).describe(
+      "the state of this function execution run. 'Created' is the initial state, but not yet dispatched to the job system. 'Dispatched' means it is send to the job system. 'Killed' means it has been manually stopped during execution. 'Running' means it is currently executing. 'PostProcessing' means the system is taking the results of the function and appying them to System Initiative. 'Failure' means the function execution has failed. 'Success' means the function has run succesfully (but it does not neccessarily mean that it was successful from the user perspective; it only means the function executed without error.",
+    ),
+    componentId: z.string().describe(
+      "the component id this function run was for",
+    ),
+    componentName: z.string().describe(
+      "the component name this function run was for",
+    ),
+    schemaName: z.string().describe(
+      "the schema name of the component this function was for",
+    ),
+    functionName: z.string().describe("the name of the function"),
+    functionKind: z.enum([
+      "Action",
+      "Attribute",
+      "Authentication",
+      "CodeGeneration",
+      "Intrinsic",
+      "Qualification",
+      "SchemaVariantDefinition",
+      "Unknown",
+      "Management",
+    ]).describe(
+      "'Action' means an action function on a component; 'Attribute' means an attribute function on a components attribute; 'CodeGeneration' means a code generation function on a component; 'Intrinsic' means it is not a javascript function, but instead implemented directly by SI; 'Qualification' means a qualification that a component is valid; 'SchemaVariantDefinition' means the typescript that defines the schema for a component; 'Unknown' means a function type that is not yet known to the system; 'Management' means a management function on a component (like import or discover.)",
+    ),
+    args: z.string().describe(
+      "A JSON string representing the arguments passed as input to this function",
+    ),
+    resultValue: z.string().describe(
+      "A JSON string representing the return value of the function",
+    ),
+    logs: z.string().optional().describe(
+      "A string of logs produced by the function; only included if the logs argument to the tool is true",
+    ),
+    code: z.string().optional().describe(
+      "The source code executed for this func run; useful for troubleshooting. Only included if the code argument to the tool is true",
+    ),
+  }).describe("the func run data"),
+};
+const GetFuncRunOutputSchema = z.object(
+  GetFuncRunOutputSchemaRaw,
+);
+
+type FuncRunResult = z.infer<typeof GetFuncRunOutputSchema>["data"];
+
+export function funcRunGetTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "funcRunGetResponse",
+        GetFuncRunOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: GetFuncRunInputSchemaRaw,
+      outputSchema: GetFuncRunOutputSchemaRaw,
+    },
+    async ({ changeSetId, funcRunId, logs, code }): Promise<CallToolResult> => {
+      const siApi = new FuncsApi(apiConfig);
+      try {
+        const response = await siApi.getFuncRun({
+          workspaceId: WORKSPACE_ID,
+          changeSetId: changeSetId,
+          funcRunId: funcRunId,
+        });
+        const result: FuncRunResult = {
+          funcRunId: response.data.funcRun.id,
+          funcRunState: response.data.funcRun
+            .state as FuncRunResult["funcRunState"],
+          componentId: response.data.funcRun.componentId,
+          componentName: response.data.funcRun.componentName,
+          schemaName: response.data.funcRun.schemaName,
+          functionName: response.data.funcRun.functionDisplayName ||
+            response.data.funcRun.functionName,
+          functionKind: response.data.funcRun
+            .functionKind as FuncRunResult["functionKind"],
+          args: JSON.stringify(response.data.funcRun.functionArgs),
+          resultValue: JSON.stringify(response.data.funcRun.resultValue || {}),
+        };
+        if (logs && response.data.funcRun.logs?.logs) {
+          let logOutput = "";
+          for (const logLine of response.data.funcRun.logs.logs) {
+            logOutput += (logLine as { message: string }).message;
+          }
+          result.logs = logOutput;
+        }
+        if (code && response.data.funcRun.functionCodeBase64) {
+          const codeString = decodeBase64(
+            response.data.funcRun.functionCodeBase64,
+          );
+          const textDecoder = new TextDecoder();
+          result.code = textDecoder.decode(codeString);
+        }
+
+        return successResponse(
+          result,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/schemaAttributesDocumentation.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesDocumentation.ts
@@ -1,0 +1,78 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { generateDescription, successResponse } from "./commonBehavior.ts";
+import { getSchemaAttributeDocumentation } from "../data/cfDb.ts";
+
+const name = "schema-attributes-documentation";
+const title = "Schema Attributes Documentation";
+const description =
+  `<description>Look up the documentation for Schema Attributes - you can look up many at once, from multiple schemas at once. Returns an array with the documentation, schemaName, and path attribute (if any). On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to understand how to use a particular attribute, or what values it accepts. Use attribute paths that mirror those returned from the schema-attributes-list tool. In addition, you can ask for the documentation for paths *earlier* than those returned by the attributes-list tool - for example, the tool might return '/domain/Tags/[array]/Key', but the user wants documentation for '/domain/Tags' - both are valid.</usage>`;
+
+const DocumentSchemaAttributesInputSchemaRaw = {
+  documentationToRetrive: z.array(z.object({
+    schemaName: z.string().describe(
+      "The Schema Name to retrieve the attribute documentation for",
+    ),
+    schemaAttributePath: z.string().describe(
+      "The schema attribute path to retrieve documentation for.",
+    ),
+  })).describe(
+    "A list of all the schema names and schema attribute paths to retrieve",
+  ),
+};
+
+const DocumentSchemaAttributesOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.array(
+    z.object({
+      schemaName: z.string().describe("the schema name"),
+      schemaAttributePath: z.string().describe("the schema attribute path"),
+      documentation: z.string().describe("the documentation for the attribute"),
+    }).describe("the documentation for a given schemaAttributePath"),
+  ).describe("an array of documentation"),
+};
+const DocumentSchemaAttributesOutputSchema = z.object(
+  DocumentSchemaAttributesOutputSchemaRaw,
+);
+
+export function schemaAttributesDocumentationTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "schemaAttributesListResponse",
+        DocumentSchemaAttributesOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: DocumentSchemaAttributesInputSchemaRaw,
+      outputSchema: DocumentSchemaAttributesOutputSchemaRaw,
+    },
+    ({ documentationToRetrive }): CallToolResult => {
+      const docs = [];
+      for (const docSpec of documentationToRetrive) {
+        const documentation = getSchemaAttributeDocumentation(
+          docSpec.schemaName,
+          docSpec.schemaAttributePath,
+        );
+        const response = {
+          schemaName: docSpec.schemaName,
+          schemaAttributePath: docSpec.schemaAttributePath,
+          documentation: documentation ||
+            "There is no documentation for this attribute; if it is an AWS schema, consider looking up the data for the corresponding cloudformation resource",
+        };
+        docs.push(response);
+      }
+      return successResponse(
+        docs,
+      );
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/schemaAttributesList.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesList.ts
@@ -1,0 +1,67 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { generateDescription, successResponse } from "./commonBehavior.ts";
+import { getAttributesForService } from "../data/cfDb.ts";
+
+const name = "schema-attributes-list";
+const title = "List all the attributes of a schema";
+const description =
+  `<description>Lists all the attributes of a schema. Returns the schema name and an array of attribute objects that contain the Attribute Name, Path, and if it is Required. On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to discover what attributes (sometimes called properties) are available for a schema.</usage>`;
+
+const ListSchemaAttributesInputSchemaRaw = {
+  schemaName: z.string().describe(
+    "The Schema Name to retrieve the attributes for",
+  ),
+};
+
+const ListSchemaAttributesOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    schemaName: z.string().describe("the schema name"),
+    attributes: z.array(
+      z.object({
+        name: z.string().describe("the attributes name"),
+        path: z.string().describe(
+          "the absolute path of the attribute, which you can use to look up its documentation",
+        ),
+        required: z.boolean().describe("if this attribute is required"),
+      }).describe("an attribute"),
+    ).describe("array of attributes"),
+  }).optional().describe("the schema information"),
+};
+const ListSchemaAttributesOutputSchema = z.object(
+  ListSchemaAttributesOutputSchemaRaw,
+);
+
+export function schemaAttributesListTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "schemaAttributesListResponse",
+        ListSchemaAttributesOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: ListSchemaAttributesInputSchemaRaw,
+      outputSchema: ListSchemaAttributesOutputSchemaRaw,
+    },
+    ({ schemaName }): CallToolResult => {
+      const attributes = getAttributesForService(schemaName);
+      return successResponse(
+        {
+          schemaName,
+          attributes,
+        },
+        "If this is an AWS resource, the attributes map 1:1 to to the Cloudformation resource, where the path is calculated by looking at the Cloudformation resources nesting. You can look up the documentation for any attribute by its schemaName and path with the schema-attributes-documentation tool.",
+      );
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -1,0 +1,142 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ChangeSetsApi, SchemasApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+import { isValid } from "ulid";
+import { getDocumentationForService } from "../data/cfDb.ts";
+
+const name = "schema-find";
+const title = "Find component schemas";
+const description =
+  `<description>Finds component schemas by name or Schema ID. Returns the Schema ID, Name, Description, and external documentation Link. On failure, returns error details. When looking for AWS Schemas, you can use the AWS Cloudformation Resource name (examples: AWS::EC2::Instance, AWS::Bedrock::Agent, or AWS::ControlTower::EnabledBaseline)</description><usage>Use this tool to find if a schema exists in System Initiative, to look up the Schema Name or Schema ID if you need it, or to display high level information about the schema.</usage>`;
+
+const FindSchemaInputSchemaRaw = {
+  changeSetId: z.string().optional().describe(
+    "The change set to look up the schema in; if not provided, HEAD will be used",
+  ),
+  schemaNameOrId: z.string().describe(
+    "The Schema Name or Schema ID to retrieve",
+  ),
+};
+
+const FindSchemaOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    schemaId: z.string().describe("the schema id"),
+    schemaName: z.string().describe("the name of the schema"),
+    description: z.string().optional().describe(
+      "a description of the schema, frequently containing documentation",
+    ),
+    link: z.string().url().optional().describe(
+      "an external URL that contains documentation about what this schema is modeling",
+    ),
+  }).optional().describe("the schema information"),
+};
+const FindSchemaOutputSchema = z.object(
+  FindSchemaOutputSchemaRaw,
+);
+type FindSchemaOutput = z.infer<typeof FindSchemaOutputSchema>;
+
+interface ChangeSetItem {
+  id: string;
+  isHead: boolean;
+  [key: string]: unknown;
+}
+
+export function schemaFindTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "schemaFindResponse",
+        FindSchemaOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: FindSchemaInputSchemaRaw,
+      outputSchema: FindSchemaOutputSchemaRaw,
+    },
+    async ({ changeSetId, schemaNameOrId }): Promise<CallToolResult> => {
+      if (!changeSetId) {
+        const changeSetsApi = new ChangeSetsApi(apiConfig);
+        try {
+          const changeSetList = await changeSetsApi.listChangeSets({
+            workspaceId: WORKSPACE_ID,
+          });
+          const head = (changeSetList.data.changeSets as ChangeSetItem[]).find((
+            cs,
+          ) => cs.isHead);
+          if (!head) {
+            return errorResponse({
+              message:
+                "No HEAD change set found; this is a bug! Tell the user we are sorry.",
+            });
+          }
+          changeSetId = head.id;
+        } catch (error) {
+          const errorMessage = error instanceof Error
+            ? error.message
+            : String(error);
+          return errorResponse({
+            message:
+              `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+          });
+        }
+      }
+      const siApi = new SchemasApi(apiConfig);
+      try {
+        let args: {
+          workspaceId: string;
+          changeSetId: string;
+          schemaId?: string | null;
+          schema?: string | null;
+        };
+
+        if (isValid(schemaNameOrId)) {
+          args = {
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId!,
+            schemaId: schemaNameOrId,
+            schema: null,
+          };
+        } else {
+          args = {
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId!,
+            schema: schemaNameOrId,
+            schemaId: null,
+          };
+        }
+
+        const response = await siApi.findSchema(args);
+        const responseData: NonNullable<FindSchemaOutput["data"]> = {
+          schemaId: response.data.schemaId,
+          schemaName: response.data.schemaName,
+        };
+
+        const docs = getDocumentationForService(responseData.schemaName);
+        responseData.description = docs.description;
+        responseData.link = docs.link;
+
+        return successResponse(
+          responseData,
+          "You can use a web search to find the cloudformation schema",
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/validateCredentials.ts
+++ b/bin/si-mcp-server/src/tools/validateCredentials.ts
@@ -1,0 +1,75 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { WhoamiApi } from "@systeminit/api-client";
+import { apiConfig } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+} from "./commonBehavior.ts";
+
+const description =
+  `<description>Validates System Initiative API credentials and workspace access. Returns information about the user, workspace, and token on success. On failure, returns error details.</description><usage>Use this tool to confirm a working credential, or after an API failure due to authentication, to confirm the credentials are working.</usage>`;
+
+const ValidateCredentialOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    userId: z.string().describe("The SI User Id"),
+    userEmail: z.string().email().describe("The Users Email"),
+    workspaceId: z.string().describe(
+      "The Workspace ID that is valid for this token",
+    ),
+    token: z.object({
+      iat: z.number().describe("The issue time for the token"),
+      exp: z.number().describe("The expiration time for the token"),
+      sub: z.string().describe(
+        "The subject the token was issued for; usually the same as userId",
+      ),
+      jti: z.string(),
+      version: z.string(),
+      userId: z.string().describe("The SI User Id"),
+      workspaceId: z.string().describe(
+        "The Workspace ID that is valid for this token",
+      ),
+      role: z.string().describe(
+        "The role for this token; will be 'automation' if its using an API token",
+      ),
+    }).describe("The decoded JWT token"),
+  }).optional().describe("The response data, populated on success"),
+};
+const ValidateCredentialOutputSchema = z.object(
+  ValidateCredentialOutputSchemaRaw,
+);
+
+export function validateCredentialsTool(server: McpServer) {
+  server.registerTool(
+    "validate-credentials",
+    {
+      title: "Validate credentials with System Initiative",
+      description: generateDescription(
+        description,
+        "validateCredentialsResponse",
+        ValidateCredentialOutputSchema,
+      ),
+      annotations: {
+        readOnlyHint: true,
+      },
+      outputSchema: ValidateCredentialOutputSchemaRaw,
+    },
+    async (): Promise<CallToolResult> => {
+      const siApi = new WhoamiApi(apiConfig);
+      try {
+        const response = await siApi.whoami();
+        return successResponse(
+          response.data,
+        );
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  );
+}

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,8 @@
     "./lib/jsr-systeminit/remove-empty",
     "./lib/jsr-systeminit/ai-agent",
     "./lib/jsr-systeminit/cf-db",
-    "./bin/si-luminork-api-tests"
+    "./bin/si-luminork-api-tests",
+    "./bin/si-mcp-server"
   ],
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",

--- a/deno.lock
+++ b/deno.lock
@@ -1,86 +1,78 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@cliffy/command@^1.0.0-rc.7": "1.0.0-rc.7",
-    "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
-    "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
-    "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
+    "jsr:@cliffy/command@^1.0.0-rc.7": "1.0.0-rc.8",
+    "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/flags@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@deno/cache-dir@0.13.2": "0.13.2",
     "jsr:@deno/emit@0.46": "0.46.0",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
-    "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
-    "jsr:@openai/openai@*": "4.87.3",
-    "jsr:@openai/openai@4": "4.87.3",
-    "jsr:@openai/openai@^4.87.3": "4.87.3",
+    "jsr:@onjara/optic@^2.0.3": "2.0.3",
+    "jsr:@openai/openai@^4.87.3": "4.102.0",
+    "jsr:@std/assert@*": "1.0.13",
     "jsr:@std/assert@0.223": "0.223.0",
-    "jsr:@std/assert@1": "1.0.12",
-    "jsr:@std/assert@^1.0.12": "1.0.12",
+    "jsr:@std/assert@1": "1.0.13",
     "jsr:@std/bytes@0.223": "0.223.0",
-    "jsr:@std/bytes@^1.0.2": "1.0.5",
-    "jsr:@std/encoding@^1.0.5": "1.0.7",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fmt@0.223": "0.223.0",
-    "jsr:@std/fmt@~1.0.2": "1.0.5",
+    "jsr:@std/fmt@^1.0.2": "1.0.8",
+    "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/fs@0.223": "0.223.0",
-    "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/internal@^1.0.6": "1.0.6",
+    "jsr:@std/internal@^1.0.6": "1.0.10",
     "jsr:@std/io@0.223": "0.223.0",
-    "jsr:@std/path@*": "1.0.8",
     "jsr:@std/path@0.223": "0.223.0",
-    "jsr:@std/path@1": "1.0.8",
-    "jsr:@std/path@^1.0.6": "1.0.8",
-    "jsr:@std/text@~1.0.7": "1.0.10",
+    "jsr:@std/path@^1.0.6": "1.1.1",
+    "jsr:@std/text@~1.0.7": "1.0.15",
+    "jsr:@systeminit/api-client@^1.0.3": "1.0.3",
     "jsr:@systeminit/cf-db@~0.1.4": "0.1.4",
     "jsr:@systeminit/remove-empty@0.1.3": "0.1.3",
-    "npm:@apidevtools/json-schema-ref-parser@*": "11.9.1",
     "npm:@apidevtools/json-schema-ref-parser@11.9.3": "11.9.3",
-    "npm:@apidevtools/json-schema-ref-parser@^11.7.3": "11.9.1",
+    "npm:@apidevtools/json-schema-ref-parser@^11.7.3": "11.9.3",
     "npm:@apidevtools/json-schema-ref-parser@^11.9.3": "11.9.3",
     "npm:@hapi/hoek@9.3.0": "9.3.0",
     "npm:@hapi/topo@5.1.0": "5.1.0",
+    "npm:@modelcontextprotocol/sdk@^1.16.0": "1.16.0_express@5.1.0_zod@3.25.76",
     "npm:@sideway/address@4.1.5": "4.1.5",
     "npm:@sideway/formula@3.0.1": "3.0.1",
     "npm:@sideway/pinpoint@2.0.0": "2.0.0",
     "npm:@types/lodash-es@^4.17.12": "4.17.12",
-    "npm:@types/lodash@^4.17.15": "4.17.15",
-    "npm:adze@*": "2.2.0",
+    "npm:@types/lodash@^4.17.15": "4.17.20",
     "npm:adze@2.2.1": "2.2.1",
-    "npm:adze@^2.2.0": "2.2.0",
+    "npm:adze@^2.2.0": "2.2.1",
     "npm:adze@^2.2.1": "2.2.1",
     "npm:argparse@2.0.1": "2.0.1",
+    "npm:axios@^1.6.1": "1.11.0",
     "npm:data-uri-to-buffer@4.0.1": "4.0.1",
     "npm:encoding@0.1.13": "0.1.13",
     "npm:eslint@^8.57.1": "8.57.1",
-    "npm:execa@*": "9.5.2",
-    "npm:fast-json-patch@*": "3.1.1",
     "npm:fast-json-patch@3.1.1": "3.1.1",
     "npm:fetch-blob@3.2.0": "3.2.0",
     "npm:formdata-polyfill@4.0.10": "4.0.10",
-    "npm:gensx@*": "0.3.5",
     "npm:joi@17.13.3": "17.13.3",
-    "npm:js-yaml@*": "4.1.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:json-schema-typed@^8.0.1": "8.0.1",
+    "npm:jwt-decode@4": "4.0.0",
     "npm:lodash-es@4.17.21": "4.17.21",
     "npm:lodash-es@^4.17.21": "4.17.21",
-    "npm:lodash@*": "4.17.21",
     "npm:lodash@4": "4.17.21",
     "npm:lodash@4.17.21": "4.17.21",
     "npm:lodash@^4.17.21": "4.17.21",
     "npm:node-domexception@1.0.0": "1.0.0",
     "npm:node-fetch@2.7.0": "2.7.0_encoding@0.1.13",
-    "npm:openai@^4.85.1": "4.85.2",
-    "npm:pluralize@*": "8.0.0",
-    "npm:toml@*": "3.0.0",
+    "npm:openai@^4.85.1": "4.104.0_zod@3.25.76_encoding@0.1.13",
     "npm:toml@3.0.0": "3.0.0",
     "npm:typescript@^4.9.5": "4.9.5",
+    "npm:ulid@^3.0.1": "3.0.1",
     "npm:web-streams-polyfill@3.3.3": "3.3.3",
-    "npm:zod@*": "3.24.2",
-    "npm:zod@3": "3.24.2",
-    "npm:zod@^3.24.2": "3.24.2"
+    "npm:zod-to-json-schema@^3.24.6": "3.24.6_zod@3.25.76",
+    "npm:zod@3": "3.25.76",
+    "npm:zod@^3.21.4": "3.25.76"
   },
   "jsr": {
-    "@cliffy/command@1.0.0-rc.7": {
-      "integrity": "1288808d7a3cd18b86c24c2f920e47a6d954b7e23cadc35c8cbd78f8be41f0cd",
+    "@cliffy/command@1.0.0-rc.8": {
+      "integrity": "758147790797c74a707e5294cc7285df665422a13d2a483437092ffce40b5557",
       "dependencies": [
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal",
@@ -89,17 +81,17 @@
         "jsr:@std/text"
       ]
     },
-    "@cliffy/flags@1.0.0-rc.7": {
-      "integrity": "318d9be98f6a6417b108e03dec427dea96cdd41a15beb21d2554ae6da450a781",
+    "@cliffy/flags@1.0.0-rc.8": {
+      "integrity": "0f1043ce6ef037ba1cb5fe6b1bcecb25dc2f29371a1c17f278ab0f45e4b6f46c",
       "dependencies": [
         "jsr:@std/text"
       ]
     },
-    "@cliffy/internal@1.0.0-rc.7": {
-      "integrity": "10412636ab3e67517d448be9eaab1b70c88eba9be22617b5d146257a11cc9b17"
+    "@cliffy/internal@1.0.0-rc.8": {
+      "integrity": "34cdf2fad9b084b5aed493b138d573f52d4e988767215f7460daf0b918ff43d8"
     },
-    "@cliffy/table@1.0.0-rc.7": {
-      "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
+    "@cliffy/table@1.0.0-rc.8": {
+      "integrity": "8bbcdc2ba5e0061b4b13810a24e6f5c6ab19c09f0cce9eb691ccd76c7c6c9db5",
       "dependencies": [
         "jsr:@std/fmt@~1.0.2"
       ]
@@ -124,16 +116,15 @@
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
-    "@luca/esbuild-deno-loader@0.11.1": {
-      "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
+    "@onjara/optic@2.0.3": {
+      "integrity": "b4bf8cae0820a3c3f362ba4d78939237fcfa23e3087bbd3f9fd3c883839820f1",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.2",
-        "jsr:@std/encoding",
+        "jsr:@std/fmt@^1.0.2",
         "jsr:@std/path@^1.0.6"
       ]
     },
-    "@openai/openai@4.87.3": {
-      "integrity": "1a5e6008880ce1b38faa83b5e647becaf870a9f23d1bc61d55f703174055e4c6",
+    "@openai/openai@4.102.0": {
+      "integrity": "ea5201bc5c8a696d3a5139a9cd2252e3ab9b2b880769a9cd7f05602ea1a02acf",
       "dependencies": [
         "npm:zod@3"
       ]
@@ -141,47 +132,35 @@
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
     },
-    "@std/assert@1.0.10": {
-      "integrity": "59b5cbac5bd55459a19045d95cc7c2ff787b4f8527c0dd195078ff6f9481fbb3",
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
       "dependencies": [
-        "jsr:@std/internal@^1.0.5"
-      ]
-    },
-    "@std/assert@1.0.12": {
-      "integrity": "08009f0926dda9cbd8bef3a35d3b6a4b964b0ab5c3e140a4e0351fbf34af5b9a",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.6"
+        "jsr:@std/internal"
       ]
     },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
     },
-    "@std/bytes@1.0.5": {
-      "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
-    },
-    "@std/encoding@1.0.7": {
-      "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
     },
-    "@std/fmt@1.0.5": {
-      "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
     "@std/fs@0.223.0": {
       "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
     },
-    "@std/internal@1.0.5": {
-      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
-    },
-    "@std/internal@1.0.6": {
-      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
     },
     "@std/io@0.223.0": {
       "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
       "dependencies": [
         "jsr:@std/assert@0.223",
-        "jsr:@std/bytes@0.223"
+        "jsr:@std/bytes"
       ]
     },
     "@std/path@0.223.0": {
@@ -190,11 +169,17 @@
         "jsr:@std/assert@0.223"
       ]
     },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    "@std/path@1.1.1": {
+      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76"
     },
-    "@std/text@1.0.10": {
-      "integrity": "9dcab377450253c0efa9a9a0c731040bfd4e1c03f8303b5934381467b7954338"
+    "@std/text@1.0.15": {
+      "integrity": "91f5cc1e12779a3d95f1be34e763f9c28a75a078b7360e6fcaef0d8d9b1e3e7f"
+    },
+    "@systeminit/api-client@1.0.3": {
+      "integrity": "a9e05367d618c66dcadf09308452cca73b3bb6a72b71d75ecad8963985adc447",
+      "dependencies": [
+        "npm:axios"
+      ]
     },
     "@systeminit/cf-db@0.1.4": {
       "integrity": "04abaef4707837dad4e252c69dca7e57014dd5038fd323dd1d11868ea1747816",
@@ -212,14 +197,6 @@
     }
   },
   "npm": {
-    "@apidevtools/json-schema-ref-parser@11.9.1": {
-      "integrity": "sha512-OvyhwtYaWSTfo8NfibmFlgl+pIMaBOmN0OwZ3CPaGscEK3B8FCVDuQ7zgxY8seU/1kfSvNWnyB0DtKJyNLxX7g==",
-      "dependencies": [
-        "@jsdevtools/ono",
-        "@types/json-schema",
-        "js-yaml"
-      ]
-    },
     "@apidevtools/json-schema-ref-parser@11.9.3": {
       "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
       "dependencies": [
@@ -228,8 +205,8 @@
         "js-yaml"
       ]
     },
-    "@eslint-community/eslint-utils@4.4.1_eslint@8.57.1": {
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+    "@eslint-community/eslint-utils@4.7.0_eslint@8.57.1": {
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dependencies": [
         "eslint",
         "eslint-visitor-keys"
@@ -254,14 +231,6 @@
     },
     "@eslint/js@8.57.1": {
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="
-    },
-    "@gensx/core@0.3.2": {
-      "integrity": "sha512-qKFzRAzBRZ8IE6SYYBdFQiLgVpn7EI6H1KxnqVNwne8l46O5LJuCWJ89csWHuPpk+p0ilulukYm15IVlDWjAZg==",
-      "dependencies": [
-        "ini",
-        "serialize-error",
-        "zod"
-      ]
     },
     "@hapi/hoek@9.3.0": {
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
@@ -289,6 +258,23 @@
     "@jsdevtools/ono@7.1.3": {
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "@modelcontextprotocol/sdk@1.16.0_express@5.1.0_zod@3.25.76": {
+      "integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
+      "dependencies": [
+        "ajv",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": [
@@ -306,9 +292,6 @@
         "fastq"
       ]
     },
-    "@sec-ant/readable-stream@0.4.1": {
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
-    },
     "@sideway/address@4.1.5": {
       "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
       "dependencies": [
@@ -321,9 +304,6 @@
     "@sideway/pinpoint@2.0.0": {
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "@sindresorhus/merge-streams@4.0.0": {
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
-    },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
@@ -333,26 +313,26 @@
         "@types/lodash"
       ]
     },
-    "@types/lodash@4.17.15": {
-      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw=="
+    "@types/lodash@4.17.20": {
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA=="
     },
     "@types/node-fetch@2.6.12": {
       "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "dependencies": [
-        "@types/node@22.5.4",
+        "@types/node@22.12.0",
         "form-data"
       ]
     },
-    "@types/node@18.19.71": {
-      "integrity": "sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==",
+    "@types/node@18.19.120": {
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
       "dependencies": [
         "undici-types@5.26.5"
       ]
     },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dependencies": [
-        "undici-types@6.19.8"
+        "undici-types@6.20.0"
       ]
     },
     "@ungap/structured-clone@1.2.0": {
@@ -364,22 +344,21 @@
         "event-target-shim"
       ]
     },
-    "acorn-jsx@5.3.2_acorn@8.14.0": {
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types@3.0.1",
+        "negotiator"
+      ]
+    },
+    "acorn-jsx@5.3.2_acorn@8.15.0": {
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dependencies": [
         "acorn"
       ]
     },
-    "acorn@8.14.0": {
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
-    },
-    "adze@2.2.0": {
-      "integrity": "sha512-6QsG6nJajn0Nb2obiCXrv2THuKuERcNwVcKtSp2lalC8/x2jJi0Dv43A/xUnOhLytP7fMNqEswPVt027gXtxpg==",
-      "dependencies": [
-        "@ungap/structured-clone",
-        "date-fns",
-        "picocolors"
-      ]
+    "acorn@8.15.0": {
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "adze@2.2.1": {
       "integrity": "sha512-zTQPl28v/WNEZo4Pmb3HThpYLLTeMuHX3fvC8Aw1CIAHT7nZR5JiqbmE/mB+3qemX4n0ygj+3KfcFpKxLINa/A==",
@@ -404,14 +383,8 @@
         "uri-js"
       ]
     },
-    "ansi-colors@4.1.3": {
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
-    },
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-regex@6.1.0": {
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
     },
     "ansi-styles@4.3.0": {
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -425,20 +398,53 @@
     "asynckit@0.4.0": {
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "axios@1.11.0": {
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dependencies": [
+        "follow-redirects",
+        "form-data",
+        "proxy-from-env"
+      ]
+    },
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "brace-expansion@1.1.11": {
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "body-parser@2.2.0": {
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "brace-expansion@1.1.12": {
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": [
         "balanced-match",
         "concat-map"
       ]
     },
-    "bundle-name@4.1.0": {
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dependencies": [
-        "run-applescript"
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
       ]
     },
     "callsites@3.1.0": {
@@ -450,18 +456,6 @@
         "ansi-styles",
         "supports-color"
       ]
-    },
-    "chalk@5.4.1": {
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
-    },
-    "cli-cursor@5.0.0": {
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dependencies": [
-        "restore-cursor"
-      ]
-    },
-    "cli-spinners@2.9.2": {
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="
     },
     "color-convert@2.0.1": {
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -478,19 +472,35 @@
         "delayed-stream"
       ]
     },
-    "commander@11.1.0": {
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
-    },
     "concat-map@0.0.1": {
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "consola@3.4.0": {
-      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA=="
+    "content-disposition@1.0.0": {
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.5": {
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
     },
     "cross-spawn@7.0.6": {
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": [
-        "path-key@3.1.1",
+        "path-key",
         "shebang-command",
         "which"
       ]
@@ -501,8 +511,8 @@
     "date-fns@3.6.0": {
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
-    "debug@4.4.0": {
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "debug@4.4.1": {
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dependencies": [
         "ms"
       ]
@@ -510,21 +520,11 @@
     "deep-is@0.1.4": {
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
-    "default-browser-id@5.0.0": {
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA=="
-    },
-    "default-browser@5.2.1": {
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-      "dependencies": [
-        "bundle-name",
-        "default-browser-id"
-      ]
-    },
-    "define-lazy-prop@3.0.0": {
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
-    },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "doctrine@3.0.0": {
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
@@ -532,8 +532,19 @@
         "esutils"
       ]
     },
-    "emoji-regex@10.4.0": {
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "encoding@0.1.13": {
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
@@ -541,12 +552,29 @@
         "iconv-lite"
       ]
     },
-    "enquirer@2.4.1": {
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": [
-        "ansi-colors",
-        "strip-ansi@6.0.1"
+        "es-errors"
       ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp@4.0.0": {
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
@@ -573,7 +601,7 @@
         "@nodelib/fs.walk",
         "@ungap/structured-clone",
         "ajv",
-        "chalk@4.1.2",
+        "chalk",
         "cross-spawn",
         "debug",
         "doctrine",
@@ -600,11 +628,11 @@
         "minimatch",
         "natural-compare",
         "optionator",
-        "strip-ansi@6.0.1",
+        "strip-ansi",
         "text-table"
       ]
     },
-    "espree@9.6.1_acorn@8.14.0": {
+    "espree@9.6.1_acorn@8.15.0": {
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dependencies": [
         "acorn",
@@ -630,24 +658,57 @@
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
     "event-target-shim@5.0.1": {
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
-    "execa@9.5.2": {
-      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+    "eventsource-parser@3.0.3": {
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dependencies": [
-        "@sindresorhus/merge-streams",
-        "cross-spawn",
-        "figures",
-        "get-stream",
-        "human-signals",
-        "is-plain-obj",
-        "is-stream",
-        "npm-run-path",
-        "pretty-ms",
-        "signal-exit",
-        "strip-final-newline",
-        "yoctocolors"
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@7.5.1_express@5.1.0": {
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "dependencies": [
+        "express"
+      ]
+    },
+    "express@5.1.0": {
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types@3.0.1",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses@2.0.2",
+        "type-is",
+        "vary"
       ]
     },
     "fast-deep-equal@3.1.3": {
@@ -662,8 +723,8 @@
     "fast-levenshtein@2.0.6": {
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "fastq@1.19.0": {
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+    "fastq@1.19.1": {
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dependencies": [
         "reusify"
       ]
@@ -675,16 +736,21 @@
         "web-streams-polyfill@3.3.3"
       ]
     },
-    "figures@6.1.0": {
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dependencies": [
-        "is-unicode-supported@2.1.0"
-      ]
-    },
     "file-entry-cache@6.0.1": {
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dependencies": [
         "flat-cache"
+      ]
+    },
+    "finalhandler@2.1.0": {
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses@2.0.2"
       ]
     },
     "find-up@5.0.0": {
@@ -702,18 +768,23 @@
         "rimraf"
       ]
     },
-    "flatted@3.3.2": {
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
+    "flatted@3.3.3": {
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
+    },
+    "follow-redirects@1.15.9": {
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "form-data-encoder@1.7.2": {
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
     },
-    "form-data@4.0.1": {
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+    "form-data@4.0.4": {
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": [
         "asynckit",
         "combined-stream",
-        "mime-types"
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types@2.1.35"
       ]
     },
     "formdata-node@4.4.1": {
@@ -729,30 +800,38 @@
         "fetch-blob"
       ]
     },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
     "fs.realpath@1.0.0": {
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "gensx@0.3.5": {
-      "integrity": "sha512-j3bicq4+gjqhLh2UE580u9r7i6OW3eH4VqWgsvRcY+kYMJp4jS12Z/fcvOkIcPKFDHsnEFfN+Al8rkDUMJAazQ==",
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": [
-        "@gensx/core",
-        "commander",
-        "consola",
-        "enquirer",
-        "ini",
-        "open",
-        "ora",
-        "picocolors"
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
       ]
     },
-    "get-east-asian-width@1.3.0": {
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="
-    },
-    "get-stream@9.0.1": {
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dependencies": [
-        "@sec-ant/readable-stream",
-        "is-stream"
+        "dunder-proto",
+        "es-object-atoms"
       ]
     },
     "glob-parent@6.0.2": {
@@ -775,8 +854,11 @@
     "globals@13.24.0": {
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dependencies": [
-        "type-fest@0.20.2"
+        "type-fest"
       ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "graphemer@1.4.0": {
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
@@ -784,8 +866,30 @@
     "has-flag@4.0.0": {
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
-    "human-signals@8.0.0": {
-      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA=="
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "http-errors@2.0.0": {
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses@2.0.1",
+        "toidentifier"
+      ]
     },
     "humanize-ms@1.2.1": {
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
@@ -822,11 +926,8 @@
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ini@5.0.0": {
-      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw=="
-    },
-    "is-docker@3.0.0": {
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-extglob@2.1.1": {
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
@@ -837,35 +938,11 @@
         "is-extglob"
       ]
     },
-    "is-inside-container@1.0.0": {
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dependencies": [
-        "is-docker"
-      ]
-    },
-    "is-interactive@2.0.0": {
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
-    },
     "is-path-inside@3.0.3": {
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
     },
-    "is-plain-obj@4.1.0": {
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
-    },
-    "is-stream@4.0.1": {
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
-    },
-    "is-unicode-supported@1.3.0": {
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
-    },
-    "is-unicode-supported@2.1.0": {
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
-    },
-    "is-wsl@3.1.0": {
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dependencies": [
-        "is-inside-container"
-      ]
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
@@ -898,6 +975,9 @@
     "json-stable-stringify-without-jsonify@1.0.1": {
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
+    "jwt-decode@4.0.0": {
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
+    },
     "keyv@4.5.4": {
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": [
@@ -926,24 +1006,32 @@
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "log-symbols@6.0.0": {
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-      "dependencies": [
-        "chalk@5.4.1",
-        "is-unicode-supported@1.3.0"
-      ]
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
     },
     "mime-db@1.52.0": {
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
     "mime-types@2.1.35": {
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": [
-        "mime-db"
+        "mime-db@1.52.0"
       ]
     },
-    "mimic-function@5.0.1": {
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="
+    "mime-types@3.0.1": {
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": [
+        "mime-db@1.54.0"
+      ]
     },
     "minimatch@3.1.2": {
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
@@ -957,14 +1045,11 @@
     "natural-compare@1.4.0": {
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
     "node-domexception@1.0.0": {
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch@2.7.0": {
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": [
-        "whatwg-url"
-      ]
     },
     "node-fetch@2.7.0_encoding@0.1.13": {
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -973,11 +1058,16 @@
         "whatwg-url"
       ]
     },
-    "npm-run-path@6.0.0": {
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dependencies": [
-        "path-key@4.0.0",
-        "unicorn-magic"
+        "ee-first"
       ]
     },
     "once@1.4.0": {
@@ -986,31 +1076,17 @@
         "wrappy"
       ]
     },
-    "onetime@7.0.0": {
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+    "openai@4.104.0_zod@3.25.76_encoding@0.1.13": {
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "dependencies": [
-        "mimic-function"
-      ]
-    },
-    "open@10.1.0": {
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
-      "dependencies": [
-        "default-browser",
-        "define-lazy-prop",
-        "is-inside-container",
-        "is-wsl"
-      ]
-    },
-    "openai@4.85.2": {
-      "integrity": "sha512-ZQg3Q+K4A6M9dLFh5W36paZkZBQO+VbxMNJ1gUSyHsGiEWuXahdn02ermqNV68LhWQxdJQaWUFRAYpW/suTPWQ==",
-      "dependencies": [
-        "@types/node@18.19.71",
         "@types/node-fetch",
+        "@types/node@18.19.120",
         "abort-controller",
         "agentkeepalive",
         "form-data-encoder",
         "formdata-node",
-        "node-fetch@2.7.0"
+        "node-fetch",
+        "zod"
       ]
     },
     "optionator@0.9.4": {
@@ -1022,20 +1098,6 @@
         "prelude-ls",
         "type-check",
         "word-wrap"
-      ]
-    },
-    "ora@8.2.0": {
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-      "dependencies": [
-        "chalk@5.4.1",
-        "cli-cursor",
-        "cli-spinners",
-        "is-interactive",
-        "is-unicode-supported@2.1.0",
-        "log-symbols",
-        "stdin-discarder",
-        "string-width",
-        "strip-ansi@7.1.0"
       ]
     },
     "p-limit@3.1.0": {
@@ -1056,8 +1118,8 @@
         "callsites"
       ]
     },
-    "parse-ms@4.0.0": {
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-exists@4.0.0": {
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
@@ -1068,42 +1130,57 @@
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
-    "path-key@4.0.0": {
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+    "path-to-regexp@8.2.0": {
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
     },
     "picocolors@1.1.1": {
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
-    "pluralize@8.0.0": {
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    "pkce-challenge@5.0.0": {
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="
     },
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
-    "pretty-ms@9.2.0": {
-      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dependencies": [
-        "parse-ms"
+        "forwarded",
+        "ipaddr.js"
       ]
+    },
+    "proxy-from-env@1.1.0": {
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
+    "qs@6.14.0": {
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
     "queue-microtask@1.2.3": {
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.0": {
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
     },
     "resolve-from@4.0.0": {
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
-    "restore-cursor@5.1.0": {
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dependencies": [
-        "onetime",
-        "signal-exit"
-      ]
-    },
-    "reusify@1.0.4": {
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    "reusify@1.1.0": {
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
     },
     "rimraf@3.0.2": {
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
@@ -1111,8 +1188,15 @@
         "glob"
       ]
     },
-    "run-applescript@7.0.0": {
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
     },
     "run-parallel@1.2.0": {
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
@@ -1120,14 +1204,39 @@
         "queue-microtask"
       ]
     },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "serialize-error@12.0.0": {
-      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+    "send@1.2.0": {
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "dependencies": [
-        "type-fest@4.37.0"
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types@3.0.1",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses@2.0.2"
       ]
+    },
+    "serve-static@2.2.0": {
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "shebang-command@2.0.0": {
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
@@ -1138,34 +1247,53 @@
     "shebang-regex@3.0.0": {
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
-    "signal-exit@4.1.0": {
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    },
-    "stdin-discarder@0.2.2": {
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="
-    },
-    "string-width@7.2.0": {
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+    "side-channel-list@1.0.0": {
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dependencies": [
-        "emoji-regex",
-        "get-east-asian-width",
-        "strip-ansi@7.1.0"
+        "es-errors",
+        "object-inspect"
       ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
+      ]
+    },
+    "statuses@2.0.1": {
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
     "strip-ansi@6.0.1": {
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": [
-        "ansi-regex@5.0.1"
+        "ansi-regex"
       ]
-    },
-    "strip-ansi@7.1.0": {
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dependencies": [
-        "ansi-regex@6.1.0"
-      ]
-    },
-    "strip-final-newline@4.0.0": {
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
     },
     "strip-json-comments@3.1.1": {
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
@@ -1178,6 +1306,9 @@
     },
     "text-table@0.2.0": {
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "toml@3.0.0": {
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
@@ -1194,26 +1325,37 @@
     "type-fest@0.20.2": {
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
-    "type-fest@4.37.0": {
-      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg=="
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types@3.0.1"
+      ]
     },
     "typescript@4.9.5": {
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
+    "ulid@3.0.1": {
+      "integrity": "sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q=="
+    },
     "undici-types@5.26.5": {
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
-    "undici-types@6.19.8": {
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
-    "unicorn-magic@0.3.0": {
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "uri-js@4.4.1": {
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": [
         "punycode"
       ]
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "web-streams-polyfill@3.3.3": {
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
@@ -1246,26 +1388,19 @@
     "yocto-queue@0.1.0": {
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
-    "yoctocolors@2.1.1": {
-      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="
+    "zod-to-json-schema@3.24.6_zod@3.25.76": {
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "dependencies": [
+        "zod"
+      ]
     },
-    "zod@3.24.2": {
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
   "redirects": {
-    "https://deno.land/std/dotenv/mod.ts": "https://deno.land/std@0.224.0/dotenv/mod.ts",
-    "https://deno.land/std/path/mod.ts": "https://deno.land/std@0.224.0/path/mod.ts",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/applyToDefaults?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/applyToDefaults?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.0.0/lib/assert?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/assert?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/clone?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/clone?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/deepEqual?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/deepEqual?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/error?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/error?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/escapeHtml?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/escapeHtml?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.0.0/lib/escapeRegex?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/escapeRegex?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/ignore?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/ignore?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/merge?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/merge?target=denonext",
-    "https://esm.sh/@hapi/hoek@^9.0.0/lib/reach?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/reach?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.3.0/lib/applyToDefaults?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/applyToDefaults?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.3.0/lib/assert?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/assert?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.3.0/lib/clone?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/clone?target=denonext",
@@ -1276,13 +1411,7 @@
     "https://esm.sh/@hapi/hoek@^9.3.0/lib/ignore?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/ignore?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.3.0/lib/merge?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/merge?target=denonext",
     "https://esm.sh/@hapi/hoek@^9.3.0/lib/reach?target=denonext": "https://esm.sh/@hapi/hoek@9.3.0/lib/reach?target=denonext",
-    "https://esm.sh/@hapi/topo@^5.0.0?target=denonext": "https://esm.sh/@hapi/topo@5.1.0?target=denonext",
     "https://esm.sh/@hapi/topo@^5.1.0?target=denonext": "https://esm.sh/@hapi/topo@5.1.0?target=denonext",
-    "https://esm.sh/@sideway/address@^4.1.3/lib/domain?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/domain?target=denonext",
-    "https://esm.sh/@sideway/address@^4.1.3/lib/email?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/email?target=denonext",
-    "https://esm.sh/@sideway/address@^4.1.3/lib/ip?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/ip?target=denonext",
-    "https://esm.sh/@sideway/address@^4.1.3/lib/tlds?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/tlds?target=denonext",
-    "https://esm.sh/@sideway/address@^4.1.3/lib/uri?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/uri?target=denonext",
     "https://esm.sh/@sideway/address@^4.1.5/lib/domain?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/domain?target=denonext",
     "https://esm.sh/@sideway/address@^4.1.5/lib/email?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/email?target=denonext",
     "https://esm.sh/@sideway/address@^4.1.5/lib/ip?target=denonext": "https://esm.sh/@sideway/address@4.1.5/lib/ip?target=denonext",
@@ -1293,47 +1422,8 @@
     "https://esm.sh/isexe@^3.1.1?target=denonext": "https://esm.sh/isexe@3.1.1?target=denonext"
   },
   "remote": {
-    "https://deno.land/std@0.220.1/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
-    "https://deno.land/std@0.220.1/assert/_diff.ts": "4bf42969aa8b1a33aaf23eb8e478b011bfaa31b82d85d2ff4b5c4662d8780d2b",
-    "https://deno.land/std@0.220.1/assert/_format.ts": "0ba808961bf678437fb486b56405b6fefad2cf87b5809667c781ddee8c32aff4",
-    "https://deno.land/std@0.220.1/assert/assert.ts": "bec068b2fccdd434c138a555b19a2c2393b71dfaada02b7d568a01541e67cdc5",
-    "https://deno.land/std@0.220.1/assert/assert_almost_equals.ts": "8b96b7385cc117668b0720115eb6ee73d04c9bcb2f5d2344d674918c9113688f",
-    "https://deno.land/std@0.220.1/assert/assert_array_includes.ts": "1688d76317fd45b7e93ef9e2765f112fdf2b7c9821016cdfb380b9445374aed1",
-    "https://deno.land/std@0.220.1/assert/assert_equals.ts": "4497c56fe7d2993b0d447926702802fc0becb44e319079e8eca39b482ee01b4e",
-    "https://deno.land/std@0.220.1/assert/assert_exists.ts": "24a7bf965e634f909242cd09fbaf38bde6b791128ece08e33ab08586a7cc55c9",
-    "https://deno.land/std@0.220.1/assert/assert_false.ts": "6f382568e5128c0f855e5f7dbda8624c1ed9af4fcc33ef4a9afeeedcdce99769",
-    "https://deno.land/std@0.220.1/assert/assert_greater.ts": "4945cf5729f1a38874d7e589e0fe5cc5cd5abe5573ca2ddca9d3791aa891856c",
-    "https://deno.land/std@0.220.1/assert/assert_greater_or_equal.ts": "573ed8823283b8d94b7443eb69a849a3c369a8eb9666b2d1db50c33763a5d219",
-    "https://deno.land/std@0.220.1/assert/assert_instance_of.ts": "72dc1faff1e248692d873c89382fa1579dd7b53b56d52f37f9874a75b11ba444",
-    "https://deno.land/std@0.220.1/assert/assert_is_error.ts": "6596f2b5ba89ba2fe9b074f75e9318cda97a2381e59d476812e30077fbdb6ed2",
-    "https://deno.land/std@0.220.1/assert/assert_less.ts": "2b4b3fe7910f65f7be52212f19c3977ecb8ba5b2d6d0a296c83cde42920bb005",
-    "https://deno.land/std@0.220.1/assert/assert_less_or_equal.ts": "b93d212fe669fbde959e35b3437ac9a4468f2e6b77377e7b6ea2cfdd825d38a0",
-    "https://deno.land/std@0.220.1/assert/assert_match.ts": "ec2d9680ed3e7b9746ec57ec923a17eef6d476202f339ad91d22277d7f1d16e1",
-    "https://deno.land/std@0.220.1/assert/assert_not_equals.ts": "ac86413ab70ffb14fdfc41740ba579a983fe355ba0ce4a9ab685e6b8e7f6a250",
-    "https://deno.land/std@0.220.1/assert/assert_not_instance_of.ts": "8f720d92d83775c40b2542a8d76c60c2d4aeddaf8713c8d11df8984af2604931",
-    "https://deno.land/std@0.220.1/assert/assert_not_match.ts": "b4b7c77f146963e2b673c1ce4846473703409eb93f5ab0eb60f6e6f8aeffe39f",
-    "https://deno.land/std@0.220.1/assert/assert_not_strict_equals.ts": "da0b8ab60a45d5a9371088378e5313f624799470c3b54c76e8b8abeec40a77be",
-    "https://deno.land/std@0.220.1/assert/assert_object_match.ts": "e85e5eef62a56ce364c3afdd27978ccab979288a3e772e6855c270a7b118fa49",
-    "https://deno.land/std@0.220.1/assert/assert_rejects.ts": "5206ac37d883797d9504e3915a0c7b692df6efcdefff3889cc14bb5a325641dd",
-    "https://deno.land/std@0.220.1/assert/assert_strict_equals.ts": "0425a98f70badccb151644c902384c12771a93e65f8ff610244b8147b03a2366",
-    "https://deno.land/std@0.220.1/assert/assert_string_includes.ts": "dfb072a890167146f8e5bdd6fde887ce4657098e9f71f12716ef37f35fb6f4a7",
-    "https://deno.land/std@0.220.1/assert/assert_throws.ts": "31f3c061338aec2c2c33731973d58ccd4f14e42f355501541409ee958d2eb8e5",
-    "https://deno.land/std@0.220.1/assert/assertion_error.ts": "9f689a101ee586c4ce92f52fa7ddd362e86434ffdf1f848e45987dc7689976b8",
-    "https://deno.land/std@0.220.1/assert/equal.ts": "fae5e8a52a11d3ac694bbe1a53e13a7969e3f60791262312e91a3e741ae519e2",
-    "https://deno.land/std@0.220.1/assert/fail.ts": "f310e51992bac8e54f5fd8e44d098638434b2edb802383690e0d7a9be1979f1c",
-    "https://deno.land/std@0.220.1/assert/mod.ts": "7e41449e77a31fef91534379716971bebcfc12686e143d38ada5438e04d4a90e",
-    "https://deno.land/std@0.220.1/assert/unimplemented.ts": "47ca67d1c6dc53abd0bd729b71a31e0825fc452dbcd4fde4ca06789d5644e7fd",
-    "https://deno.land/std@0.220.1/assert/unreachable.ts": "3670816a4ab3214349acb6730e3e6f5299021234657eefe05b48092f3848c270",
-    "https://deno.land/std@0.220.1/dotenv/mod.ts": "0180eaeedaaf88647318811cdaa418cc64dc51fb08354f91f5f480d0a1309f7d",
-    "https://deno.land/std@0.220.1/dotenv/parse.ts": "09977ff88dfd1f24f9973a338f0f91bbdb9307eb5ff6085446e7c423e4c7ba0c",
-    "https://deno.land/std@0.220.1/dotenv/stringify.ts": "0047ad7068289735d08964046aea267a750c141b494ca0e38831b89be6c020c2",
-    "https://deno.land/std@0.220.1/flags/mod.ts": "9f13f3a49c54618277ac49195af934f1c7d235731bcf80fd33b8b234e6839ce9",
-    "https://deno.land/std@0.220.1/fmt/colors.ts": "d239d84620b921ea520125d778947881f62c50e78deef2657073840b8af9559a",
     "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
     "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
-    "https://deno.land/std@0.224.0/dotenv/mod.ts": "0180eaeedaaf88647318811cdaa418cc64dc51fb08354f91f5f480d0a1309f7d",
-    "https://deno.land/std@0.224.0/dotenv/parse.ts": "09977ff88dfd1f24f9973a338f0f91bbdb9307eb5ff6085446e7c423e4c7ba0c",
-    "https://deno.land/std@0.224.0/dotenv/stringify.ts": "275da322c409170160440836342eaa7cf012a1d11a7e700d8ca4e7f2f8aa4615",
     "https://deno.land/std@0.224.0/path/_common/assert_path.ts": "dbdd757a465b690b2cc72fc5fb7698c51507dec6bfafce4ca500c46b76ff7bd8",
     "https://deno.land/std@0.224.0/path/_common/basename.ts": "569744855bc8445f3a56087fd2aed56bdad39da971a8d92b138c9913aecc5fa2",
     "https://deno.land/std@0.224.0/path/_common/common.ts": "ef73c2860694775fe8ffcbcdd387f9f97c7a656febf0daa8c73b56f4d8a7bd4c",
@@ -1411,652 +1501,6 @@
     "https://deno.land/std@0.224.0/path/windows/resolve.ts": "8dae1dadfed9d46ff46cc337c9525c0c7d959fb400a6308f34595c45bdca1972",
     "https://deno.land/std@0.224.0/path/windows/to_file_url.ts": "40e560ee4854fe5a3d4d12976cef2f4e8914125c81b11f1108e127934ced502e",
     "https://deno.land/std@0.224.0/path/windows/to_namespaced_path.ts": "4ffa4fb6fae321448d5fe810b3ca741d84df4d7897e61ee29be961a6aac89a4c",
-    "https://deno.land/x/denoflate@1.2.1/mod.ts": "f5628e44b80b3d80ed525afa2ba0f12408e3849db817d47a883b801f9ce69dd6",
-    "https://deno.land/x/denoflate@1.2.1/pkg/denoflate.js": "b9f9ad9457d3f12f28b1fb35c555f57443427f74decb403113d67364e4f2caf4",
-    "https://deno.land/x/denoflate@1.2.1/pkg/denoflate_bg.wasm.js": "d581956245407a2115a3d7e8d85a9641c032940a8e810acbd59ca86afd34d44d",
-    "https://deno.land/x/esbuild@v0.20.0/mod.js": "5c6fc2e98424ced3a4159c2f267c6bc62b49906e9dc86f724b3d88a482c55c70",
-    "https://deno.land/x/json_schema_typed@v8.0.0/draft_07.ts": "1d8a7c80be7b9dd80c583e471fdfec5be526a9b039d1753a9c0f9aa2e8da8be5",
-    "https://deno.land/x/lodash_es@v0.0.2/lodash.default.js": "6a5a423bd9cdaf45ab289c16ac9ecb579058fb2bc97873c879d8e228e51084da",
-    "https://deno.land/x/lodash_es@v0.0.2/mod.ts": "4a1af2b6110e49d3f388d2e81a9d7269b341bd066ea2e8120bc0397de98958fa",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_DataView.js": "0c4811491cd0c415553118f42f9b31112ed58bdb3941358a99deec9347e7a829",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Hash.js": "7221393e8931adc88430d3badefee1568ffccf91a6efcd9dda2be498f4a09551",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_LazyWrapper.js": "77e63978b95b1b1dd6d0d8c58eadeab22a58e00e50491b9dccdc285f7a7ab2d0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_ListCache.js": "a8c13a041707d9c96eff21d95a78326b6e2af12b067527bcba22108ce15b600c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_LodashWrapper.js": "b170f31ce90cc1c9b767295c6f32975b7d7f109c332297007bbb5bd1c64e61f8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Map.js": "014aa839395eedfb215d1a994754db6716ba8c65ff3945b986270a4743b269bb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_MapCache.js": "fd27ffa20196943af9cbb4694555582d3045fff54b6f808269e4d3a645c3d886",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Promise.js": "55c26a3a24e9f2e6158d36fdeec3b34d59d9f9be08e415a7f50936429595c656",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Set.js": "84d53490631612489f33e3a4a9199f22c853e58b337aa1e10408e63d5129e216",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_SetCache.js": "0dd677f901228955ec136fb35bb20c4a8dbc4c1ef63649298a29b7b0958b9b07",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Stack.js": "391b608ace36e0845f917ab7a5bbaab07930f9ad8b570849857ed564a0ec3a76",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Symbol.js": "631160c3c0cbd05ec8a3d1934ded4a312504a29f04a00be2b29372d00dd6bc6d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_Uint8Array.js": "0181e8a163773e63ca1c366a134df3306c5fec28f487beb326b6bb92113d619d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_WeakMap.js": "1248b893bd82f38179e2ac6df0ff2fa8daf5e5becd11b55d8b2073a5eaab3f47",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_apply.js": "b2e6d04f093a956feef2d826cba78dab35ea1e87e8fdf7f905120adbc0bd134e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayAggregator.js": "2d7486df7ca61784cc1baccb1486f1783e38f75d7b017a941e96e945efdaac2c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayEach.js": "cfbf3667657e0f260600a9aa9359a8bde73a9241df474f77f17c06cd9fe76b4d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayEachRight.js": "0b94862cdcf0a1e25e50133d86be315a22d7c7dbf4170f5215004d95353214a9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayEvery.js": "a755d6c94351ba2979ad532d2ebb4d1d27b1b58b49bd53b9190d580fd00bfe17",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayFilter.js": "46a23fd1969903486b620f5de048c9347f24863f13416db0a632de56cc78b479",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayIncludes.js": "f1ffc64a01e957c2bcec10f0682c73deab068b55b7c55953ec47df32256107bc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayIncludesWith.js": "0f9eb5b700c04043dc9e9fb752b46386dd02eada3cdf714f65cdbbe55371353f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayLikeKeys.js": "c441c2b158f992a5dd14bae0b35d20c3ec25a8a5b6cd439e1be0b1764e831612",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayMap.js": "ae3521733bd602f0f0443562ca13d3d1c8f42e130d4d4b0deacd931b68b0c60b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayPush.js": "ef2cb71a84885b726882f9664e3c2078279012ba7b220935b7e7390d85d89288",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayReduce.js": "b7fcb5405eac2c287eb90230995a5ba9e13e36933af3ad40dc84a29c364fbb7e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayReduceRight.js": "0c590017c353aa017507a481551f175dd7fe52049116d6501fbad4af0861e112",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arraySample.js": "820e2fc1f8615b8b4e32674082f11ad23228103df96b61a938832fe4ff64562e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arraySampleSize.js": "1afaa5ad8b0370c0c7baf14be4639e1b1f41854bb39d17124b3306fe8ffb5820",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arrayShuffle.js": "94d9119ef856d71e28f5ad65b0ac2e8fa85b01ecbd0a4b2a20e43fcb03dbdfe1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_arraySome.js": "0b50b5e018eabcb2a0b041bc02b5ae0c8d1f16914f94f376ecaf7f887cbd3aa3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_asciiSize.js": "cb2cd50ccfcc10187a4cc383914c0f811f5155532b080209a5fe65041867360c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_asciiToArray.js": "31d8d3eea65375a5b9e280e0a23ef2a4f9eff022119d5b7ed338b925ebd58780",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_asciiWords.js": "598a889963843093438d7453d71e09f759c9fefe1a731bbf87ecadc569272a9a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_assignMergeValue.js": "9018dc11f6fe776f0d6ffa27ec31107552bb1f0ac4f7424db1e1011532bc2c14",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_assignValue.js": "30c56330342d8af0405b9a113f73232fb6fc748a4177787d2b61d1a894cefdf9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_assocIndexOf.js": "b34ff3bbc5cf630e9ea1103eacd7bfcc208347a6b616398e515c7aee821bf8a4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseAggregator.js": "19dd907b3e48d1ab28a893a83d05f0e5133996f5fd18a1301dddb42a01031124",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseAssign.js": "1cce8f5275323ec54e7cc5539e260b8730606c16a14f56de7a815d46ef046297",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseAssignIn.js": "d5e10d50ae24b20e36ecb2c7596ba0ac50431e7a19d75d270b896be3257f1e24",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseAssignValue.js": "fc102066006ab1aa06bf1ed8329c64804b8c61c616840f0739031aafc009fb91",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseAt.js": "d2deadcb558f9024d1871e8d34e8dd6520ded3f738b03d1f4ef85d3798727ca1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseClamp.js": "012ba26308b2ffd9b2f92f20b1894962f6417a98747db968e328c2b76897f3f3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseClone.js": "69d03c7e6fb31a642cd17ae233aa926c4a30538d97562c86d599c6fba95d7603",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseConforms.js": "b0f75057d241513ddfe0ad8391bd87adea5b0fbb40e277effd456893584711bf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseConformsTo.js": "38fbe5fe3b942d5d26b37ef2352e7a619d760f93dffd67b0b9bb77799d0c076c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseCreate.js": "d2298952b6832fe420556a324428d247ae04540a564bf95d30f4e1bd7370a668",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseDelay.js": "38e3669c558a916c724bd4326945a19ecbcc3951c7aef7f76e8b122e78263b8b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseDifference.js": "5bc2ada6f0f5d5f3f3a7a87c6d8878a7fde32768589ea0191b5c36e09e4e4995",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseEach.js": "c18c9d3f90c8ca7f3ede215ea69de5a28dac956f06451fed7cd58876cdbbb6f7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseEachRight.js": "5dd6fcf90252fea5842ad059663d01ad0aaaff972301f9aee5dbe6614ce11573",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseEvery.js": "d1c6ce4ef6c3a179374de1863eb102a406637ece2149616bdd938ffb8462768c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseExtremum.js": "3c590121012aaa9cbbc7de9507fa98d285bd7158cc7e3edb804c35610cffbed7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFill.js": "ed23def9d8bbfcb3192ea4d54dcaa3f655f3cbf6764da765e9d01025014c239a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFilter.js": "d80e6bae72ad15a58bcd36a79d783deff5cb6e541f9c377de4a8951e27fabcc0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFindIndex.js": "0d058c13978446de75c58e8716d59f7c4f886990100534aa40b9b7cf2ae408dd",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFindKey.js": "f20b3869cf1c3475eb999e591d45ad5d1a7503174315ad8c508642f1a4ca8203",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFlatten.js": "01a8f6924b9b3ae4765c6e5f2e064c1ef064d2055bff5d95045f0736e1097b81",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFor.js": "171c18eca21431b2067189679bcfb5087463a64c071087b9511e9fcc67acadff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseForOwn.js": "18d20c10eae085e80846477a65fa026bac516b447c5446a8e0f48c5a90c8a67e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseForOwnRight.js": "eff6100dde7a64a7a6e804112b6f97cfdb12043076fd86dcf9c8ced6b7d53274",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseForRight.js": "0622c36eb92a1264023940a211535550749f9262e9de27474105803cccf71803",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseFunctions.js": "5af9947df65c62848827a5b6bd6342be6106872356605d77fa5f9ca645d5a34a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseGet.js": "76ec9e50af57d35f9738d3fd9ec1b91dd63e9854381b397b8a41f1462c8e029d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseGetAllKeys.js": "45f92029359aaddc01b6aaf58370ba554430f141d1ff8879f6ef829c03ed4e44",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseGetTag.js": "3a9eebe37ba231eff0380b5f76ac5b5fcee4590665642fd052d77aa51c7d063f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseGt.js": "cc4d6cfd9da71ee5868545c5274806eadb8ca0b266ea7f08587da05f673797e9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseHas.js": "9b08b441a68a0fb9133a056f639219eca13ac301f0f6814ab2a4401a9442cd45",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseHasIn.js": "caff1788e232528fe29da4ceb0e07e064a2ac3d4e893ff0465a4d3013765360f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseInRange.js": "d1b3021ee550521ec85040238584f5a927cd18b4784ffa96a6e9f66cdcc50c6a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIndexOf.js": "2828587465acb419fb570f0241e9f4da2bf031ce20617451648907e6410d320a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIndexOfWith.js": "c564120a31b17efeee1452117e1395a307189ae5cc09997639b23ec8e4ccabfb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIntersection.js": "91185d9c6a2c28c515d452ac0f177a172cdf01da8d3177760921b0b357600207",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseInverter.js": "61040337845c51112eece21c8c3fa65b60dbe96f30aa3a2c6d86ce149fec9fc9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseInvoke.js": "e6247121f0bff0cbd8bbafae3ae2b2760c577deddac35e7b3625e3014eabad1b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsArguments.js": "8cc4e523affa6237c8177cd7cb038ede5e6778deaf3fa9c052f3e416840e0334",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsArrayBuffer.js": "52a3689c985bb974b544992a571efde6b84033e68b715dc091face274f737fe6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsDate.js": "684cef60ed48ab597e1920b30e78a11649c016858b2c8dfeee66be5a9c2d3c05",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsEqual.js": "332f33381628ed8c9849cb3e218d0e7122d47a736fea46f7abe76c1ef6904469",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsEqualDeep.js": "64174049ab03796b0cf775075cadbf74ddbc7d5bb80c10835117417375c16528",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsMap.js": "1c0b6aa98f5a9b4b21c56aaad2e662b8f3c7c483592a964e514443424d1d4493",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsMatch.js": "6820e70ce329033393a30946f5e79b8020afe60eb36399ca76062820eb994058",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsNaN.js": "2b31c10fb13313647e5d4d2e858abdb6bcec88b138669728c5214ca3d8baee87",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsNative.js": "1557c70dbb11eba112c6f5454e3cbaf7a714656da0db17e0dfe83441a70e31b1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsRegExp.js": "d7e58d031a5e88ab8fabf7e170e0859d5afdcb38e54e21bf233a4220d992f848",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsSet.js": "33903d3fdffb6d08dd4beefdb4a2e16c240af87d4ca0c4558aa730b1a87ea55d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIsTypedArray.js": "eb8a844c83bf159a41222acde165ab3f4a9983be77297496550164d10633b076",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseIteratee.js": "682c78be7d5145aac812935eca760bee4941f71e6404fb5c3bd778fdd190dae4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseKeys.js": "5ad980ce937752fa85ce2e48e981eed26ad9b0ee83a0b34491b4c032ab393aee",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseKeysIn.js": "c582f1f38230256bebba36251eccfbf082e7a395bf7b85aecc4496fd798dc83a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseLodash.js": "a2b8a5ec6dc638d34b03037736ee546fbea640643c1a0827afeb0895ce6c451f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseLt.js": "6ebaf722a155d87af068234fe158b4435c54a14c5fc15efb76f4c198237ac18c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseMap.js": "47e4f68c3c160e099028bac2a6c8df64e4285a8a29235ac8a7f44f2c06b54d52",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseMatches.js": "b3cebbc41fe98443bfa4eb119e8e8da42425c5064566d13653028629fc9f267d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseMatchesProperty.js": "1be880b258ae7e0620f184df11dc9c7942cfc4d248a924e6a93cbaccde74a1f6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseMean.js": "ad1081a30035f3926d4a041dbcfce33fd0439dd2471e3c5cd70f7017b42dd98c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseMerge.js": "6d8fada634d2384897e591daaea777b08f0397f953cab3642a541ef9b57c3dac",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseMergeDeep.js": "eec32b72db812c61e62ab0eed2cbc13cab9f75264aa6af9f5c8e7800cf50d3b1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseNth.js": "81a7862b009adca2822495e988a70bc579fd0f373ec6fdad9274e5fd9d89500c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseOrderBy.js": "faae984dd36e898dd406af38f19475fe473c41c4e638293c7122a9173386ebe1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_basePick.js": "be15064b2459865a0dfbdb374372aa4bf25b3fbf08e9552d5db20a665a909e79",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_basePickBy.js": "9ebf3befcd5f6124d7e563e573b68ea6448f834543b42244e45a2b9c9369c087",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseProperty.js": "7f3c9243eb26034d9e01553ba0e3dca6d949724355ad46f69e0e3328301277cc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_basePropertyDeep.js": "b1c557b398ef34577c5858e8be933a6f04003bcabb42510405e0de5149e4cc8d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_basePropertyOf.js": "a62950da12b7236a1524bc1191d43ed2edc6e93827f1b12e903d71f9f262e15b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_basePullAll.js": "3b8b7c894bd13e4c43b898f7c38e412e9fd8c6e8c8a41dcefee68ff80d34ac6b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_basePullAt.js": "720daedc26a4b1b76f79dc90de66ed772b04ea8865523c4670b780a2ee39964a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseRandom.js": "d74ff1f60fc55cfc35b5dd4eb1bb6dee5a9ef289f366b3ac8df6988a321f3e91",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseRange.js": "c10760efec1cf5ece8a25af30455ba6254c52ea2e74b167547c5499c1b5b977a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseReduce.js": "e85c15d2434fbf5c925f0b277372ab2780cbe80b45905baf873b8ef0f1ef6be7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseRepeat.js": "ca39ea92c9d7507281ba76e1eda345bc51203187c8700652c9f7965aef3a05af",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseRest.js": "f796cefb2c34daf6ad295d2af58abc96ea34348676a23a88e11789bc45f844ea",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSample.js": "032232633ae8c719d596ca7fd2c92d46b736bf58ee6c344eb6c642e8da113edf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSampleSize.js": "9b3a09cc73605e04106f547b3cb8303393ac2155e85a75f29be6ee4a0e255441",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSet.js": "11030a8c8b839be620d2233c1236d04fd08508d357edaf7c3eb3189354ee362e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSetData.js": "3cb4bb352cada1eab70d6c3bb06f90000b9eb0c68a61c3c9b1ddecdae6e04b99",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSetToString.js": "75d18e54921591874d3d54591087f458a423eed3d7042f237753fbca692d1d7f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseShuffle.js": "0da7ac2a693e76ae8b5827d90e88f7c53ba1bb25ee6fa0da4537449a05e42459",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSlice.js": "01913d08224c395783d4be26f1be8db57a0c1f1c53a0e3b8fea60055726b7ced",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSome.js": "4130846547ef5c12ff7756c00e6aad32b2ca75678e6f4c6802bd0180f8067f1b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSortBy.js": "3246812818378a65f35f2d6e3efd358380e4a30bdd143b994b673a60e6fbab76",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSortedIndex.js": "fd14ffcdbf24892594372f69f4c012aa641aed5087afc0159103605430fd3cbf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSortedIndexBy.js": "688adfc367439d1fb62912db83625f41f7101e30207a06ceefc634759b6da561",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSortedUniq.js": "0cb97ac908e675c379134659f8814fd244017ef0c401913c3f6bb6282feb69ef",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseSum.js": "499ebff818e516c4a78e0fd5216bd63d286c48147ad05612d4ec6e9e683a51f2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseTimes.js": "0d71867db092ef76aed4436956c0cf26d0990eb5d19c88f74edbe8c7ae2dfc93",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseToNumber.js": "fa0f9ea95e83fc9e9fc9949009df0b087ca987c43246ce548ac07f7b3f561467",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseToPairs.js": "29bca9551ca9b9b41d42232aff6fff9d0cd6eb83550612e1d49f6f9c531950fe",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseToString.js": "dc45840c564e75b058f8492a207d84a80629facdc33d80c4f05018aacdad675b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseTrim.js": "8cce4af7b95677ab2c74cc39cac7abb359eaab9515427191974f5edd69ad5a71",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseUnary.js": "25d6f22dcecef2d761e3059330425d1c585dfa81d50ba1dcd82d5524bfa78b53",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseUniq.js": "7fd05b3294fa6a78ef86115898480abf6c45a4e0815312c657246bf5fa7c29f2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseUnset.js": "03f96487914730f7462632d4b655ce2033636dbf9c2a63569e57f922830d023f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseUpdate.js": "2fe8901b11eb7e895a37ac0aa49b80bd1e13b83ce83027f1257e7f4a4c01c103",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseValues.js": "5f9486150a50c0f4dc8c5ab04a7a7d58fa9bb3e8e6d6d1a6f1ce9db24349e5a6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseWhile.js": "a92c7d0f081d9e1b763b27ddcf386fcbfa782245105d012e4f6f44565d8b7c9e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseWrapperValue.js": "7e07e072a0cf891d42ef0a2c699320e09948d3e08e03474dbf946da79b7edfea",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseXor.js": "1abd63581ad152a5369b46bfa6cb2a407762f2ee75892bb61263e9faa2ca9ca4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_baseZipObject.js": "55df8ae46ca2d003681a296d1b2b0662e95c9f191f89fdc57af95b48e46b10c4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cacheHas.js": "142cd8ff86e5e823b1262c6ae0e7843b28c3b0e806c502f7d11daddf941cbc14",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_castArrayLikeObject.js": "15614b9419ef6650e99e6a85690ba6a68fcf71a7ccf3b1841c47badc902d3814",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_castFunction.js": "1da66c213c6fb96a4cd9cd3cb54f8dd5ac103465425bd7bc0282e3aa5d982472",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_castPath.js": "375ca22e1255f6e787cfcb5e6e795f4d68595befd8aab4156b2e7fa5d1c80793",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_castRest.js": "52f39408b59d49b3cb351ec514f9372ddd8123e6545484f626fff98f47552418",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_castSlice.js": "20de417088b7fce8a3c36ed16dace11e4f3104ce25fb38ec5e94dae0974172fe",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_charsEndIndex.js": "140b7d08336cb375b598d7af5846613633f0ee6b61ee64ae79a4b2fd8d7e4bd1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_charsStartIndex.js": "af53bd64f21d7526ffe8aec7dcb8f038ba7d4215612eca7791a14323366f906c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cloneArrayBuffer.js": "04c06ac0667c7681872950fefa3d82af988cbb2f45e7ac94ad30a1a7fbca760e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cloneBuffer.js": "879343bd3fe02c37cbd8691dfb7d2b3599a069bc646bc415d49b347b06e7f801",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cloneDataView.js": "b9a868e7012cd534c7f01d0d65173b005f0252fbd6c5b607423998c2d33f968d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cloneRegExp.js": "683f8e1bd6e13beb3cc33858eb9d38da573df4aa6a2e02f035a2723ba05c21c4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cloneSymbol.js": "6be913cb0962aa51be9588bd01e02b3db72443a574b7d65ecf8036c78ddf4d4b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_cloneTypedArray.js": "40396608091618700dc31a89b5e3a70d8a77158134bbe85ca0a33f42061cf90f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_compareAscending.js": "1e22b628978cdcc121df44e8884e4b518f4c8cf20bc8e8b1961248d815bdd4a7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_compareMultiple.js": "25f532223b2f85f82938c245f9c5d5fa1acd918f2e1c088798f0711dd8be6d93",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_composeArgs.js": "521e8326c11e4ff1e25fe82ad7cfebe7924da55ad8dd972ae2431fd203b22d97",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_composeArgsRight.js": "38de3210a1b3246983a106e13e9dc671f00f03e5ff474c7c54231e6df5c46dd5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_copyArray.js": "66e841eb36a87af2b6bd8d7a21651d2f6c65ee11186ba8c0cd8a5f7856aa626c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_copyObject.js": "f348153f6d3fb121b2c2afe79ae0484fa12e5732772720aa44e128badf42b63e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_copySymbols.js": "4895deb1d808c6234457aeab3b06cc9cac80f6b79a0190fef8fd65d78ae91dc2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_copySymbolsIn.js": "589716ac9ef018b9c3ebb65d8f1aa8bb18b1cda819b5309a6374564cc3e370b6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_coreJsData.js": "020778ed390efefeb8ea3cf88873e9e2818784b3e26fa001ec51fa81c71d0392",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_countHolders.js": "eace52eb448ca61b6a6eb44a6f08a7e8a5c85284a9ed0b8cfa42308a7de7e56f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createAggregator.js": "97daf6720a06695fc9df1e6ea4435cee8d6f5374684ad3803bd05fca54fba8dc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createAssigner.js": "6c238f9cd9247a342da1557fd97d501928cf7ded1d5b1d8646fd279bcc68b921",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createBaseEach.js": "7d72f767d47d7392b3decad9c127e84b1f6b689d501d400a3960e2bad2551ae5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createBaseFor.js": "ce5bfd3ffa87788ae4edf6764fe3abc6cc75c18cddb71fb65d6de562fbebb511",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createBind.js": "2ae658584f4a9b38711a6a8040a63becd360d96fd08b64a1214bcfe35c36da2c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createCaseFirst.js": "26d8ee22d1f47b7028884569c6151b2adc88b71d50178e7fa5e2659d0af37aa3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createCompounder.js": "f8257824694137bf865deaea983c8e746b6b10c11618dcea2ed3ff4318a43586",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createCtor.js": "adb78b514d254baca36870f300b311640b43b407b31a091787c97fbb4bd43727",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createCurry.js": "bb7d9ba55c2c4dd8be56de1c9f2d069523bfe2884bae0e2973dc88a31083d89f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createFind.js": "e0c3a84aa167ae148ad6f7c72713c4905c0f7a3fb4f30b126cc1f1f496c38695",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createFlow.js": "289828ad2da44c6e98907303ffacb39502a4edd2e2fce27066b9d584c3827cf9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createHybrid.js": "0ae49480f4aee16f3409cb1b9c47d61aa766cff35dde323d19e2fa1733c97eff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createInverter.js": "76c69af2e66b6fb402472541b230033a658f4b2af323759c9c8e026384171fff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createMathOperation.js": "a93a24069bddedd4b858e9f5392da394d8c60ced87c8ff653144972a0ba7ddd8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createOver.js": "643dff9445a0e6b169a6eb058a6545560ccf9cb2879c4fc30286c538a8edf332",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createPadding.js": "c73c2d0ef0bebe351d2b0ee048ac7273e90a60cec0666c3c298f8c169c57e274",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createPartial.js": "e8c8f8c0c51465d491f238aeda7873dfff377917724a92c022bdca85ee915a8e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createRange.js": "4ff416b91a379f927b8a640b844114ef9622c5ad781f8cd5b2aac6124dba3c40",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createRecurry.js": "edfa939883788e0aa8f0bf12c96a07281c51e6a29dd3f81c52681444bbfef489",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createRelationalOperation.js": "64e620c96989f0bbd9486c21fc5456b75111c191b90114a344e88d5302d05b0f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createRound.js": "374c5b97c9c6d553a82a23679ce36fc3fc8a1f82b81e4a6044d8bba1a0e8e1e5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createSet.js": "01a8a6101f7e424e34dda54fce6a3d2a9f5791a1112512c8c4ae46dfcc3b0a19",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createToPairs.js": "ce8fd24fb7ab8764930686c63f2db3625b40e00b2b30f60097475b874f0cf588",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_createWrap.js": "447640e62372c3dfb5d6b455acf1e99dd25f1ad9eb2a10d078ef97afd6bbd45e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_customDefaultsAssignIn.js": "1ce2ff74a29bbef1fb3efcdb6940d3194189c647d0609bd590c2a52092a71b53",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_customDefaultsMerge.js": "45a5654f3ed4c3281034c96f3b5a8e5b03e8006c3448673c09de460fd1cc8bb8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_customOmitClone.js": "a60feb9a5c28d976f4740c3c22edc2ca8a728d4bb83e0c5bc25586ec1dbf2ac8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_deburrLetter.js": "acc04cf0abe0b871f287a1360daafd3c0201ad8aac7d618576142fc9a989e21a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_defineProperty.js": "08fe1a52a602829f143cf1a1dd4a133533b1a9cda8ef2071563dcb21750c7517",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_equalArrays.js": "ef1ec1ba10240336affff703995642b5f44f9b9278fa81559e4f7ca231877413",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_equalByTag.js": "72a492144060bc60415836aa1f8dc60949a75923f26d47c6007f16da092ef8b0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_equalObjects.js": "c386d0f1a6cb4d2a8b2803ef06cd69199b2e00c7d3062a6ea8ab9b0308bac243",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_escapeHtmlChar.js": "96451046e1ca9a2e38dafdd0635f163976631bea1a32688bfbed105f1c224940",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_escapeStringChar.js": "b6dacd270ee946173123a15ceb308d67b58bf15ec57fba31a7ed70a51f4f4a6a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_flatRest.js": "366430a7a0db893ad22e3412c7bc3d6a27ac71f332cc27303cf9e5cb524c0b24",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_freeGlobal.js": "0b65c37b3c1ce6d1800cb59a330dde73f1009f0d10eeaf8fd45f7607b87db4c5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getAllKeys.js": "01e917e05dd9a3dce40c4b68fe47fe57b6b5a349074e00a4a60768b95fada6e5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getAllKeysIn.js": "9609ec06ed5e1229cc9e6cc156be0806b9108483ae8bb2e45092c764ea011a71",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getData.js": "3548841b9b3df2daa0177abfce4c0a19dab91852b2f8cd05894e690cbc36a6b1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getFuncName.js": "ae247589c0407dbcc62a1ee3911b8561c9dbb2bb0b83dd8b7e15e59714da0eaa",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getHolder.js": "0e3c1a5eaaa7bca69cd5d0f17b452e6e0444a55dacca036ebca04ffdd48fcbb6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getMapData.js": "4ab0307467b45546bd3d8146d67f0e123f2049e6934722653803fe90b3484374",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getMatchData.js": "fbb4e029c9ad497872f30f15691e319807214aaa074b6a272c1d01d0ee319645",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getNative.js": "b93d64fd14cab48b0ad9b0f1b896ee8dcd74d8d5a20ca9cae6f34aa4a68ae9ef",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getPrototype.js": "0d28834baa350bc2ff483720439732052e2695a44b52cce790c99677fc733cf4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getRawTag.js": "0023dec54160317b70d52df1d7918638bc16a2869b1bf355f0a4f3e755aa6faf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getSymbols.js": "34d1bb981fb74a7c1193363e21f8d2634aca05436151bc2297bd9bbf0cd8080c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getSymbolsIn.js": "beb7a439db355b7f133a0460747b072bcf57f5f85f999b0e03262d2b409206c7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getTag.js": "86877c73f440b311c85b96f32a5e05995f0e247ef86091bc3d5f4e585439f8c6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getValue.js": "afff70502a4a536f971f961811013811c177e6f885d1e7e4e41c48c08ea6d6c7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getView.js": "537d39bfe28a9814a513bf28f4df56ef5fe9d01ce0f8ea2e842efbace90cf91d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_getWrapDetails.js": "13ca3f74dc6a6b64d97bcc4fd62fb72968506622c82b70bcdb683c121b94c01f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hasPath.js": "48f51da88883825ea4598509101fd21666746f95341cd8f488ffa8911d19a8a8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hasUnicode.js": "1b9ffe8c8b337c09709647874e132c23f98212791c936da6f0f3844c96112a92",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hasUnicodeWord.js": "fffc30c67e6bcde00590638d4bbbc3abe54f22adc9fba1639697014bbfa53aed",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hashClear.js": "54d4b21fbc05b32b246c4449e27a30628f9d8b6749c08ae965ff8c81af6dad67",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hashDelete.js": "eaf93621141b5c23d99a299c6f8620192faf0fcc71f4f00c01ce5de8f98bc92a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hashGet.js": "5aa4530201b81f25dc5609240b855f11a8bdd85d92c6bfb8cb2566758bfeaac7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hashHas.js": "92a91d1122b450660d889520e13f185829e296334b1cc708a7b0009a2c568b71",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_hashSet.js": "6535755fba2510b74079e573dc12f8c4f750131793d658ace64cf128fd1e0db2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_initCloneArray.js": "e29650695eb943a391552749678b039dfcd0c1f25294ffa5eee3c5dc4388f990",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_initCloneByTag.js": "e1edeb1cead74091a0ebbdeb8ccc1ca84248afc08294a1732aa984ef630dc0df",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_initCloneObject.js": "18145c5222148da5ee58b43862e8790ac455f1752fa86e881306a335f403ea7f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_insertWrapDetails.js": "e9d266a74bf7ab11b638f718f2d735e2a8072bfae7aa9f3b83e12d6e58cec4a9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isFlattenable.js": "dbf59e7070db64fa694fb2154a9aa45e47658ae4a9ddfa9667c3cc9fc1e8489d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isIndex.js": "33b5bf1805dd076edfc1199e114995a62170f8d6c835e0035ec05099ae29fa97",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isIterateeCall.js": "b03e71d858a91acdfc4b5b1c00b283e9e27ffd03567a06f6e6ce3c666c7b2f75",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isKey.js": "7ed944b05910095ae65d5fde97c1c3c9d81d38c80900ed7b46a5bc5fd501d98a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isKeyable.js": "207b697e802fc7f957d1275f7da727f59c6673e58ee2078fbc1af56f5f08c0de",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isLaziable.js": "5e9740b450ebd0ccbc505399b89d5eb3407ff26949e145eaaef7499d0c0482c2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isMaskable.js": "8e329fc447867493a58d074145f010969226735ab2de0eb98a6d613f4c5fd172",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isMasked.js": "cc641b21108046e4ebe15220dae4f7ad463760596800ebf31d5e53df1b98f152",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isPrototype.js": "df65c802abe765ca4473d3dd632c0b3d13e9f2397dedd7cf9742f0157b2396ed",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_isStrictComparable.js": "afd62e564b991585e12bc0021f1eb0664efd9f690f572554302fa4d5b8f6e52e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_iteratorToArray.js": "35293928814c0426f5663b9e266c2233bb4ebd7719961ca8b19e3ae7d79fddf1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_lazyClone.js": "b20f52dfcaf4d8f8b40288ce6ad68ff4b5b9f1c0024b32c31eeb1b5d1f32adcf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_lazyReverse.js": "eef3dc2edc97d99b8bd7f746cd7533aa67f4bf4e691ee5dfbc98c122f806cad0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_lazyValue.js": "cb3970d156f8cf11270fe82e8e432b67aa633caa9373555c55294cbf716e1381",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_listCacheClear.js": "e0e283b9176131c84766c243101a75d90566b4577e5c70cc6a38ad6266d805f6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_listCacheDelete.js": "4f60c332ff1ea93b47e744cfbeccb8cc65eed33e7bb302d6bad1fb596f70b186",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_listCacheGet.js": "25d578131e42d496bf92590cc2daa636203fc0512eeab29e2add3ac569921e03",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_listCacheHas.js": "c091833394e006cf700731a117a75310786726246843f225de698e94f1d1e798",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_listCacheSet.js": "0696b9f99b4ed89c08725c8acc805b7cc493078ea0fb8d9153bfb920878fa029",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mapCacheClear.js": "0be01bc64f84e1252f501dbe68d2166eb97ac321bf6638415478ff24a26ac388",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mapCacheDelete.js": "a52b87a49edecdb1b47793b5bb26d41e4bf379c369a420949302e1b1562b5af7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mapCacheGet.js": "bb71dbbe31d7fbd56016b622ea28b4c1ec570a8c910030dc927465737b458a4e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mapCacheHas.js": "5b9c230d5e00aba2d482404cc8dbe327b23ad29325d13a0e49e93cfd0b1bf54d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mapCacheSet.js": "43318a641896356f4b187bee7aad9be1147b766722108a7e7425d7e1ea322bfa",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mapToArray.js": "fd24c54b48cbdcb659a15dc013554a473fa7524b7c5fa2a7f8dc2229c7ad2bcc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_matchesStrictComparable.js": "73a82ac3f13e1d7a625c36cb4c8de3e85f734b13229d5f1ba37d5db443c7355a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_memoizeCapped.js": "1e8b9c9d029c9efa55f74f048564ca8e36d287ea455698235f563e788fccefff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_mergeData.js": "6354f0f0fe161a30c83e9b2a3cb6f5826d0d7570ee1e4ac21ee5dc6f6a45935b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_metaMap.js": "f96f29b8f4f35592e571e4ccc756f545270d466a959060d8af2f3d427af39eac",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_nativeCreate.js": "59c4a564c25a021902259cb237cfa331daf056423d359258ac968c60f51aa324",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_nativeKeys.js": "df95037fd30b575dc9a1173fea65d68bd8cdb07ba10186b7cc43c4d7c69a92f9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_nativeKeysIn.js": "e63e54e1eaf58287382c811139a5a497512356c0c192f646e00abd0e94bf625b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_nodeUtil.js": "f81d8e969afead3562231a1c368fcf884b51339ee04aff07a2b67f8ba794f03b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_objectToString.js": "8f1bb6043dc27219e71dfae28900a7f214a0856118a628efeb120169fe46fe8c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_overArg.js": "599268d0a0a7da23b421ca0cfefbea1f295e44c33bab99fb87df38f4ef97bb9c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_overRest.js": "2680f289bb332cf28f3a6413929e2afb46886fb1b747e9f6d33aa50c29ba68db",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_parent.js": "4e6b976ff242a252bd2608dcba0657a81ed6f370c0c21f0c13b180f37fcaa1d3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_reEscape.js": "6f8efc8ea0c7988baab4eaae8b35485d9acc2e6aaded4598b232452d359f0d14",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_reEvaluate.js": "622c801212d03c0500e8878a2609f85c516423f1d518e66c8f7db3c67d1327ae",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_reInterpolate.js": "a88ae2c20a0aee81061b5b99e5f94dd942359f8f76f04f4c33f57f6f15ed0969",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_realNames.js": "26176b3fcffcb2c01ca2b2906ccdb9083465f93abc3e467a48b5b70df3d36e47",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_reorder.js": "8270c7427bba48e02722dfa9fad0d5610f1962be05ae1589df2925b0684ce97e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_replaceHolders.js": "d4d3dd88db58d9339141ee09086b3816a24bb9020c4f21f2c49fb071c2115b65",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_root.js": "df58ff96c454ca91ace20d20e6af49b354c70dfba7e737adc00cd23e8ff77168",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_safeGet.js": "5f9023f036ae9eef9a0196bac43db899fce05712ab4594efe195827eba585111",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setCacheAdd.js": "401386f4cc34e3675ee768b340e521df8b021abb3b9e8fba9b2a49614d54a189",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setCacheHas.js": "fc24b8606ffad00aab53dd47f42225ca4a97272b7b90df1db7f75a57cb49761e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setData.js": "5b7349b9da3ae0b351ef558ff54327b2e44e847c755ffcfece80de3b2bcd713e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setToArray.js": "316f948fca04c5b007fe78c6edc199a69496beef8d395f44bdc0dbfd7a46a1ed",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setToPairs.js": "44fa058454fa90a360348bfaaae5880c370c5e95f5f53b5b8174711d27fec3cd",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setToString.js": "2a1ef073af2370f4bf3258d41bcc62f06ae23a41ae13543e5105946b2b07b03b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_setWrapToString.js": "976b5f3fb5ef356abfb7ff9d0bf81f6988c7b033b58bfce1f4195c8984693818",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_shortOut.js": "1b8768641ee4b76051240ec40b2bfe84e6f21682a71ce6f6f6972363f5b9c634",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_shuffleSelf.js": "5b741f17dd16195e529091489d6cff6afc827f48bbb03e11e6bec71acc79caf1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stackClear.js": "2f18f696265ae6318deb51419e121ab543b4fd9ff240892e8e054d944db8020a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stackDelete.js": "ae947fc8f29882a437db228bcdac90cd048f94bdd758e508b53987be2e28cdfe",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stackGet.js": "ae5633328aae57109e1ce84e70a587c2ba90503294f758ab8086d032ebb40897",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stackHas.js": "06066c99b9909bdc25bb702b579ca29a69ab478d9819506af29aa7e6476eddba",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stackSet.js": "4f96a1dfb190aae58f59bc26cd1a27fae1d10abc338e1f57a67e69d47b832cbe",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_strictIndexOf.js": "14328ec9997a49f35a4c16caa01444e079c836f030992197d3f1d7bd45a43dab",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_strictLastIndexOf.js": "3283640f66f1e8f1a0feb3df6ebe1678df08e4cd7781235bbe47e03a4d6e8bd1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stringSize.js": "609aabd3d549c2f4c7842daa82da6e91d2fa20d403185fbaaa491f4090cfc903",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stringToArray.js": "7d8a6f7807f071c62b9fb5a4b057613e2c9a13d9cb6fdd7df5debc9bfecd0be9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_stringToPath.js": "273b937d9dbb867c6f4ae4fe74b28e92bdb5108c94ef2033625ef61061295477",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_toKey.js": "9ffff48c982394b61f0e19c2864d371b6bb9b9dc0fef05eab7487ac82012d3bc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_toSource.js": "a2333d6455d5a8802b8e8d64f0de422f04a4603cf477429d2baabb8021ec9032",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_trimmedEndIndex.js": "1ff25e476022aa45aa96dbea87228e3ff709c1f3b8b82561b7f040279575a2ef",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_unescapeHtmlChar.js": "54c3ebcc97e436abf43a7a4f71c0d480a0edb5e2ba7475836ddaacc660ac1bd9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_unicodeSize.js": "2733ca09ddb5aa648ce6082937e5db8fe14fa727e5e6dc4e6efbb9109ebba5e0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_unicodeToArray.js": "806bbf241de7849459a492f859067be4d3379df49358812b41379a966aae7922",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_unicodeWords.js": "f132197f36da541ee8e6d5f5de2bd938f3ccc4ff4cb4aabff444f21a12e64e9a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_updateWrapDetails.js": "23cb06d622f73c9e60da136cc1e30ed79491ccf2d6ce12b19e14c6b828b010e0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/_wrapperClone.js": "7c04a85a5c71d36436dfc95dcb39f4c937a99ae6244f9ec294d0e293ca8fec23",
-    "https://deno.land/x/lodash_es@v0.0.2/src/add.js": "7f6c2925110e151d391499076cf097f9b1199648674572cc9e328261092ef3fe",
-    "https://deno.land/x/lodash_es@v0.0.2/src/after.js": "0229081b187c81c079e6bebf93c13e96b05395d1cd9033aa328d8d05a3501a85",
-    "https://deno.land/x/lodash_es@v0.0.2/src/array.default.js": "3407c3c87ed010ff369fea0b893763be087085e2cd8b3c71004e98d395e73326",
-    "https://deno.land/x/lodash_es@v0.0.2/src/array.js": "9e9c6fa6e95b2a2769d5116beb02c9345134eac04405eb33965aff6539273cb2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/ary.js": "193cd1078083505cdb6c1a5ef3dc13b4e2c3912711a29e100718091fa96c29a2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/assign.js": "8a353e1f181cf2de8baae4a60dfbd2c3875b956b5a7c2049b6f4a2822be169e4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/assignIn.js": "5bf2c4357338a69baa94efdb1c35814ada504489bae5e9865b27ef1bc12b6ebf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/assignInWith.js": "4ffcb7b4b3ead72d076f8360e3ab913216327a40bcc4eaa0e435f1930d128fb7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/assignWith.js": "1241b647653af775e9b0f0e15d07e9fb0f7ca9c3e538a0a6fd51b3e96c7d5128",
-    "https://deno.land/x/lodash_es@v0.0.2/src/at.js": "5529d349fc0d92becd247e086a027ff2457c32a6bc9ba1482366b1d357e8ac10",
-    "https://deno.land/x/lodash_es@v0.0.2/src/attempt.js": "4a702ab485362a62c4bec0b321966cf0c617847ea6268a3459a02655f00cf392",
-    "https://deno.land/x/lodash_es@v0.0.2/src/before.js": "129ac5e417675d3767db4f83e8ea87676a203cc1cd89efb336739fe426e4ac24",
-    "https://deno.land/x/lodash_es@v0.0.2/src/bind.js": "7625bdb657c8587f539ff46211b97ce7620f7cd9510e0f5b7dd7fbcaf4f0a48e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/bindAll.js": "2f23342a27c5f58c19292b0a785eacc247c14663ca45fc31d5bd5aaca0ca7a7e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/bindKey.js": "05a152022093decf741c2338a44b86f77b5d23bd735827f482180d3ac81d3bb7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/camelCase.js": "efa9687baf3a7807bc97d842b891ca6442138d1c5251ee823dddd392f7c6f596",
-    "https://deno.land/x/lodash_es@v0.0.2/src/capitalize.js": "2382093dd0efd7b2846f8a90376de31a2d736b396b2379ee7d51abe1de9363da",
-    "https://deno.land/x/lodash_es@v0.0.2/src/castArray.js": "be4e7743cc9d27e0a1f61740d852d3f3d1f89da0e6c56d9a0725f623c44fb165",
-    "https://deno.land/x/lodash_es@v0.0.2/src/ceil.js": "014822d831b2d6b83d37f17a314eaf1be89f9c48f2a48f1aa48508dd7fc4acc3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/chain.js": "c28797bf34f48441a4cbafa3a0ad19170597f68cae59f4ca4f502c486790909f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/chunk.js": "5e6f0d19752929a6fef0afc9bfeddcc44686a9a405a8289d75bce67e6cd6d1a8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/clamp.js": "17a5f0faa6e079daf1a3ee4ead12160724f40764b47243aeff8c24ca54f63692",
-    "https://deno.land/x/lodash_es@v0.0.2/src/clone.js": "9f7005c7e7d8c46b0c289ec309ffd769db368a414495082be138880b187f2be0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/cloneDeep.js": "1122beed4773529f5b9ef627486f7f5c4d116438f3e651d8ef6041994ae3a88f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/cloneDeepWith.js": "16fea9f19de6c40b3015945d3be35668e55e1766a82f8bec417c95b31a13d0fa",
-    "https://deno.land/x/lodash_es@v0.0.2/src/cloneWith.js": "0ae4763070c8501d4c1755a730cbd6091a66556eedd991a769f6be005c6745cf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/collection.default.js": "01cb73b5dd8f48cebdc94afdcf5fa628ef49fb6ba5fafb84bb168f354cc33b18",
-    "https://deno.land/x/lodash_es@v0.0.2/src/collection.js": "977ae4bf5238b87bf70f281603d1498fd9141dbb66799ae725b305a0f47dd3ca",
-    "https://deno.land/x/lodash_es@v0.0.2/src/commit.js": "7883addf66a93ac95a59c14e28a9b3c03915f108d6eacae2ce741de3ddeeb30f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/compact.js": "1209db306299566c321915b959a68a8ea8af03e8a8f7e53d3f576a90a6a19bbf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/concat.js": "35001637814f7f173b7f0c1ae497375ae94025839866469c25a3547062908a56",
-    "https://deno.land/x/lodash_es@v0.0.2/src/cond.js": "12f42783deb73d1498ec6f2662535cc9432721de0d5f6cb8d94186ed89ee4f41",
-    "https://deno.land/x/lodash_es@v0.0.2/src/conforms.js": "b5541dd308015606061ee2f9017e9668d6c5e9fb6ee7dbee3b0c900596699562",
-    "https://deno.land/x/lodash_es@v0.0.2/src/conformsTo.js": "4016a3038d3044aed0f906da2c50d8ac2db8f5239fcfe0c801f2f488d6fb077b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/constant.js": "cce774605f469fe731a3aa932019b71df84fe6c47741b018a17e69c042f32ca3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/countBy.js": "d83139f2d46f3fd5d35ea9548b1516158624e89566597ab29ff43c5889ae7109",
-    "https://deno.land/x/lodash_es@v0.0.2/src/create.js": "b788a99d6a2317558273e5330127d25f9fa9042395f84dd25274e7d28edab870",
-    "https://deno.land/x/lodash_es@v0.0.2/src/curry.js": "858b008d7ebceb48155d14d01a49384c29235ce99f7b6c9b7f3c30c4efaf574b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/curryRight.js": "ecb50ac507bccf91a2f7d9261e9f4804c66fea777f79de1a180a45038f0c4201",
-    "https://deno.land/x/lodash_es@v0.0.2/src/date.default.js": "59b87d58a2af80bdcbc9d89cb8bc65093167cb49ec8df391df503ce2288e9bab",
-    "https://deno.land/x/lodash_es@v0.0.2/src/date.js": "57926fd240f5ef8dedf25959e999d1bfc6dcb31589998300a858611559606d26",
-    "https://deno.land/x/lodash_es@v0.0.2/src/debounce.js": "d5f2c62200af44e14130d0018a27a47b0d6256220ea41b35b8d8fd0807805030",
-    "https://deno.land/x/lodash_es@v0.0.2/src/deburr.js": "5af1d51fe36a96701dae2db9e5eee2bda272edb59b7e31da687d0dff5a2ca573",
-    "https://deno.land/x/lodash_es@v0.0.2/src/defaultTo.js": "d52c7dc3b21ab856545f636d92956dfef31df7794453f4683eb1d7f60b80fa44",
-    "https://deno.land/x/lodash_es@v0.0.2/src/defaults.js": "18bdda11e735027012c1a3394acedb851307fd76dbac77339b37c7066fc6fea1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/defaultsDeep.js": "bdceb5f7d832ecb8d46502a1fe5bc276cd5f8815abd15c253b06051827ff43be",
-    "https://deno.land/x/lodash_es@v0.0.2/src/defer.js": "d8163c12cf7312db57a3b46a3182c26848100abcea43ecb91fda9f0947e12d4d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/delay.js": "018e6b5cc40ac4a91027b720799af086dd579d3dfe06c24e916476f6c5f5c4ce",
-    "https://deno.land/x/lodash_es@v0.0.2/src/difference.js": "937ade5f9b13e047421803813de9c1950e6dc78bbbf928819db7b4d0a80b9c7f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/differenceBy.js": "8cad12f4a1d0535dc7b843a5f68c1f732d9bd7531cdae1e0e178e4378633182f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/differenceWith.js": "f1e333001361fb47303190373b1f1302eccb55baaad6306aff4d243eff7e8a23",
-    "https://deno.land/x/lodash_es@v0.0.2/src/divide.js": "3202cd1b95da01b3c92a8c9fd1b2cb157115a926b51f72ace0201b0f0884ded1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/drop.js": "5e7ab48513361465840081db445e12bce56a82927cecf9a28a3cc67b4938f10d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/dropRight.js": "4cfa3e1085df9fcbd07ee92c01e97d8b20efbecc589afaca4c34e569f2a88de8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/dropRightWhile.js": "3197f06021d759746b24dc1a1f4768f2d6158c2384d99de959fdcb4484e10c7b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/dropWhile.js": "f8ed889a4c56166cb6322a5c5dd6eb29100099299c10c83b0a9f4b6897003227",
-    "https://deno.land/x/lodash_es@v0.0.2/src/each.js": "9b18959aa9dabdc1111913bd54763d4311f505515050417fd25b951c97010b41",
-    "https://deno.land/x/lodash_es@v0.0.2/src/eachRight.js": "02d53374092727f3f8e5a829aa728aefcfb540d5a113abd00ed08aba5352c736",
-    "https://deno.land/x/lodash_es@v0.0.2/src/endsWith.js": "64e7badf7b50f540a6b5f61b02cd15c3dbaf4a163c51897c246d7969f6f19df4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/entries.js": "9d65625c845ca656c7a89271f144bec65d91cac91cf70c4363b9e4ba08f6d89b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/entriesIn.js": "683b6eeb44a3cb21669302ffd1e1f16d58fb7ed63830be757270dad3665bfde2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/eq.js": "3a51729bde3af1d9bacf9b67e966d8c154e22b02f5e1cecc13f53f7f00889c13",
-    "https://deno.land/x/lodash_es@v0.0.2/src/escape.js": "7babdce893618e4104b3baec5664f7d645b9a18d38e94ed09c4430ebb0f0a0ff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/escapeRegExp.js": "e606b284899737aad46b97933513629d580ba98199dfc4ed173738ff6c17c8be",
-    "https://deno.land/x/lodash_es@v0.0.2/src/every.js": "4fd4c643817bd1b59e4b80835987be9a96168fa15257527353355cfbf03c64c9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/extend.js": "f6c78154c8dbb96761dbfec6566217cc944d30e7d4ec337131b8877123dd1035",
-    "https://deno.land/x/lodash_es@v0.0.2/src/extendWith.js": "efe58da78ae351b6ada34bc9c1dc9bdb47823a34e937ec4b462e70b7d8e5ef07",
-    "https://deno.land/x/lodash_es@v0.0.2/src/fill.js": "604c72ba8aa0e1c609ae2ea8779328ab5f3d05691ddd858c177c948bac31ec15",
-    "https://deno.land/x/lodash_es@v0.0.2/src/filter.js": "3db358055789614bf51d5a094e43b39f4c1717a8f2f38848c6ac267a7d469675",
-    "https://deno.land/x/lodash_es@v0.0.2/src/find.js": "e7191d086b913fe73067b192543bebfdd9903736a8a6a53a65fcd8a6572c028a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/findIndex.js": "befb111ff4df3e8f69c100c304999c99309ebd9ad059247ec9dcc757baaaeb92",
-    "https://deno.land/x/lodash_es@v0.0.2/src/findKey.js": "6fc490008497da9eb9850c1a25406bb2358bc5627313c7381c1aff264c0b0b44",
-    "https://deno.land/x/lodash_es@v0.0.2/src/findLast.js": "853dab865ea56e21636c2447f4bfb35ec396cc6bf10f0462ab1afbcb00a0dd6b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/findLastIndex.js": "66561545105b5934ba8fa4bada50954fe88921a6bfef8cad3bb498151a3bbbaf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/findLastKey.js": "6d3742cf880d29ca676c698109c5d3e56e87eea431e1bdba8cdd28698436609d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/first.js": "0fc33df0ab58d79c58523a9ac27254aba3adfab7c872a765dd04326307b28f9d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flatMap.js": "70cd946ce9ea074bd57c23cd7452202d511d5d1d5d04f73c6289651c2e1f2e6f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flatMapDeep.js": "0e988d90ae3735b60af7063a5ca09a2be773cf68a69077f59cea9c9948a0434b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flatMapDepth.js": "c1294f14b4e404ef1664b7d1a6650a9356337fa357fe572efe42853c648dd8c5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flatten.js": "e36e2b1c043747342573024964a1a776012c083c60f1d4816cbe6c0b1a62b381",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flattenDeep.js": "c8f092c0b7e37e25650a07c2344ffbdf03f2a99ebf3a8cb9576d9b7ec0454530",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flattenDepth.js": "287b1266aef1140eec28a51d0ab2124b2e54fb46f94497697318c115e0ff56c6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flip.js": "e906dd0bd2f4e01834a15b4a178b1b2a9e68d1bdba589377f862f3eea0fd0611",
-    "https://deno.land/x/lodash_es@v0.0.2/src/floor.js": "d29cfc10b3142b8a39d0eb8eb8f47cded12dc9f9e1b74e46db27685dd8ed010a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flow.js": "e6915c341a63d1d8e4851aa78bc63d7b4bddd36e5d88f67084f78b3042949d8f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/flowRight.js": "476e9ae3d6af2704725dead0dec7b8f6fe78c07ad84706f46c2365897571305e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/forEach.js": "5d6b87ae960d707fd0df73f943aea6bdba4ebec9ae7dbaece58132b4670ed4ce",
-    "https://deno.land/x/lodash_es@v0.0.2/src/forEachRight.js": "aba8edea94bcd692d71d2172e53dbf82f3729fd4794a805a3617acc4275011d4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/forIn.js": "2e88343c022e1cb82ae03ce8e3a66570d33397880ef0bf690f1180f373ab438c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/forInRight.js": "5b0468985ec59e8d7a1af9d4ab17ec708fef757a8a32cc55d8b9a9a7d2ab83fd",
-    "https://deno.land/x/lodash_es@v0.0.2/src/forOwn.js": "954a5725fba018a5bd2d58b2b4a6ca14258e4eb0f6aae5ba42de6f2866c8cb78",
-    "https://deno.land/x/lodash_es@v0.0.2/src/forOwnRight.js": "dd45eeb010ecc6abdf26fe28cb1ef40b18d99e31d46e7d0780005e079dc464e5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/fromPairs.js": "576133ee2d5c75536c262974e89d7b15f51423e52b62fba28f838ea0144d0222",
-    "https://deno.land/x/lodash_es@v0.0.2/src/function.default.js": "e74e982647e015ad15f3bc088a5d91226b5a1a2ff1d1b8e82eeb4047547cf660",
-    "https://deno.land/x/lodash_es@v0.0.2/src/function.js": "f145c82925da0699ad5c20560752947a3343d218bbc363bb68e1b833e7abfb7d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/functions.js": "f4869ccabf7ba9060bbffac047ecf1b4a67b576acd625c221c4cb9433b76d9aa",
-    "https://deno.land/x/lodash_es@v0.0.2/src/functionsIn.js": "2fc188a926dfa69bea9901c517d43eca38f9898a2810926e3b0cb19aad464813",
-    "https://deno.land/x/lodash_es@v0.0.2/src/get.js": "da9982ae72d4ec4e0cb7fd30e691e19581848b7eb8a8b28e6331678285615c31",
-    "https://deno.land/x/lodash_es@v0.0.2/src/groupBy.js": "018a58cd0c4b430e13668bde16e60634b3aa0cb2fea9c59f359e3a232a343730",
-    "https://deno.land/x/lodash_es@v0.0.2/src/gt.js": "8acd697a721efc1f7cf5d7b5eb8f1920d132f3e19da022f07f122c73f6170d89",
-    "https://deno.land/x/lodash_es@v0.0.2/src/gte.js": "ab886f1046b0af3a805fc1cffa0c543a8d3be472e8a43776b2ec3bd5a063fb6e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/has.js": "ef180edfe669ba3c31caea4b4cfbc86cbfa0846e648ef982223afcdccbd5f105",
-    "https://deno.land/x/lodash_es@v0.0.2/src/hasIn.js": "4561bbd438a9e3c8f0922646d4b5939c6bdd7dfb26deadcabcff8403a6df6a8b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/head.js": "99c64e2bbfa17f0605c52e6c52f72e943581183b5a704d4edeeb7b5e43b2e912",
-    "https://deno.land/x/lodash_es@v0.0.2/src/identity.js": "152c43149691b31cb9bcdf1be4ba07a3963babbd096bcf6313182d3f2597f023",
-    "https://deno.land/x/lodash_es@v0.0.2/src/inRange.js": "3a9143c4d621797cefe9416edd42432904c25ee5984759010aa2ea907052dcd3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/includes.js": "9807eadfe07818ac4a5416c6e17a320b648322806f59c2347f9f014436e56c47",
-    "https://deno.land/x/lodash_es@v0.0.2/src/indexOf.js": "a62b0e3826d12eca7d0010a94753905f98cb9e58358ad9f269792c2cfd0612a3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/initial.js": "d0f93b64d79de4f3e3a6fe89fdaebc8a02a9d18ebee9f90cd3bf30d0a40ec28b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/intersection.js": "e85edcdaf87ee1dad1a669536b0f91db3747cd0275d7c2247a4970a02bf39c78",
-    "https://deno.land/x/lodash_es@v0.0.2/src/intersectionBy.js": "2c05b5d6d524d2cc6fd0d6e29f92d8c2136efcb865608e0a4182e7e47d25bf84",
-    "https://deno.land/x/lodash_es@v0.0.2/src/intersectionWith.js": "9233dfd36d5f516d4de8d711b7b4b2bf01b90d32acba3c592541f318bd6ccd61",
-    "https://deno.land/x/lodash_es@v0.0.2/src/invert.js": "885c49447b9a37e5b5120209a3f433f782b40134d1235f1d9d434f6d4892a61c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/invertBy.js": "b7831df7e72645717e812568e9a60fe766a71540602b7a4112aff37236c8bce8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/invoke.js": "c57c9ebdc63812ea8247e0b84736e2aad53a4e25b651e791d060c0e5b6972b36",
-    "https://deno.land/x/lodash_es@v0.0.2/src/invokeMap.js": "2fbf852927d5d2d18bc87a9f63e7b6dc79cad0da4710e6ef0e51882231884f77",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isArguments.js": "08791025dc5d7ec5183e290aa2aa6a9c4af78703f0d42d1b9421b607c3199fcc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isArray.js": "0d9bcdfdf53955d9253076ddd68e0b992b2c91fb8364baa2ca971e57cbb74e4b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isArrayBuffer.js": "58ed2a85326d433456316ef13a8bf12764d110c36e7290b8d9f51e0b8a1ce463",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isArrayLike.js": "46956ba526a01c3371fe26a492bf2a247b20d995e6891f2ac99a17b1ab64b49f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isArrayLikeObject.js": "76434e9c893ae3eaccb555792ea5754d42b5765efe5d360d78d2c4abda788ecb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isBoolean.js": "02b75dab099a4ce0a178fe32fe671fb4350133353c29916ecc42d035cf6bb5d1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isBuffer.js": "683ac01368bb0b51e7571332797cdec13cf5fa26a79ad20764045f01b1d249d2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isDate.js": "f58ab84e10e6b7f61aff5badb9f587944bf90d0a267de196ae6fe9a36fc60360",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isElement.js": "f71bd89159ec8f944b9d1325a2b084368e34953d0d1a712e6de31ac66c89cd7d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isEmpty.js": "a2ec3e96e3395946d44bdf0229acc8610c7a4b07e2f3910a424ef4a704eed178",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isEqual.js": "60c66b9d8e67d807bb91d2487f05a5400c14031b4c59aee9920646529d494d17",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isEqualWith.js": "b7a667d8aab3dbde3da485c7b172602a810d5ef152acbb08c04516e10fe43ed6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isError.js": "bcd71260aa1aafae10ea606d6278029a4c8c56ed892ced917a1557e8abff5a05",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isFinite.js": "a0e3d653638a3b4f73b0876a7c55feb44866390aebe1d534f3933a90ff8c3e15",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isFunction.js": "4cf0f598213e142e5d9ad09f17d3611723a9e2e3def000a39edbf38b493b3b08",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isInteger.js": "a2cd7df5c9b4b59e06836cf58b3da67e52f93683f224239de6baafb3944d1042",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isLength.js": "ef8193123dc3fbd12be9893aa39aea7df0a779074e604d853c56da1c09d24e11",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isMap.js": "9cdd2a2b80768554c2d0d88c8fe8460f07d55f9832ca1149a3156d139aff572d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isMatch.js": "7f6553a64aa2c87984ca18035cde4296c856c635b5f697eb4d9036378f7e31ff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isMatchWith.js": "68d9416b26ea6a90ea06a16119820bb27935afa9360b62806f7b7639f9da36ff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isNaN.js": "37962fb2480574d2050eeb774638f4b57f9e104c10de55d064e40ae10e1b3d09",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isNative.js": "59cf58e3e1782714ae7d07a3230142efc4e07c54bb725a330ce3533bc79de9c8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isNil.js": "cacf48eaa3b43b80d6912a04f1abb5498ced464e8caecfd08393007f5f0bfc52",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isNull.js": "182b7572104c372bab9ef321111bdc0eebb279447386d649c56e40249fc0c89b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isNumber.js": "4d47a4ebb813272cf997cd008c2ad8934290a1ef7bf8ab31e39c819015dcb86b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isObject.js": "fc44c8f265db1492ea04f777d9e2d8598b44d481f5eb38360cb58c1e45b8cbd9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isObjectLike.js": "e45d69136695e8568c6fb3c7327f96ac1a8ff7284b1b22f26fb4654255fd0c6c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isPlainObject.js": "f790a22fd205b03f11f95fe0657c9244ff48e45363633fa110c3c5688177b192",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isRegExp.js": "427b4185103740e642df855259fa0fd2721c3051485a737e67907df6c0c66607",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isSafeInteger.js": "5deceb0b1e05d89a60cc4f52c635e920d0edf2bc60b6ac60166be8c59463fd83",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isSet.js": "37c903d4dc8656e75a406a2a71577858bc1f61b40aaa610fefb20423fd9dbd4a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isString.js": "91c39c006bbd6924da8a18e9515d273cb1973e632df6b36f713a82f65e864df8",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isSymbol.js": "f0dc1666c3cec2306cd4fd0f63a9a7ab1f25ed21d2db6664b1edc81bd3641a41",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isTypedArray.js": "ea3531a60d17525b79f484377cd4053f32fec478822dd2b51ca63ade12520737",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isUndefined.js": "4a250b584a4809b8410dd5e28271b499ba15e1133a3b63081bba7cec5a455c86",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isWeakMap.js": "af2fba7b4236f498b7fdc8976d4166487d45785d8ecaa894484e99939cc7198f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/isWeakSet.js": "4504ad61c4c35bbdc870ec9fc6be4e8551e1c0853a8f1b6b8f3e8269db4bf5d2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/iteratee.js": "a3750c4ba68ec038bb6faa9d24024ceddc46f804ddae46f41d59faef07f18357",
-    "https://deno.land/x/lodash_es@v0.0.2/src/join.js": "2f791dd3d33d7033f23af1bcb523df3910f26ed52a4eda7a098e0e30ca55496d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/kebabCase.js": "f9324cf6fe6033abbbbedc636a5a7127968ada7d06f38b5c47efe05bf08a7d66",
-    "https://deno.land/x/lodash_es@v0.0.2/src/keyBy.js": "9c856fcc32633fb3168f1894cb8bc293f801bb0befee8d67e3450ff0d93fad43",
-    "https://deno.land/x/lodash_es@v0.0.2/src/keys.js": "cdcc1e10b113af10125daaae5cde3135d581e7f53a22d1190fa12bee62c3315e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/keysIn.js": "fba7db7b7420f0cc87b6636aa748e8c5f44e44cb5408fd33d1fa967b13f0039e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lang.default.js": "9e89d3b5b6f56ff2a98a1c5826b231a99f77dfbb1a8a0e6a8f3ce5eeb7de46cf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lang.js": "b99f39bf01eeef121a1b61b23f2a5fae649fa0265c2b543095a834b75af10ade",
-    "https://deno.land/x/lodash_es@v0.0.2/src/last.js": "8ce00d6b783b8610a3680ab555a833f65a6bf62aa8304e85e86fb7c48d6428c5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lastIndexOf.js": "f2c4fc32233c698c8735f87606f0ad99a31ffabfeddf989e3f919bd8e4fbb8d9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lowerCase.js": "25d608af760b31821ccd0565cab57a0c4034ab9af4ccab196ea86018cf23f9c6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lowerFirst.js": "fc5b5c8c2cd3e5f3359822b4aa1d27bdb08844135c7fe771fa18d467a95b341f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lt.js": "7ea7274ea0c4d91124622475fec6acb7125447829e435a9ab2d46bc6da9d4fd1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/lte.js": "55f701715aec867a37e168986be65ce7db931e471f29372fa4d8f5e48741e11b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/map.js": "8ba15cc10575d929729df276ac1515d7087730a3637c277a9ba90ab0b0ccb820",
-    "https://deno.land/x/lodash_es@v0.0.2/src/mapKeys.js": "bd94b719a21c6a28e1c92303503128392569a4ece207b0f55073c88190000536",
-    "https://deno.land/x/lodash_es@v0.0.2/src/mapValues.js": "2361d940db5708060af41cf88d2421831a34b5ee1e87b8a8538c27ca3407f5f2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/matches.js": "f019b55723ff2f6e7ca4d2bf35c6cb33dfb40f9e72de432d0645f8327179d158",
-    "https://deno.land/x/lodash_es@v0.0.2/src/matchesProperty.js": "ed63897c7f1ad105a1c95e1aec94252a069107e7a1b8a3fcf254bc530824edf1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/math.default.js": "c132993e811b4de1d4fd8d5e277a0fbda02fc83b595a94beb170b0383657fe1a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/math.js": "bcb42f38a6d2d037d4ad66d45719ae3c29aa117f3e7c3b9adf6ca172d6b06035",
-    "https://deno.land/x/lodash_es@v0.0.2/src/max.js": "9cd0724f9afd1e529a3efc3189b290303fe5c48bcd854259be9272a1499ce477",
-    "https://deno.land/x/lodash_es@v0.0.2/src/maxBy.js": "4477302fc2f050728841f8f0cc177fe83cbe3bf84b6b2b6c76f90f406c34fbdb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/mean.js": "7a075dfb56ce29746e829499e385ed0e2667e88203cae0ea3d7a823f63462beb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/meanBy.js": "24ab29c6acd38be1170fcac1c91eaffb1feb19c5e32976ee557482e1ed3bf58b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/memoize.js": "2a38b3b9b90e1592565de2168467c3daa6a4a95610cd3afd8890208a7c02c782",
-    "https://deno.land/x/lodash_es@v0.0.2/src/merge.js": "8004f9d4c737e69f5d871ff61e2966460c907036b7a514751d66f8f9b06572b1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/mergeWith.js": "daef90b174930aabe2f79850603ece4931b1df9d592dc3d2d77bd99040623974",
-    "https://deno.land/x/lodash_es@v0.0.2/src/method.js": "c8bd447c33447d1efc9d85196453631dcb3201c85cbaa3d7237280c843017753",
-    "https://deno.land/x/lodash_es@v0.0.2/src/methodOf.js": "33754a912fa0b51f5064bf737414524054110793ef70a7a2401a1ce8faeb93b7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/min.js": "7bdb9a3ee63ecc3ddd995a8356b10b8a3c10b4e213415b41caf64885240d2609",
-    "https://deno.land/x/lodash_es@v0.0.2/src/minBy.js": "24f6b663d3dd388f0353a203bfb3f158503bc2ab9d7efa229a756443ae0a8e0f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/mixin.js": "a0141e5e3fae3c0327708840ead1b34243f3ff4c43bb0dd4a3a3a886c5eeef05",
-    "https://deno.land/x/lodash_es@v0.0.2/src/multiply.js": "bd25a8797114fc5e00b432f75019df23e6a9b015009ef89b0a0a0d10b97301ce",
-    "https://deno.land/x/lodash_es@v0.0.2/src/negate.js": "461b37451823d07c678fc33e6d237fbf082922da802ffc756c3024f1c0addffc",
-    "https://deno.land/x/lodash_es@v0.0.2/src/next.js": "c2cbfd2d4aacebd559d8b2eb8df8747e13480a151ac2c7dcf4114fd9543d3110",
-    "https://deno.land/x/lodash_es@v0.0.2/src/noop.js": "b0dc31de67593b6fe56a49b13f3d7da222668daf3f8ef7b475903d30a98a7331",
-    "https://deno.land/x/lodash_es@v0.0.2/src/now.js": "1304c9968c6c069d6529465225da0dbccf18055c0e340eda213ce6c47565a58f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/nth.js": "44200179398b85cd2b2d868899a2251551212eec706a8bdd7c761e6549536cad",
-    "https://deno.land/x/lodash_es@v0.0.2/src/nthArg.js": "233ec286f68e7128370453608a895259159b4987d63a0a9d188dfba45758b403",
-    "https://deno.land/x/lodash_es@v0.0.2/src/number.default.js": "f7a5aa9bcd19b5cf1f224cffd61b6c305047fe245b5a8444a1cb70cfcf5054ec",
-    "https://deno.land/x/lodash_es@v0.0.2/src/number.js": "c2ebc2da8255d315df4a82dff158c62424f3e8917818f59a698828e8e9b34cc1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/object.default.js": "8f062031cd3241c9ff128910bb4f2cd69818b88a84b68ce3b2ab5f21c7da25ac",
-    "https://deno.land/x/lodash_es@v0.0.2/src/object.js": "5b1a01f3756508d03c794a70c755429f4741a413b40530c83dab7057825e975b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/omit.js": "de577fc677627a1381062f61549754ec88049b759175216708bdeb08984b5784",
-    "https://deno.land/x/lodash_es@v0.0.2/src/omitBy.js": "4c6d3f52653c623a13967e03d84c5c7a638cb118c80ca5c157ff60d347027701",
-    "https://deno.land/x/lodash_es@v0.0.2/src/once.js": "b6d9d8f42abf3ec177d6bb3632fbe5db292441c66018ed13072665e4828d3366",
-    "https://deno.land/x/lodash_es@v0.0.2/src/orderBy.js": "748bf0a440c4fc0200e6ef7158c10c695bf3451ed952242b3556fbf954550fa5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/over.js": "16238cc4efe5a906dffee54298abd504e9bdf306fcd30b44fe7a22e6a9ddfec5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/overArgs.js": "346972ca09cf07271977ec84d9edf6e86e0b5b3b4ac1b683d081336a68bf4fa2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/overEvery.js": "29fbcb5593c6c7daefd81a536537234929625dec99d13df7373b64337afc1585",
-    "https://deno.land/x/lodash_es@v0.0.2/src/overSome.js": "36d471202c49a36aac229733d6acf61074a4fcc59ef9d63987e5b0e002384011",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pad.js": "8716d6d74fd135c6a8a6d7e974e2fbb8aada314822c36c30ac559ce0ef6ba796",
-    "https://deno.land/x/lodash_es@v0.0.2/src/padEnd.js": "7cd63db7530ed1cc4fa79fdbec6d96f5af6b7a6aa5dc6d0347bc2c83bda7521b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/padStart.js": "327dee6206cc7047db081142ddc3ac17b717ee2949a43405e0e20a02feda08d9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/parseInt.js": "8dbdf16a45391777cb57ec9ee2e0e129a8aaa5871c4e2ed32d4efb81520a1cd5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/partial.js": "0851972788dce2f4e0f3a69322a45ccda88bff73640d17dccbdd27e4ad9538f1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/partialRight.js": "ca155c45a83dfeb4ac343b195904504788c51c389d5d61bc869f5d420179b181",
-    "https://deno.land/x/lodash_es@v0.0.2/src/partition.js": "3c45e0644b7ef63d784f48f953d0e0b735d1a1b2561af343717614c3c8c9340b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pick.js": "5c84703ee65d5c937b8565c4f55875364cd52e983529f9d984a735eef283c3ff",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pickBy.js": "9e1d4befd724af1ae594bcf53ca198cac912054f1f62ebe0af94f8e89b7de687",
-    "https://deno.land/x/lodash_es@v0.0.2/src/plant.js": "9fb5f2532d4482e38d4a6829749e8c3a86fb3849d86aadbd50901ab05a1b9581",
-    "https://deno.land/x/lodash_es@v0.0.2/src/property.js": "e922d6d26711a4aab2654fd17e0d1e59c4fbbdcca9482ac047f9ca90c2217e2c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/propertyOf.js": "a85c19e48ee98afe897f31d6581f7f145baf9a1a46a2c95ce64068875d655f10",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pull.js": "53374684e47e67d720aeda1dd69e18453ac333570720d63940db8b04f0ea3e61",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pullAll.js": "0a7465cdfd73e47dead2472a697ec442895392b094eeb4309d93666a84ff7955",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pullAllBy.js": "e735efbc19b88c4e40bba4860fb8486d3715ac66bfd24407fb3505aa1d711901",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pullAllWith.js": "7d140bd317ff00966450e65d6cb43f310ccb681b1b3f0cd1ca2daeee2cf01305",
-    "https://deno.land/x/lodash_es@v0.0.2/src/pullAt.js": "6e4de44eace5e186d1d623626aa4aee6473e37964c5296081c2404bd6ba01d09",
-    "https://deno.land/x/lodash_es@v0.0.2/src/random.js": "119b40bf65e8709ab233d6403b9c6fbee7f2a617bdc7f6334e2c755abc66e2e4",
-    "https://deno.land/x/lodash_es@v0.0.2/src/range.js": "30e4286aca42f47d01e32466f4cc326fdebe5e06f8bed8c87cd9d2753b037915",
-    "https://deno.land/x/lodash_es@v0.0.2/src/rangeRight.js": "83366149703d4b593ac8ad4c09af0142c3cdea41b905903091b7def7dca910f1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/rearg.js": "7793b212aef31b6963ef91fd56f2c75e0f348c51992d8c87d723ecd7cd95f973",
-    "https://deno.land/x/lodash_es@v0.0.2/src/reduce.js": "6aae033a085de22c5b6318da0f6142a026183a0828fc5b20c62cc8c3647aa68b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/reduceRight.js": "e93f34bbdb333d9968c40a8c3eb7718c6a86fd0de3ae341079b554bb4cf1be57",
-    "https://deno.land/x/lodash_es@v0.0.2/src/reject.js": "5db125b64943ca59af8ff7edd7a5ec37c23cf291c16138556924447c87611711",
-    "https://deno.land/x/lodash_es@v0.0.2/src/remove.js": "250bb03dff4c1c1c1c33545ba1cd04af1bdb4cbfcf950cc0d639e8fcefaafdfb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/repeat.js": "6fa2ff6386de5da11494c9082690d7612bdce435c6e87592988e8d7e21e4d488",
-    "https://deno.land/x/lodash_es@v0.0.2/src/replace.js": "e8d818b14f93bba6ade97919cac8f5370912f1f430432a2b75f458c195b76cc7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/rest.js": "1428e6fc70b2684561964fe5eb8352ea0364a9ee5b46f5620371f123cfa229f3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/result.js": "5fdecc93f02850527024ad98fb2e098b91eed34923312023c7e4c2a1c2a1ed6d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/reverse.js": "3741dfc2453a170236c4cbea43197d105402df608c2b9336fc372f7943b4f1c6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/round.js": "cb6c0c8b7596aef61bdc145d18c7caa0e07718cb587cd904716bb50753a2d9eb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sample.js": "8b04bf4fe0a86e05894652d22e1ebe96c762ec4c0f1e93cf7e8139ac68250eb2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sampleSize.js": "831f09b947dd21f9bf4fe26944b981df46c198b6ce023af242b3c040fb6c75b0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/seq.default.js": "85d89c5533fc51ab3760b2edd0c1d4bec5503ee60c4f2b98d3cd04f11276a69d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/seq.js": "929986548a10e45b9ac7112cecfeb5b48167430633e50d9e0f4ec67c612467b7",
-    "https://deno.land/x/lodash_es@v0.0.2/src/set.js": "7503458fc8d205755377bf365b24954bd19b63665068ef3dd1574c6e87ec67e0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/setWith.js": "861cd9425ed707ca61c34ad3caa4b8f97c3f5f42255826760905bdade30ea38e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/shuffle.js": "ef326a20311d872f8d7fedd6e90417a8f828edfc3a10bf0925118ca17082aa7a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/size.js": "1caf9f4be482114ffe1acb122d8566bf5da0581026f67905a0049f3fe3fadb2c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/slice.js": "a85183b29ce9d44f3a040511fb22c7240f9fc9394bc42a192972939629a3e9c2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/snakeCase.js": "055d2713e0c99bcbb0bc56eb309c12c126998faac90ca7287819b5e5b4c9e32f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/some.js": "f4300769ebbf2f71ddcae7e8c8f1a44817699002212a9a25eb6a4271188ec49a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortBy.js": "24a2d5a13880d6aac426e839248ebcaf401ca6231720abe4e7426a2c06e77c5c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedIndex.js": "73e22e1d0b28fdc38325b253151fb4fcfc3d0665c8af71c09eeed4326d6e2a7e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedIndexBy.js": "583cb3e8af550fb5e162b2ea1a7ed84cf7655646c39f551fcf763e8b02cf6af5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedIndexOf.js": "99d1f781190ca698e18bb20fa286c2b4d43ae0a1fe57c48f130255916aa90d44",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedLastIndex.js": "67658f39de67a6a24296a71f91b0cea27952b408a2a78055931232fd6b117806",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedLastIndexBy.js": "a4552a970fff174cf62ab30cc17a0a5451e5122184afca0c43049803fec68cf1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedLastIndexOf.js": "0e52f8e23cf9c0daf6eb5d793299fe11fbb1b8be1bf22d2e66cf10636adbbe41",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedUniq.js": "0b23aa21cf887a1db228d20ecc388f5cc4ad6a0f40a3e8935d4aa44410a69c95",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sortedUniqBy.js": "e2f662094aceab8ac43ffabcf53745bfc9d08fc5e718f60e317429e32f623326",
-    "https://deno.land/x/lodash_es@v0.0.2/src/split.js": "354bc0faaf242c6ebc8218ea03d9c112272978010c385e4fbfd774d4d8103870",
-    "https://deno.land/x/lodash_es@v0.0.2/src/spread.js": "e5c22f18dd30065de7cce993793c7536dabba4c82a6c151ea2fab4ebc9bc41e9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/startCase.js": "be0a1c8b49f1433805aa9ac19493128132cb08210515717d5c725af136095667",
-    "https://deno.land/x/lodash_es@v0.0.2/src/startsWith.js": "0c477f52e8333dfa772e571912590821a980efe013f2d79e0fc9575df17452e9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/string.default.js": "f3485fb9b6529688414d90aa81939d8089833dc0ac17cbcba9dbe3e5c1c3da3c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/string.js": "7a0743b5bafcde641e5c3e80af10f9c6d37a5bf5b662590bafb79a746930d77c",
-    "https://deno.land/x/lodash_es@v0.0.2/src/stubArray.js": "fbb65461e7df8d72ba98065d2db95b3b781a66c58e396e2c76f8264d427b705e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/stubFalse.js": "fd1d278ab0f9329d2b39c180bb97fcbfb609ec117f89443fc2ed898b633493ea",
-    "https://deno.land/x/lodash_es@v0.0.2/src/stubObject.js": "a5ffecb629ea2040db6d37e73e3672c349397cf315a2af619e91d115efe41cfa",
-    "https://deno.land/x/lodash_es@v0.0.2/src/stubString.js": "cfe6783a15bd424881aa87530d01a0a618e35d0c7f2cfe87de3b6ee680a1e2b0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/stubTrue.js": "eda9e41310626951dbdca8c9b52dd440382e3e8bc0c6cd99e8a36658216ec91f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/subtract.js": "29eeabfc41be5aaed5324f567783bbccb7e3ad4a81a911ef6618e9d4c83e7c51",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sum.js": "d34e99934eccd924c73f914986f937929a6df4fe2e8899e8dcc3fcca79647bcf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/sumBy.js": "58f18be82af0409278563c13ad72f2a39ed67b43028a5cf71a434cb6c947b057",
-    "https://deno.land/x/lodash_es@v0.0.2/src/tail.js": "9c3cc597c96183300338b1d0d69206df264a0dd5bd263613162b3da6174f884d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/take.js": "b2a983f35fc0888464592471fcd9ae72f33071420dbda1d6a60e01c2b8cf0725",
-    "https://deno.land/x/lodash_es@v0.0.2/src/takeRight.js": "6e427b970813a00c2650c8c40dcf840b64f91e4996363eff620493c859dbec5a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/takeRightWhile.js": "1c85009412c448e2a1cf44a6dab98fe588cc74c1b41be5611bc938a6b07d5d6e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/takeWhile.js": "9e4367f55e8826c2bea398783fe24e4eb00fac7fecea4cafca158f3a29555207",
-    "https://deno.land/x/lodash_es@v0.0.2/src/tap.js": "adc395245a0aaf4a5635b68441bb5fde116035c1c43738840d9792d7c862c477",
-    "https://deno.land/x/lodash_es@v0.0.2/src/template.js": "9b2c0d8fff7df15d9b6b8031dc8db392c8d2ca88cb4b5e2f80c715de4cf09229",
-    "https://deno.land/x/lodash_es@v0.0.2/src/templateSettings.js": "319ee09d1cbd22dab0bc302e3935c33da9a1432888817a88407076156dbeac85",
-    "https://deno.land/x/lodash_es@v0.0.2/src/throttle.js": "d236ef311beb5042f68688ddc473e473edfe9be3b1ec5806431ad97828f4ac16",
-    "https://deno.land/x/lodash_es@v0.0.2/src/thru.js": "c7e1b7a237dc3668c88d64b3fc9c2b1d6bc68db50949c8b10d73b2101c8cb55d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/times.js": "e1a725236bfbf7ea2d245694e88f3a4eb2aaf310bb1a115b2c2cb48f0b8d2080",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toArray.js": "9dfc67af6a6b4506ac5ec28840c9026e473637e365cce55dfdeb300e2d4f2280",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toFinite.js": "ba02408b127cd0d31ad263fd21aac6a6a7a66257354b30afe897e6c1da166e94",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toInteger.js": "f727679fc4f778f078e768df837d2a68f8d3430217cf2a3adf536d784d1d921e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toIterator.js": "f9be4cb6620b531ad18eeef95b60fca80d61736e8c7eee9e3c61a05040a6b2c2",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toJSON.js": "1453c4073e4a4329d407b4e53ce8b9974e2f802c8ba07a5d0bc62b857e58cef5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toLength.js": "de08d40fabf2709e153e60f19dd110f1927e6be6c26ba2f1b713fd446a627786",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toLower.js": "94c42e39060ece35a2046d04daac3638d4915447df90190f26e6a391ace2c352",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toNumber.js": "05f8ad055069ca69ac0c91112a70906367e167a088bd4d6b84f15cb0b100a2e0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toPairs.js": "3fa74c8504fbc8d87955c76616fd80bf82b9c1d3fa001f103fc35366cebc111e",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toPairsIn.js": "7dcf13df048e33f74cc8bcbace35961feea077b993d07b901c4508fee90f82b6",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toPath.js": "59aef05ec627bec95468bb333e199e2d2fc996182baf6501534b34373d0deb61",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toPlainObject.js": "9345d80139f01e8768e0a134266ea2fc1196c22afc0f4022de66cb9a68b52a70",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toSafeInteger.js": "ce0e7eb4532d5949eb194fe5404ef558669d57967142e97f3cc3e893a8365023",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toString.js": "3f4c8d942944c3fe622e9fba36275b6291e834113619b266909822becfa94976",
-    "https://deno.land/x/lodash_es@v0.0.2/src/toUpper.js": "fee2b732b867e3ccaeb69a1c2f98d54300b459841e17e576a2142d237b057435",
-    "https://deno.land/x/lodash_es@v0.0.2/src/transform.js": "508fbac08dd70532c12dca1e1efeb5e937095994580aa306352785a135cee993",
-    "https://deno.land/x/lodash_es@v0.0.2/src/trim.js": "251ae2854c76426244485216ffb88b61e8948a39239f57d9a69407b7627e609f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/trimEnd.js": "475f85bcb3ec34b3de8f3e0c323232179988880ad059c45fe23b7574b68f7395",
-    "https://deno.land/x/lodash_es@v0.0.2/src/trimStart.js": "1c5b3a8e7226a8bde644c0836f1ba2e8c4b2e6debae1aceae08300dee88ed37a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/truncate.js": "b116e6ed31492932587acc457c1ce683cb864ed06707e951514e342d2b22b0c5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unary.js": "a970bfadd5311ae210819c1c4ee40efb5fd10f7285aa70ef3a18145a50449ea3",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unescape.js": "3ace360684af3a8e3d537b294ce05ec377cf2fb9c1b9002720a8f9e30fa36b3f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/union.js": "16c4fb976d5485b2ff9b5368dd260696957adb1ffff33377208a20488dba2205",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unionBy.js": "47f2561ca2ed97fcc07c5823c03b973283a5da0931619fc3cd297ac62fedd404",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unionWith.js": "7982c75cf58ece511df61df6506e1dee0c82de03db121a4e2d73ea5e74f8de04",
-    "https://deno.land/x/lodash_es@v0.0.2/src/uniq.js": "aedaa761b16b87507196d94179f7bc4983ba86e0c5dc7efae58f883fa61f8679",
-    "https://deno.land/x/lodash_es@v0.0.2/src/uniqBy.js": "67f54eed7b2feb663054d029e663de822c34f0f00f91ff28b6884e1f2309f2a5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/uniqWith.js": "0e5b825c82b8f7bba2353dd65d9b88a5544906b8a55562ad8cefca6af655874b",
-    "https://deno.land/x/lodash_es@v0.0.2/src/uniqueId.js": "f33804ffeaa9f151d528813b65cf4bd1dc3eae001bf3dee63423c009e0c40df0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unset.js": "c6033f2817b249f7a323ba5bb5a8a6ad47a4a30a41f09c4a69afe13d9fce204a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unzip.js": "8003e42eac6b1d40d48896ed9428414e4891bbe3a231ada9dbeb1e89e577ccd0",
-    "https://deno.land/x/lodash_es@v0.0.2/src/unzipWith.js": "a934f1e9f84a55fbbe3d41b2a42d732cca04b279de9542bf44608ae85f496795",
-    "https://deno.land/x/lodash_es@v0.0.2/src/update.js": "d8ddb4114aa2101e775c1d64d5d475208ee9b9b72753342b9516a6e085217426",
-    "https://deno.land/x/lodash_es@v0.0.2/src/updateWith.js": "2098b44cb6587176812d65c78cbdc159095ffaf745d8055bba2c1e242af03c5f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/upperCase.js": "70747558f308524e539d53d0c039942f310cdb26f99176ada4d57f1b22dab909",
-    "https://deno.land/x/lodash_es@v0.0.2/src/upperFirst.js": "1923b5661a65f9efb07814acca2c33d5f31e7e38c9021f7db432f1d03dc2bf05",
-    "https://deno.land/x/lodash_es@v0.0.2/src/util.default.js": "e2751dc8841c303c27c951703d0f404e75429a42e1e5d273b63c505fdff9a97a",
-    "https://deno.land/x/lodash_es@v0.0.2/src/util.js": "54ab6bd0ad9847e4d54a5f6ccaaa2d038539ba742516b2b0c542cf820e16dfdf",
-    "https://deno.land/x/lodash_es@v0.0.2/src/value.js": "1453c4073e4a4329d407b4e53ce8b9974e2f802c8ba07a5d0bc62b857e58cef5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/valueOf.js": "1453c4073e4a4329d407b4e53ce8b9974e2f802c8ba07a5d0bc62b857e58cef5",
-    "https://deno.land/x/lodash_es@v0.0.2/src/values.js": "e12a6336a23ef03323b05f52df5a04f76c76bfe831dfd7e0143e521d6ec96a6f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/valuesIn.js": "056b75ae09c36b3c628812813c85f1051eda94b664ce02147aff19f79fc98b1d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/without.js": "41af88c983594364a34d470dbf651bca7ffbd1beea207bc6b3ad606d87feca78",
-    "https://deno.land/x/lodash_es@v0.0.2/src/words.js": "a999d2d5d77affc8fa93047e232fc80183d1b05b3b05c0be58780a3624adf52f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/wrap.js": "a1fb50883c3bbb8165397732b86c382473028d4856721ed161017489c7a90fe1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/wrapperAt.js": "985f9b4a1694e1f389bd9efb3254d8861a16c9ceb683d9ceeef6b90c79b2f267",
-    "https://deno.land/x/lodash_es@v0.0.2/src/wrapperChain.js": "deebd61a77b4fab8be5464043e04e9ed74cabb8b91138471a0a27dac989e8efb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/wrapperLodash.js": "e274921afa7b72319d09c91a4ac494819ada924e6070c3092b0963feb110b7e1",
-    "https://deno.land/x/lodash_es@v0.0.2/src/wrapperReverse.js": "9e207c5f34f78d98f6ef1c51d5a2afbe5cf9892b73859f5f4199e4319cc41eab",
-    "https://deno.land/x/lodash_es@v0.0.2/src/wrapperValue.js": "26a1a5d2d17aace1d97a97f7242193f8de2a4bcd462f2ddcbe048998da01959d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/xor.js": "a67d291736b87537b6018d038517aba170244ca381aadce572ab42051edd6922",
-    "https://deno.land/x/lodash_es@v0.0.2/src/xorBy.js": "4dee71c05e32209d14d58a50c7019295fac137f3cef63101871e8bd8bc81a3d9",
-    "https://deno.land/x/lodash_es@v0.0.2/src/xorWith.js": "07193048382dffe5dcf6f8d0fa284299aea90779621f2982c6db4475fa41e41d",
-    "https://deno.land/x/lodash_es@v0.0.2/src/zip.js": "4c27073c4d77c0233fe9000da62de50991bc6806da0aa446818427664d2fc780",
-    "https://deno.land/x/lodash_es@v0.0.2/src/zipObject.js": "e069bf473251b19f39587b9bdbfce017d0cd0ec2abe835fedcd1c9ab68a0ac4f",
-    "https://deno.land/x/lodash_es@v0.0.2/src/zipObjectDeep.js": "5ace286d0c9b25960c1e1ffd11e4d1d9eb10c847c99d2ac6ac56460367262edb",
-    "https://deno.land/x/lodash_es@v0.0.2/src/zipWith.js": "0ff58c20b2716a05db1d0e72b94b4e3c55c6e293e6e6ed8c47abf17706fc9a5f",
-    "https://deno.land/x/ulid@v0.3.0/mod.ts": "f7ff065b66abd485051fc68af23becef6ccc7e81f7774d7fcfd894a4b2da1984",
     "https://esm.sh/@hapi/hoek@9.3.0/denonext/lib/applyToDefaults.mjs": "2d344eac743ca2020c5279b950773169ca29aeba2636cf5a24fb3c731d09ddca",
     "https://esm.sh/@hapi/hoek@9.3.0/denonext/lib/assert.mjs": "2a2e50ad798e752b75a953d5b35fca7a783b63f5d071ac76a7507a71e8800ada",
     "https://esm.sh/@hapi/hoek@9.3.0/denonext/lib/clone.mjs": "d90b9c37dca829c1c470a928208145199096eb76545c090738213e22f8073794",
@@ -2099,8 +1543,6 @@
     "https://esm.sh/isexe@3.1.1?target=denonext": "b3c61e7e70b9d56865de461fbcdae702ebf93743143457079a15a60e30dfcf83",
     "https://esm.sh/joi@17.13.3": "48329caa5c606750511c6d790442e5d3249e6650b97131dd32f2a74e74bedcd3",
     "https://esm.sh/joi@17.13.3/denonext/joi.mjs": "e4f3b0b742c83f9b70df9d1c23f9d867418a2004768b27223fbf8d19f1fb5739",
-    "https://esm.sh/joi@17.9.1": "6f7e336415084e7f12bfee20f442ba7b6089db28b1107c3e5f80cae0c431888b",
-    "https://esm.sh/joi@17.9.1/denonext/joi.mjs": "4508f3d20b2567e6d0edc6820c748c32cce421ca1b049764f0870e55b526676a",
     "https://esm.sh/which@4.0.0": "50b06c1a68e3ef88dc8e2c68c17b732a6d1917000d5d59637496da3b61549c8e",
     "https://esm.sh/which@4.0.0/denonext/which.mjs": "9f47207c6dc9684fe3d852f2290c474577babaeabf60616652630c0b90421a53"
   },
@@ -2152,6 +1594,23 @@
           "npm:node-fetch@2.7.0",
           "npm:toml@3.0.0",
           "npm:web-streams-polyfill@3.3.3"
+        ]
+      },
+      "bin/si-mcp-server": {
+        "dependencies": [
+          "jsr:@cliffy/command@^1.0.0-rc.8",
+          "jsr:@onjara/optic@^2.0.3",
+          "jsr:@std/assert@1",
+          "jsr:@std/encoding@^1.0.10",
+          "jsr:@systeminit/api-client@^1.0.3",
+          "jsr:@systeminit/cf-db@~0.1.4",
+          "npm:@modelcontextprotocol/sdk@^1.16.0",
+          "npm:axios@^1.6.1",
+          "npm:jwt-decode@4",
+          "npm:lodash@^4.17.21",
+          "npm:ulid@^3.0.1",
+          "npm:zod-to-json-schema@^3.24.6",
+          "npm:zod@^3.21.4"
         ]
       },
       "lib/jsr-systeminit/ai-agent": {

--- a/generated-sdks/typescript/deno.json
+++ b/generated-sdks/typescript/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@systeminit/api-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript/JavaScript SDK for the System Initiative Public API",
   "exports": {
     ".": "./index.ts"

--- a/generated-sdks/typescript/deno.lock
+++ b/generated-sdks/typescript/deno.lock
@@ -1,0 +1,158 @@
+{
+  "version": "4",
+  "specifiers": {
+    "npm:@types/node@18": "18.19.120",
+    "npm:axios@^1.6.1": "1.11.0",
+    "npm:typescript@5": "5.8.3"
+  },
+  "npm": {
+    "@types/node@18.19.120": {
+      "integrity": "sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios@1.11.0": {
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dependencies": [
+        "follow-redirects",
+        "form-data",
+        "proxy-from-env"
+      ]
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "follow-redirects@1.15.9": {
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+    },
+    "form-data@4.0.4": {
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "proxy-from-env@1.1.0": {
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "typescript@5.8.3": {
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="
+    },
+    "undici-types@5.26.5": {
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@types/node@18",
+        "npm:axios@^1.6.1",
+        "npm:typescript@5"
+      ]
+    }
+  }
+}

--- a/generated-sdks/typescript/package.json
+++ b/generated-sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-initiative-api-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript/JavaScript SDK for the System Initiative Public API",
   "author": "System Initiative <support@systeminit.com>",
   "repository": {


### PR DESCRIPTION
Adds an MCP server! Currently supports:

* Managing change sets
* Managing components
* Troubleshooting functions 
* Managing actions
* Reviewing schmea for AWS components only

Doesn't work yet for credentials, IAM policy, and a few other things. Has some buck2 integration, and wants to ship a docker container, but needs a bit of work to actually figure that out.

## How does this PR change the system?

It allows you to run an MCP server with something like claude code and do fun things.

## How was it tested?

All by hand. We'll have to roll our own test suite at some point!
