### PR TITLE
feat(wb): Hide unconnected when visualizing connections

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -599,6 +599,10 @@ const navigateToMap = () => {
   query.map = "1";
   if (component.value?.id) {
     query.c = component.value.id;
+    // Add flag to hide unconnected components
+    // This is a specific path through to the Map to show only the items
+    // that would effectively show in a pin
+    query.hideUnconnected = "1";
   }
 
   router.push({

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -334,6 +334,7 @@ export type SelectionsInQueryString = Partial<{
   viewId: string;
   searchQuery: string;
   retainSessionState: string; // If set, the component should load up with the last state it had on this tab. Used by Explore.vue
+  hideUnconnected: string; // Flag to hide unconnected components when navigating to map
 }>;
 
 const compositionLink = computed(() => {


### PR DESCRIPTION
When navigating to the map as part of the vizualising of connections 
from the component details page, we want to behave similar to how pin 
Works. This means we will show the direct connections in and out of the 
Component and then hide everything else

https://jam.dev/c/03c9fe2c-e195-49ed-8d5d-3e0b3359b472