### PR TITLE
feat(web): Show the number of hidden components on a search

### DIFF
--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -161,6 +161,39 @@
       </span>
     </div>
   </div>
+  <div
+    v-else-if="row.type === 'filteredCounterRow'"
+    class="flex items-center justify-center gap-1"
+  >
+    <span
+      :class="
+        clsx('text-xs', themeClasses('text-neutral-600', 'text-neutral-300'))
+      "
+    >
+      {{ row.hiddenCount }} components hidden
+    </span>
+    <span
+      :class="
+        clsx('text-xs', themeClasses('text-neutral-600', 'text-neutral-300'))
+      "
+    >
+      |
+    </span>
+    <button
+      :class="
+        clsx(
+          'text-xs underline cursor-pointer hover:no-underline',
+          themeClasses(
+            'text-neutral-600 hover:text-black',
+            'text-neutral-300 hover:text-white',
+          ),
+        )
+      "
+      @click="emit('resetFilter')"
+    >
+      Reset Filter
+    </button>
+  </div>
   <!-- This is subtle, but important. We need a div here, even if empty. -->
   <div v-else>
     <!-- footer area -->
@@ -343,6 +376,7 @@ const emit = defineEmits<{
   (e: "clickCollapse", title: string, collapsed: boolean): void;
   (e: "childSelect", componentIdx: number): void;
   (e: "childDeselect", componentIdx: number): void;
+  (e: "resetFilter"): void;
 }>();
 
 defineExpose({ exploreGridComponentRefs });
@@ -373,6 +407,10 @@ export type ExploreGridRowData =
   | {
       type: "emptyRow";
       groupName: string;
+    }
+  | {
+      type: "filteredCounterRow";
+      hiddenCount: number;
     };
 </script>
 


### PR DESCRIPTION
If a user has a search that filters out a number of components on the 
grid, we want to tell them how many it filtered out so it’s more clear 
to the user

https://jam.dev/c/e373ac82-df13-477d-b433-40a0dad3e918