### PR TITLE
fix(web): Prevent readonly field interaction causing a new change set on HEAD

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -88,10 +88,10 @@
                 : [!readOnly && themeClasses('text-shade-100', 'text-shade-0')],
             )
           "
-          tabindex="0"
-          @focus="openInput"
+          :tabindex="readOnly ? -1 : 0"
+          @focus="(e) => !readOnly && openInput()"
           @keydown.tab="(e) => (readOnly ? onTab(e) : null)"
-          @click.left="openInput"
+          @click.left="(e) => !readOnly && openInput()"
         >
           <TruncateWithTooltip>
             <template v-if="(isArray || isMap) && !isSetByConnection">
@@ -1069,8 +1069,12 @@ const labelRect = ref<undefined | DOMRect>(undefined);
 const inputTouched = ref(false);
 
 const resetEverything = () => {
+  // Don't reset form state for readonly fields
+  // as this can trigger a value form update
+  if (readOnly.value) return;
+
   resetFilteredOptions();
-  valueForm.reset();
+  if (!valueForm.state.canSubmit) valueForm.reset();
   mapKey.value = "";
   mapKeyError.value = false;
   selectedIndex.value = defaultSelectedIndex();


### PR DESCRIPTION
Fixes: https://linear.app/system-initiative/issue/BUG-922

When on HEAD, we were seeing a new change set being created when going 
to the component details page and interacting with a readonly componemt.
the issue was because of the following chain of events:

  1. Click on readonly field → openInput() called
  2. openInput() → calls resetEverything()
  3. resetEverything() → calls valueForm.reset()
  4. valueForm.reset() → triggers form watchers/reactive updates
  5. Form reactive updates → potentially emit "save" event
  6. "save" event → bubbles to AttributePanel → calls save() function
  7. save() function → makes API call to UpdateComponentAttributes
  8. API call → triggers changeset creation if on HEAD