### PR TITLE
feat(dal): default subscriptions for scalar values

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -330,7 +330,7 @@ impl Action {
         let mut actions = vec![];
         let snap = ctx.workspace_snapshot()?;
         let action_category_id = snap
-            .get_category_node_or_err(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(CategoryNodeKind::Action)
             .await?;
 
         for action_idx in snap
@@ -406,7 +406,7 @@ impl Action {
     ) -> ActionResult<Option<ActionId>> {
         let snap = ctx.workspace_snapshot()?;
         let action_category_id = snap
-            .get_category_node_or_err(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(CategoryNodeKind::Action)
             .await?;
 
         for action_idx in snap
@@ -486,7 +486,7 @@ impl Action {
 
         let action_category_id = ctx
             .workspace_snapshot()?
-            .get_category_node_or_err(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(CategoryNodeKind::Action)
             .await?;
         Self::add_incoming_category_edge(
             ctx,
@@ -643,7 +643,7 @@ impl Action {
     pub async fn all_ids(ctx: &DalContext) -> ActionResult<Vec<ActionId>> {
         let action_category_node_index = ctx
             .workspace_snapshot()?
-            .get_category_node_or_err(None, CategoryNodeKind::Action)
+            .get_category_node_or_err(CategoryNodeKind::Action)
             .await?;
         let action_edges = ctx
             .workspace_snapshot()?

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -121,6 +121,7 @@ use crate::{
 };
 
 pub mod debug;
+pub mod default_subscription;
 pub mod dependent_value_graph;
 pub mod is_for;
 pub mod subscription;
@@ -467,6 +468,13 @@ impl AttributeValue {
         destination_id: InputSocketId,
         add_fn: add_edge_to_input_socket,
         discriminant: EdgeWeightKindDiscriminants::Socket,
+        result: AttributeValueResult,
+    );
+    implement_add_edge_to!(
+        source_id: AttributeValueId,
+        destination_id: Ulid,
+        add_fn: add_default_subscription_source_edge,
+        discriminant: EdgeWeightKindDiscriminants::DefaultSubscriptionSource,
         result: AttributeValueResult,
     );
 

--- a/lib/dal/src/attribute/value/default_subscription.rs
+++ b/lib/dal/src/attribute/value/default_subscription.rs
@@ -1,0 +1,242 @@
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+    VecDeque,
+};
+
+use si_id::{
+    AttributeValueId,
+    ComponentId,
+    PropId,
+    ulid::Ulid,
+};
+
+use super::{
+    AttributeValue,
+    AttributeValueResult,
+    subscription::ValueSubscription,
+};
+use crate::{
+    Component,
+    DalContext,
+    EdgeWeight,
+    EdgeWeightKind,
+    EdgeWeightKindDiscriminants,
+    Prop,
+    PropKind,
+    Schema,
+    SchemaVariant,
+    attribute::path::AttributePath,
+    prop::ResolvedPropSuggestion,
+    schema::variant::SchemaVariantResult,
+    workspace_snapshot::node_weight::{
+        CategoryNodeWeight,
+        NodeWeight,
+        category_node_weight::CategoryNodeKind,
+    },
+};
+
+async fn get_or_create_default_subscription_category(
+    ctx: &DalContext,
+) -> AttributeValueResult<Ulid> {
+    let snapshot = ctx.workspace_snapshot()?;
+
+    Ok(
+        match snapshot
+            .get_category_node(CategoryNodeKind::DefaultSubscriptionSources)
+            .await?
+        {
+            Some(id) => id,
+            None => {
+                let static_id = CategoryNodeKind::DefaultSubscriptionSources
+                    .static_id()
+                    .unwrap_or_default();
+
+                let node_weight = CategoryNodeWeight::new(
+                    static_id,
+                    static_id,
+                    CategoryNodeKind::DefaultSubscriptionSources,
+                );
+                snapshot
+                    .add_or_replace_node(NodeWeight::Category(node_weight))
+                    .await?;
+                let root_id = snapshot.root().await?;
+                snapshot
+                    .add_edge(
+                        root_id,
+                        EdgeWeight::new(EdgeWeightKind::new_use()),
+                        static_id,
+                    )
+                    .await?;
+
+                static_id
+            }
+        },
+    )
+}
+
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct DefaultSubscription {
+    pub source_av_id: AttributeValueId,
+    pub dest_av_id: AttributeValueId,
+}
+
+impl DefaultSubscription {
+    /// NOTE: This will clobber existing subscriptions
+    pub async fn subscribe(&self, ctx: &DalContext) -> AttributeValueResult<()> {
+        let (root_attribute_value_id, path) =
+            AttributeValue::path_from_root(ctx, self.source_av_id).await?;
+        let subscription = ValueSubscription {
+            attribute_value_id: root_attribute_value_id,
+            path: AttributePath::from_json_pointer(path),
+        };
+
+        AttributeValue::set_to_subscriptions(ctx, self.dest_av_id, vec![subscription], None).await
+    }
+}
+
+pub async fn detect_possible_default_connections(
+    ctx: &DalContext,
+    destination_component_id: ComponentId,
+    suggestions: &BTreeMap<PropId, BTreeSet<ResolvedPropSuggestion>>,
+) -> AttributeValueResult<Vec<DefaultSubscription>> {
+    let source_attribute_values = AttributeValue::get_default_subscription_sources(ctx).await?;
+    if source_attribute_values.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut potential_source_props = BTreeMap::new();
+    for source_attribute_value_id in source_attribute_values {
+        let prop_id = AttributeValue::prop_id(ctx, source_attribute_value_id).await?;
+        let prop = Prop::get_by_id(ctx, prop_id).await?;
+        // TODO: Support for objects, maps, and arrays will come next,
+        // to support them we have to do a deep comparison on the two
+        // prop types.
+        if !matches!(
+            prop.kind,
+            PropKind::String | PropKind::Integer | PropKind::Boolean
+        ) {
+            continue;
+        }
+
+        potential_source_props.insert(prop_id, (prop, source_attribute_value_id));
+    }
+
+    let mut result = vec![];
+
+    let root_av_id = Component::root_attribute_value_id(ctx, destination_component_id).await?;
+    let root_children = AttributeValue::child_av_ids(ctx, root_av_id).await?;
+    let mut work_queue = VecDeque::from(root_children);
+    while let Some(dest_av_id) = work_queue.pop_front() {
+        let dest_prop_id = AttributeValue::prop_id(ctx, dest_av_id).await?;
+        let prop = Prop::get_by_id(ctx, dest_prop_id).await?;
+        let mut potential = None;
+
+        let children = AttributeValue::child_av_ids(ctx, dest_av_id).await?;
+        work_queue.extend(children);
+
+        if let Some(suggestions) = suggestions.get(&dest_prop_id) {
+            for &suggestion in suggestions {
+                if suggestion.dest_prop_id != dest_prop_id {
+                    continue;
+                }
+
+                let Some((source_prop, source_av_id)) =
+                    potential_source_props.get(&suggestion.source_prop_id)
+                else {
+                    continue;
+                };
+
+                if source_prop.kind == prop.kind {
+                    if potential.is_some() {
+                        // Ambiguous match!
+                        potential = None;
+                        break;
+                    }
+
+                    potential = Some(DefaultSubscription {
+                        source_av_id: *source_av_id,
+                        dest_av_id,
+                    });
+                }
+            }
+        }
+
+        if let Some(potential) = potential {
+            result.push(potential);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Returns a map of potential *destination* prop ids to the
+/// ResolvedPropSuggestion for the entire change set
+pub async fn calculate_all_prop_suggestions_for_change_set(
+    ctx: &DalContext,
+) -> SchemaVariantResult<BTreeMap<PropId, BTreeSet<ResolvedPropSuggestion>>> {
+    let mut result: BTreeMap<PropId, BTreeSet<ResolvedPropSuggestion>> = BTreeMap::new();
+
+    for schema_id in Schema::list_ids(ctx).await? {
+        for variant_id in Schema::list_schema_variant_ids(ctx, schema_id).await? {
+            let mut suggestions = vec![];
+            suggestions.extend(SchemaVariant::props_suggested_as_sources(ctx, variant_id).await?);
+            suggestions
+                .extend(SchemaVariant::props_suggested_as_destinations(ctx, variant_id).await?);
+
+            for suggestion in suggestions {
+                result
+                    .entry(suggestion.dest_prop_id)
+                    .and_modify(|sugs| {
+                        sugs.insert(suggestion);
+                    })
+                    .or_insert_with(|| BTreeSet::from([suggestion]));
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+impl AttributeValue {
+    pub async fn set_as_default_subscription_source(
+        ctx: &DalContext,
+        id: AttributeValueId,
+    ) -> AttributeValueResult<()> {
+        let category_id = get_or_create_default_subscription_category(ctx).await?;
+
+        AttributeValue::add_default_subscription_source_edge(
+            ctx,
+            id,
+            category_id,
+            EdgeWeightKind::DefaultSubscriptionSource,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_default_subscription_sources(
+        ctx: &DalContext,
+    ) -> AttributeValueResult<Vec<AttributeValueId>> {
+        let snapshot = ctx.workspace_snapshot()?;
+
+        let Some(default_subscription_category_id) = snapshot
+            .get_category_node(CategoryNodeKind::DefaultSubscriptionSources)
+            .await?
+        else {
+            return Ok(vec![]);
+        };
+
+        Ok(snapshot
+            .incoming_sources_for_edge_weight_kind(
+                default_subscription_category_id,
+                EdgeWeightKindDiscriminants::DefaultSubscriptionSource,
+            )
+            .await?
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect())
+    }
+}

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -730,7 +730,7 @@ impl Component {
 
         // Root --> Component Category --> Component (this)
         let component_category_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Component)
+            .get_category_node_or_err(CategoryNodeKind::Component)
             .await?;
         Self::add_category_edge(
             ctx,
@@ -1725,7 +1725,7 @@ impl Component {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let component_category_node_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Component)
+            .get_category_node_or_err(CategoryNodeKind::Component)
             .await?;
 
         let component_node_indices = workspace_snapshot
@@ -1753,7 +1753,7 @@ impl Component {
 
         let mut components = vec![];
         let component_category_node_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Component)
+            .get_category_node_or_err(CategoryNodeKind::Component)
             .await?;
 
         let component_node_indices = workspace_snapshot

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -728,7 +728,7 @@ impl Diagram {
         let base_change_set_ctx = &base_change_set_ctx;
 
         if let Some(components_cat_id) = base_snapshot
-            .get_category_node(None, CategoryNodeKind::Component)
+            .get_category_node(CategoryNodeKind::Component)
             .await?
         {
             for component_id in base_snapshot

--- a/lib/dal/src/diagram/diagram_object.rs
+++ b/lib/dal/src/diagram/diagram_object.rs
@@ -73,7 +73,7 @@ impl DiagramObject {
         Self::add_view_edge(ctx, view_id, id, EdgeWeightKind::DiagramObject).await?;
 
         let diagram_object_category_id = snap
-            .get_category_node_or_err(None, CategoryNodeKind::DiagramObject)
+            .get_category_node_or_err(CategoryNodeKind::DiagramObject)
             .await?;
         Self::add_category_edge(
             ctx,

--- a/lib/dal/src/diagram/view.rs
+++ b/lib/dal/src/diagram/view.rs
@@ -131,7 +131,7 @@ impl View {
 
         // Root --> View Category --> View (this)
         let view_category_id = snap
-            .get_category_node_or_err(None, CategoryNodeKind::View)
+            .get_category_node_or_err(CategoryNodeKind::View)
             .await?;
         Self::add_category_edge(ctx, view_category_id, id.into(), EdgeWeightKind::new_use())
             .await?;
@@ -187,7 +187,7 @@ impl View {
         let snap = ctx.workspace_snapshot()?;
 
         let category_node = snap
-            .get_category_node(None, CategoryNodeKind::View)
+            .get_category_node(CategoryNodeKind::View)
             .await?
             .ok_or(DiagramError::ViewCategoryNotFound)?;
 
@@ -226,7 +226,7 @@ impl View {
         let snap = ctx.workspace_snapshot()?;
 
         let view_category_id = snap
-            .get_category_node(None, CategoryNodeKind::View)
+            .get_category_node(CategoryNodeKind::View)
             .await?
             .ok_or(DiagramError::ViewCategoryNotFound)?;
 
@@ -342,7 +342,7 @@ impl View {
         let snap = ctx.workspace_snapshot()?;
 
         let view_category_id = snap
-            .get_category_node(None, CategoryNodeKind::View)
+            .get_category_node(CategoryNodeKind::View)
             .await?
             .ok_or(DiagramError::ViewCategoryNotFound)?;
 

--- a/lib/dal/src/entity_kind.rs
+++ b/lib/dal/src/entity_kind.rs
@@ -85,7 +85,8 @@ impl EntityKind {
             | EntityKindEvents::DeprecatedAction
             | EntityKindEvents::DeprecatedActionRunner
             | EntityKindEvents::DeprecatedActionBatch
-            | EntityKindEvents::ValidationPrototype => None,
+            | EntityKindEvents::ValidationPrototype
+            | EntityKindEvents::CategoryDefaultSubscriptionSources => None,
             EntityKindEvents::SchemaVariant => {
                 let variant_name = SchemaVariant::get_by_id(ctx, id.into_inner().into())
                     .await?

--- a/lib/dal/src/func.rs
+++ b/lib/dal/src/func.rs
@@ -324,7 +324,7 @@ impl Func {
             .await?;
 
         let func_category_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(CategoryNodeKind::Func)
             .await?;
         Self::add_category_edge(ctx, func_category_id, id, EdgeWeightKind::new_use()).await?;
 
@@ -447,7 +447,7 @@ impl Func {
     ) -> FuncResult<Option<FuncId>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let func_category_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(CategoryNodeKind::Func)
             .await?;
         let func_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
@@ -477,7 +477,7 @@ impl Func {
     ) -> FuncResult<Option<FuncId>> {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let func_category_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(CategoryNodeKind::Func)
             .await?;
         let func_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
@@ -635,7 +635,7 @@ impl Func {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let func_category_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Func)
+            .get_category_node_or_err(CategoryNodeKind::Func)
             .await?;
 
         let func_node_indexes = workspace_snapshot

--- a/lib/dal/src/module.rs
+++ b/lib/dal/src/module.rs
@@ -216,7 +216,7 @@ impl Module {
         workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         let schema_module_index_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Module)
+            .get_category_node_or_err(CategoryNodeKind::Module)
             .await?;
         workspace_snapshot
             .add_edge(
@@ -259,7 +259,7 @@ impl Module {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let module_node_indices = {
             let module_category_index_id = workspace_snapshot
-                .get_category_node_or_err(None, CategoryNodeKind::Module)
+                .get_category_node_or_err(CategoryNodeKind::Module)
                 .await?;
             workspace_snapshot
                 .outgoing_targets_for_edge_weight_kind(
@@ -418,7 +418,7 @@ impl Module {
 
         let mut modules = vec![];
         let module_category_index_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Module)
+            .get_category_node_or_err(CategoryNodeKind::Module)
             .await?;
 
         let module_node_indices = workspace_snapshot

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -216,7 +216,7 @@ impl Schema {
         workspace_snapshot.add_or_replace_node(node_weight).await?;
 
         let schema_category_index_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Schema)
+            .get_category_node_or_err(CategoryNodeKind::Schema)
             .await?;
         workspace_snapshot
             .add_edge(
@@ -435,7 +435,7 @@ impl Schema {
 
         let mut schemas = vec![];
         let schema_category_index_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Schema)
+            .get_category_node_or_err(CategoryNodeKind::Schema)
             .await?;
 
         let schema_node_indices = workspace_snapshot
@@ -484,7 +484,7 @@ impl Schema {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let schema_category_index_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Schema)
+            .get_category_node_or_err(CategoryNodeKind::Schema)
             .await?;
         let schema_node_indices = workspace_snapshot
             .outgoing_targets_for_edge_weight_kind(
@@ -510,7 +510,7 @@ impl Schema {
         let workspace_snapshot = ctx.workspace_snapshot()?;
         let schema_node_indices = {
             let schema_category_index_id = workspace_snapshot
-                .get_category_node_or_err(None, CategoryNodeKind::Schema)
+                .get_category_node_or_err(CategoryNodeKind::Schema)
                 .await?;
             workspace_snapshot
                 .outgoing_targets_for_edge_weight_kind(

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -119,6 +119,7 @@ use crate::{
     prop::{
         PropError,
         PropPath,
+        ResolvedPropSuggestion,
     },
     schema::variant::{
         leaves::{
@@ -2410,7 +2411,8 @@ impl SchemaVariant {
                 | EdgeWeightKindDiscriminants::Manages
                 | EdgeWeightKindDiscriminants::DiagramObject
                 | EdgeWeightKindDiscriminants::ApprovalRequirementDefinition
-                | EdgeWeightKindDiscriminants::ValueSubscription => {}
+                | EdgeWeightKindDiscriminants::ValueSubscription
+                | EdgeWeightKindDiscriminants::DefaultSubscriptionSource => {}
             }
         }
 
@@ -2529,6 +2531,38 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<String> {
         let variant = Self::get_by_id(ctx, id).await?;
         Ok(variant.display_name.to_string())
+    }
+
+    pub async fn props_suggested_as_sources(
+        ctx: &DalContext,
+        id: SchemaVariantId,
+    ) -> SchemaVariantResult<Vec<ResolvedPropSuggestion>> {
+        let mut result = vec![];
+
+        let props = Self::all_props(ctx, id).await?;
+
+        for prop in props {
+            let suggested_as_sources_for = prop.suggested_as_source_for(ctx).await?;
+            result.extend(suggested_as_sources_for);
+        }
+
+        Ok(result)
+    }
+
+    pub async fn props_suggested_as_destinations(
+        ctx: &DalContext,
+        id: SchemaVariantId,
+    ) -> SchemaVariantResult<Vec<ResolvedPropSuggestion>> {
+        let mut result = vec![];
+
+        let props = Self::all_props(ctx, id).await?;
+
+        for prop in props {
+            let suggested_sources_for = prop.suggested_sources_for(ctx).await?;
+            result.extend(suggested_sources_for);
+        }
+
+        Ok(result)
     }
 }
 

--- a/lib/dal/src/secret.rs
+++ b/lib/dal/src/secret.rs
@@ -326,7 +326,7 @@ impl Secret {
 
         // Root --> Secret Category --> Secret (this)
         let secret_category_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(CategoryNodeKind::Secret)
             .await?;
         Self::add_category_edge(
             ctx,
@@ -567,7 +567,7 @@ impl Secret {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let secret_category_node_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(CategoryNodeKind::Secret)
             .await?;
 
         let indices = workspace_snapshot
@@ -601,7 +601,7 @@ impl Secret {
         let workspace_snapshot = ctx.workspace_snapshot()?;
 
         let secret_category_node_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(CategoryNodeKind::Secret)
             .await?;
 
         let indices = workspace_snapshot
@@ -631,7 +631,7 @@ impl Secret {
 
         let mut secrets = vec![];
         let secret_category_node_id = workspace_snapshot
-            .get_category_node_or_err(None, CategoryNodeKind::Secret)
+            .get_category_node_or_err(CategoryNodeKind::Secret)
             .await?;
 
         let secret_node_ids = workspace_snapshot

--- a/lib/dal/src/workspace_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot.rs
@@ -1064,23 +1064,21 @@ impl WorkspaceSnapshot {
 
     pub async fn get_category_node_or_err(
         &self,
-        source: Option<Ulid>,
         kind: CategoryNodeKind,
     ) -> WorkspaceSnapshotResult<Ulid> {
-        self.get_category_node(source, kind)
+        self.get_category_node(kind)
             .await?
             .ok_or(WorkspaceSnapshotError::CategoryNodeNotFound(kind))
     }
 
     pub async fn get_category_node(
         &self,
-        source: Option<Ulid>,
         kind: CategoryNodeKind,
     ) -> WorkspaceSnapshotResult<Option<Ulid>> {
         Ok(self
             .working_copy()
             .await
-            .get_category_node(source, kind)?
+            .get_category_node(kind)?
             .map(|(category_node_id, _)| category_node_id))
     }
 

--- a/lib/dal/src/workspace_snapshot/dependent_value_root.rs
+++ b/lib/dal/src/workspace_snapshot/dependent_value_root.rs
@@ -58,7 +58,7 @@ impl DependentValueRoot {
         }
 
         if let Some(dv_category_id) = snap
-            .get_category_node(None, CategoryNodeKind::DependentValueRoots)
+            .get_category_node(CategoryNodeKind::DependentValueRoots)
             .await
             .map_err(Box::new)?
         {
@@ -95,7 +95,7 @@ impl DependentValueRoot {
 
         Ok(
             match snap
-                .get_category_node(None, CategoryNodeKind::DependentValueRoots)
+                .get_category_node(CategoryNodeKind::DependentValueRoots)
                 .await
                 .map_err(Box::new)?
             {
@@ -117,7 +117,7 @@ impl DependentValueRoot {
         let snap = ctx.workspace_snapshot().map_err(Box::new)?;
 
         let dv_category_id = match snap
-            .get_category_node(None, CategoryNodeKind::DependentValueRoots)
+            .get_category_node(CategoryNodeKind::DependentValueRoots)
             .await
             .map_err(Box::new)?
         {
@@ -169,7 +169,7 @@ impl DependentValueRoot {
         let snap = ctx.workspace_snapshot().map_err(Box::new)?;
 
         let dv_category_id = match snap
-            .get_category_node(None, CategoryNodeKind::DependentValueRoots)
+            .get_category_node(CategoryNodeKind::DependentValueRoots)
             .await
             .map_err(Box::new)?
         {

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -81,6 +81,10 @@ pub enum EdgeWeightKind {
     /// [`AttributePath`] is a path to a nested child AV (e.g.
     /// `/domain/PolicyDocument/Statements/0/Operation`).
     ValueSubscription(AttributePath),
+    /// An edge from an attribute value to the default subscription source
+    /// category node, indicating that this value should be used as a default
+    /// subscription source if it matches a prop suggestion on a component.
+    DefaultSubscriptionSource,
 }
 
 impl EdgeWeightKind {
@@ -151,6 +155,7 @@ impl si_split_graph::CustomEdgeWeight<EdgeWeightKindDiscriminants> for EdgeWeigh
             | EdgeWeightKind::Represents
             | EdgeWeightKind::Manages
             | EdgeWeightKind::DiagramObject
+            | EdgeWeightKind::DefaultSubscriptionSource
             | EdgeWeightKind::ApprovalRequirementDefinition => None,
         }
     }
@@ -179,7 +184,8 @@ impl si_split_graph::CustomEdgeWeight<EdgeWeightKindDiscriminants> for EdgeWeigh
             | EdgeWeightKind::Manages
             | EdgeWeightKind::DiagramObject
             | EdgeWeightKind::ApprovalRequirementDefinition
-            | EdgeWeightKind::ValueSubscription(_) => false,
+            | EdgeWeightKind::DefaultSubscriptionSource => false,
+            EdgeWeightKind::ValueSubscription(_) => false,
         }
     }
 
@@ -207,6 +213,7 @@ impl si_split_graph::CustomEdgeWeight<EdgeWeightKindDiscriminants> for EdgeWeigh
             | EdgeWeightKind::Manages
             | EdgeWeightKind::DiagramObject
             | EdgeWeightKind::ApprovalRequirementDefinition
+            | EdgeWeightKind::DefaultSubscriptionSource
             | EdgeWeightKind::ValueSubscription(_) => self.clone(),
         }
     }

--- a/lib/dal/src/workspace_snapshot/graph/correct_transforms.rs
+++ b/lib/dal/src/workspace_snapshot/graph/correct_transforms.rs
@@ -89,7 +89,7 @@ pub fn add_dependent_value_root_updates(
     let mut updates = vec![];
 
     if let Some((category_node_id, category_node_idx)) =
-        graph.get_category_node(None, CategoryNodeKind::DependentValueRoots)?
+        graph.get_category_node(CategoryNodeKind::DependentValueRoots)?
     {
         let existing_dvu_nodes: Vec<_> = graph
             .edges_directed(category_node_idx, Outgoing)

--- a/lib/dal/src/workspace_snapshot/graph/tests.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests.rs
@@ -535,7 +535,7 @@ mod test {
             .cleanup_and_merkle_tree_hash()
             .expect("cleanup and merkle");
         let pre_update_root_node_merkle_tree_hash: MerkleTreeHash =
-            MerkleTreeHash::from_str("389d15c7a2f5db02d32232ab8304bfe7")
+            MerkleTreeHash::from_str("a6ef705fec010be4fdc89ab97b5bc543")
                 .expect("able to create hash from hex string");
         assert_eq!(
             pre_update_root_node_merkle_tree_hash, // expected
@@ -554,7 +554,7 @@ mod test {
             .expect("cleanup and merkle");
 
         let post_update_root_node_merkle_tree_hash: MerkleTreeHash =
-            MerkleTreeHash::from_str("2525d60d0669121d11240f6aef299eb6")
+            MerkleTreeHash::from_str("f0241305edc32ef70dfc608fe7d5c319")
                 .expect("able to create hash from hex string");
         assert_eq!(
             post_update_root_node_merkle_tree_hash, // expected
@@ -581,7 +581,7 @@ mod test {
 
         // Ensure that there are not more nodes than the ones that should be in use, and the
         // initial ones (categories and default views)
-        assert_eq!(15, graph.node_count());
+        assert_eq!(16, graph.node_count());
 
         // The hashes must not change upon cleanup.
         assert_eq!(

--- a/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
+++ b/lib/dal/src/workspace_snapshot/graph/tests/rebase.rs
@@ -126,7 +126,7 @@ mod test {
             .cleanup_and_merkle_tree_hash()
             .expect("merkle it!");
         assert_eq!(
-            17,                // expected
+            18,                // expected
             onto.node_count()  // actual
         );
 

--- a/lib/dal/src/workspace_snapshot/graph/v3.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v3.rs
@@ -783,6 +783,7 @@ impl WorkspaceSnapshotGraphV3 {
                     EdgeWeightKindDiscriminants::Use => "black",
                     EdgeWeightKindDiscriminants::ValidationOutput => "darkcyan",
                     EdgeWeightKindDiscriminants::ValueSubscription => "green",
+                    EdgeWeightKindDiscriminants::DefaultSubscriptionSource => "green",
                 };
 
                 match edgeref.weight().kind() {
@@ -866,6 +867,9 @@ impl WorkspaceSnapshotGraphV3 {
                         CategoryNodeKind::View => ("Views (Category)".into(), "black"),
                         CategoryNodeKind::DiagramObject => {
                             ("Diagram Objects (Category)".into(), "black")
+                        }
+                        CategoryNodeKind::DefaultSubscriptionSources => {
+                            ("Default Subscription Sources (Category)".into(), "black")
                         }
                     },
                     NodeWeight::Component(component) => (
@@ -1454,7 +1458,8 @@ impl WorkspaceSnapshotGraphV3 {
                     | EdgeWeightKind::ManagementPrototype
                     | EdgeWeightKind::Manages
                     | EdgeWeightKind::DiagramObject
-                    | EdgeWeightKind::ApprovalRequirementDefinition => {}
+                    | EdgeWeightKind::ApprovalRequirementDefinition
+                    | EdgeWeightKind::DefaultSubscriptionSource => {}
                 }
             }
         }

--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -1365,6 +1365,7 @@ impl From<&NodeWeight> for EntityKind {
                 CategoryNodeKind::DependentValueRoots => EntityKind::CategoryDependentValueRoots,
                 CategoryNodeKind::View => EntityKind::CategoryView,
                 CategoryNodeKind::DiagramObject => EntityKind::CategoryDiagramObject,
+                CategoryNodeKind::DefaultSubscriptionSources => EntityKind::CategoryDiagramObject,
             },
             NodeWeight::Component(_) => EntityKind::Component,
             NodeWeight::Content(content_node_weight) => match content_node_weight

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -167,7 +167,7 @@ impl CorrectTransforms for AttributeValueNodeWeight {
         }
 
         let dvu_cat_node_id: Option<NodeId> = graph
-            .get_category_node(None, CategoryNodeKind::DependentValueRoots)?
+            .get_category_node(CategoryNodeKind::DependentValueRoots)?
             .map(|(id, _)| id.into());
 
         let mut should_add = false;

--- a/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/category_node_weight.rs
@@ -38,6 +38,33 @@ pub enum CategoryNodeKind {
     DependentValueRoots,
     View,
     DiagramObject,
+    DefaultSubscriptionSources,
+}
+
+const DEFAULT_SUBSCRIPTION_SOURCE_CATEGORY_ID_STR: &str = "0000DNP8N22X0A8S4CV2APWX3A";
+
+impl CategoryNodeKind {
+    /// Adding a new category node to an existing workspacewithout migrating a
+    /// workspace and all its change set requires that the category node have a
+    /// static id, so that the rebaser will treat all versions of it in every
+    /// change set as the same node.
+    pub fn static_id(&self) -> Option<Ulid> {
+        match self {
+            CategoryNodeKind::Action
+            | CategoryNodeKind::Component
+            | CategoryNodeKind::DeprecatedActionBatch
+            | CategoryNodeKind::Func
+            | CategoryNodeKind::Module
+            | CategoryNodeKind::Schema
+            | CategoryNodeKind::Secret
+            | CategoryNodeKind::DependentValueRoots
+            | CategoryNodeKind::View
+            | CategoryNodeKind::DiagramObject => None,
+            CategoryNodeKind::DefaultSubscriptionSources => {
+                Ulid::from_string(DEFAULT_SUBSCRIPTION_SOURCE_CATEGORY_ID_STR).ok()
+            }
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/secret_node_weight.rs
@@ -168,7 +168,7 @@ impl CorrectTransforms for SecretNodeWeight {
         }
 
         let dvu_cat_node_id: Option<NodeId> = graph
-            .get_category_node(None, CategoryNodeKind::DependentValueRoots)?
+            .get_category_node(CategoryNodeKind::DependentValueRoots)?
             .map(|(id, _)| id.into());
 
         let mut should_add = false;

--- a/lib/dal/src/workspace_snapshot/selector.rs
+++ b/lib/dal/src/workspace_snapshot/selector.rs
@@ -338,23 +338,21 @@ impl WorkspaceSnapshotSelector {
 
     pub async fn get_category_node_or_err(
         &self,
-        source: Option<Ulid>,
         kind: CategoryNodeKind,
     ) -> WorkspaceSnapshotResult<Ulid> {
         match self {
-            Self::LegacySnapshot(snapshot) => snapshot.get_category_node_or_err(source, kind).await,
-            Self::SplitSnapshot(snapshot) => snapshot.get_category_node_or_err(source, kind).await,
+            Self::LegacySnapshot(snapshot) => snapshot.get_category_node_or_err(kind).await,
+            Self::SplitSnapshot(snapshot) => snapshot.get_category_node_or_err(kind).await,
         }
     }
 
     pub async fn get_category_node(
         &self,
-        source: Option<Ulid>,
         kind: CategoryNodeKind,
     ) -> WorkspaceSnapshotResult<Option<Ulid>> {
         match self {
-            Self::LegacySnapshot(snapshot) => snapshot.get_category_node(source, kind).await,
-            Self::SplitSnapshot(snapshot) => snapshot.get_category_node(source, kind).await,
+            Self::LegacySnapshot(snapshot) => snapshot.get_category_node(kind).await,
+            Self::SplitSnapshot(snapshot) => snapshot.get_category_node(kind).await,
         }
     }
 

--- a/lib/dal/tests/integration_test/attribute_value/subscription.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription.rs
@@ -20,6 +20,8 @@ use dal_test::{
 use pretty_assertions_sorted::assert_eq;
 use serde_json::json;
 
+pub mod default_subscriptions;
+
 // AV subscribes to name AV on same component
 #[test]
 async fn subscribe_to_name_on_same_component(ctx: &mut DalContext) -> Result<()> {

--- a/lib/dal/tests/integration_test/attribute_value/subscription/default_subscriptions.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription/default_subscriptions.rs
@@ -1,0 +1,302 @@
+use dal::{
+    AttributeValue,
+    Component,
+    DalContext,
+    SchemaVariantId,
+    attribute::value::default_subscription::{
+        DefaultSubscription,
+        calculate_all_prop_suggestions_for_change_set,
+        detect_possible_default_connections,
+    },
+};
+use dal_test::{
+    Result,
+    helpers::{
+        component,
+        schema::variant,
+    },
+    test,
+};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn test_set_as_default_subscription_source(ctx: &DalContext) -> Result<()> {
+    variants_with_prop_suggestions(ctx).await?;
+
+    let suggestions_for_change_set = calculate_all_prop_suggestions_for_change_set(ctx).await?;
+
+    let source_component_a_id = component::create(ctx, "default_source_a", "default_source_a")
+        .await
+        .expect("should be able to create component");
+    let source_component_b_id = component::create(ctx, "default_source_b", "default_source_b")
+        .await
+        .expect("should be able to create component");
+
+    let _dest_component_a_id =
+        component::create(ctx, "default_destination_a", "default_destination_a")
+            .await
+            .expect("should be able to create component");
+
+    assert!(
+        AttributeValue::get_default_subscription_sources(ctx)
+            .await?
+            .is_empty()
+    );
+
+    let default_sources_paths = [
+        ["root", "domain", "source_bool"],
+        ["root", "domain", "source_string"],
+        ["root", "domain", "source_integer"],
+    ];
+
+    let mut default_source_av_ids = vec![];
+
+    for path in &default_sources_paths {
+        let av_id = Component::attribute_values_for_prop_by_id(ctx, source_component_a_id, path)
+            .await
+            .expect("should be able to find avs for prop")
+            .pop()
+            .expect("should have a prop");
+
+        AttributeValue::set_as_default_subscription_source(ctx, av_id)
+            .await
+            .expect("should be able to set as default subscription source");
+
+        default_source_av_ids.push(av_id);
+    }
+
+    let mut sources = AttributeValue::get_default_subscription_sources(ctx).await?;
+
+    sources.sort();
+    default_source_av_ids.sort();
+
+    assert_eq!(
+        default_source_av_ids, sources,
+        "default source av ids should match"
+    );
+
+    let dest_component_b_id =
+        component::create(ctx, "default_destination_a", "default_destination_a")
+            .await
+            .expect("should be able to create component");
+
+    let default_destinations_paths = [
+        ["root", "domain", "dest_bool"],
+        ["root", "domain", "dest_string"],
+        ["root", "domain", "dest_integer"],
+    ];
+
+    let mut expected_defaults = vec![];
+    for (idx, path) in default_destinations_paths.iter().enumerate() {
+        let dest_av_id = Component::attribute_values_for_prop_by_id(ctx, dest_component_b_id, path)
+            .await
+            .expect("should be able to find avs for prop")
+            .pop()
+            .expect("should have a prop");
+
+        let source_av_id = default_source_av_ids
+            .get(idx)
+            .copied()
+            .expect("should have a matching source");
+
+        expected_defaults.push(DefaultSubscription {
+            source_av_id,
+            dest_av_id,
+        });
+    }
+
+    let mut possible_defaults =
+        detect_possible_default_connections(ctx, dest_component_b_id, &suggestions_for_change_set)
+            .await
+            .expect("should be able to detect possible default connections");
+
+    possible_defaults.sort();
+    expected_defaults.sort();
+
+    assert_eq!(expected_defaults, possible_defaults);
+
+    for default_sub in possible_defaults {
+        default_sub
+            .subscribe(ctx)
+            .await
+            .unwrap_or_else(|_| panic!("should be able to subscribe: {default_sub:?}"));
+    }
+
+    let conflicting_av_id = Component::attribute_values_for_prop_by_id(
+        ctx,
+        source_component_b_id,
+        &["root", "domain", "source_bool"],
+    )
+    .await
+    .expect("should be able to find avs for prop")
+    .pop()
+    .expect("should have a prop");
+
+    AttributeValue::set_as_default_subscription_source(ctx, conflicting_av_id)
+        .await
+        .expect("should be able to set as default subscription source");
+
+    let possible_defaults_two =
+        detect_possible_default_connections(ctx, dest_component_b_id, &suggestions_for_change_set)
+            .await
+            .expect("should be able to detect possible default connections");
+
+    // one of the suggestions is now ambiguous since it could be either of the two source components
+    assert_eq!(possible_defaults_two.len(), 2);
+
+    Ok(())
+}
+
+async fn variants_with_prop_suggestions(
+    ctx: &DalContext,
+) -> Result<(
+    SchemaVariantId,
+    SchemaVariantId,
+    SchemaVariantId,
+    SchemaVariantId,
+)> {
+    let default_source_a_id = variant::create(
+        ctx,
+        "default_source_a",
+        r#"
+        function main() {
+        return {
+            props: [
+            {
+                name: "source_bool",
+                kind: "boolean",
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_boolean" },
+                ]
+            },
+            {
+                name: "source_string",
+                kind: "string",
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_string" },
+                    { schema: "default_destination_b", prop: "/domain/dest_string" },
+                ]
+            },
+            {
+                name: "source_integer",
+                kind: "integer",
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_integer" },
+                    { schema: "default_destination_b", prop: "/domain/dest_integer" },
+                ]
+            }
+            ]
+        }}"#,
+    )
+    .await?;
+
+    let default_source_b_id = variant::create(
+        ctx,
+        "default_source_b",
+        r#"
+        function main() {
+        return {
+            props: [
+            {
+                name: "source_bool",
+                kind: "boolean",
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_bool" },
+                ]
+            },
+            {
+                name: "source_string",
+                kind: "string",
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_string" },
+                    { schema: "default_destination_b", prop: "/domain/dest_string" },
+                ]
+            },
+            {
+                name: "source_integer",
+                kind: "integer",
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_integer" },
+                    { schema: "default_destination_b", prop: "/domain/dest_integer" },
+                ]
+            }
+            ]
+        }}"#,
+    )
+    .await?;
+
+    let default_destination_a_id = variant::create(
+        ctx,
+        "default_destination_a",
+        r#"
+        function main() {
+        return {
+            props: [
+                {
+                    name: "dest_string",
+                    kind: "string",
+                    suggestSources: [
+                        { schema: "default_source_a", prop: "/domain/source_string" },
+                        { schema: "default_source_b", prop: "/domain/source_string" },
+                    ]
+                },
+                {
+                    name: "dest_integer",
+                    kind: "integer",
+                    suggestSources: [
+                        { schema: "default_source_a", prop: "/domain/source_integer" },
+                        { schema: "default_source_b", prop: "/domain/source_integer" },
+                    ]
+                },
+                {
+                    name: "dest_bool",
+                    kind: "boolean",
+                    suggestSources: [
+                        { schema: "default_source_a", prop: "/domain/source_bool" },
+                        { schema: "default_source_b", prop: "/domain/source_bool" },
+                    ]
+                }
+            ]
+        }}"#,
+    )
+    .await?;
+
+    let default_destination_b_id = variant::create(
+        ctx,
+        "default_destination_b",
+        r#"
+        function main() {
+        return {
+            props: [
+                {
+                    name: "dest_string",
+                    kind: "string",
+                    suggestSources: [
+                        { schema: "default_source_a", prop: "/domain/source_string" },
+                        { schema: "default_source_b", prop: "/domain/source_string" },
+                    ]
+                },
+                {
+                    name: "dest_integer",
+                    kind: "integer",
+                    suggestSources: [
+                        { schema: "default_source_a", prop: "/domain/source_integer" },
+                        { schema: "default_source_b", prop: "/domain/source_integer" },
+                    ]
+                },
+                {
+                    name: "dest_boolean",
+                    kind: "boolean",
+                }
+            ],
+        }}"#,
+    )
+    .await?;
+
+    Ok((
+        default_source_a_id,
+        default_source_b_id,
+        default_destination_a_id,
+        default_destination_b_id,
+    ))
+}

--- a/lib/dal/tests/integration_test/deserialize/mod.rs
+++ b/lib/dal/tests/integration_test/deserialize/mod.rs
@@ -282,6 +282,9 @@ fn make_me_one_with_everything(graph: &mut WorkspaceSnapshotGraphVCurrent) {
             EdgeWeightKindDiscriminants::ValueSubscription => {
                 EdgeWeightKind::ValueSubscription(AttributePath::from_json_pointer("/json_pointer"))
             }
+            EdgeWeightKindDiscriminants::DefaultSubscriptionSource => {
+                EdgeWeightKind::DefaultSubscriptionSource
+            }
         };
 
         if last_node + 1 == node_indexes.len() {

--- a/lib/si-events-rs/src/workspace_snapshot.rs
+++ b/lib/si-events-rs/src/workspace_snapshot.rs
@@ -30,6 +30,7 @@ pub enum EntityKind {
     AttributeValue,
     CategoryAction,
     CategoryComponent,
+    CategoryDefaultSubscriptionSources,
     CategoryDependentValueRoots,
     CategoryDeprecatedActionBatch,
     CategoryDiagramObject,


### PR DESCRIPTION
Adds a new category node, `DefaultSubscriptionSources`, and a new edge kind: `DefaultSubscriptionSource` which points from an attribute value to the new category.

This allows us to calculate default subscriptions based on the `suggestSources` and `suggestAsSourceFor` maps in `ui_optionals` for a schema. If a suggested connection matches one of the default subscription sources unambiguously, we will be able to create that subscription when the component is created.

This PR implements the initial logic for discovering the default subscriptions and adds the new category node. Default subscriptions will not yet be created on component create (the calculation of suggested sources is expensive and needs to be done ahead of time and cached).

Only scalars supported in this PR. A follow up is coming for arrays, objects, and maps.

Includes a refactor to remove the never used not once source id argument to get_category_node