### PR TITLE
feat(web): Add sticky array and map headers

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -126,10 +126,12 @@
     >
       <template #header><span class="text-sm">domain</span></template>
       <ComponentAttribute
-        v-for="child in filtered.tree.children"
+        v-for="(child, index) in filtered.tree.children"
         :key="child.id"
         :component="component"
         :attributeTree="child"
+        :stickyDepth="0"
+        :isFirstChild="index === 0"
         @save="save"
         @delete="remove"
         @remove-subscription="removeSubscription"

--- a/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
+++ b/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
@@ -3,7 +3,8 @@
   <dl
     :class="
       clsx(
-        'border my-2xs',
+        'border',
+        sticky ? 'my-0' : 'my-2xs',
         themeClasses('border-neutral-300', 'border-neutral-600'),
       )
     "
@@ -14,12 +15,16 @@
         clsx(
           'group/header',
           'px-2xs py-xs flex flex-row items-center gap-2xs cursor-pointer h-lg',
+          sticky && 'sticky',
           open && 'border-b',
           themeClasses(
             'bg-white border-neutral-300 hover:bg-neutral-100',
             'bg-neutral-800 border-neutral-600 hover:bg-neutral-700',
           ),
         )
+      "
+      :style="
+        sticky ? { top: `${stickyTopOffset}px`, zIndex: stickyZIndex } : {}
       "
       @click="() => (open = !open)"
     >
@@ -44,9 +49,15 @@ import { ref } from "vue";
 const props = withDefaults(
   defineProps<{
     defaultOpen?: boolean;
+    sticky?: boolean;
+    stickyTopOffset?: number;
+    stickyZIndex?: number;
   }>(),
   {
     defaultOpen: true,
+    sticky: false,
+    stickyTopOffset: 0,
+    stickyZIndex: 10,
   },
 );
 

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -23,7 +23,15 @@
     :class="clsx('flex flex-col', !showingChildren && 'mb-[-1px]')"
   >
     <template v-if="showingChildren">
-      <AttributeChildLayout>
+      <AttributeChildLayout
+        :sticky="
+          attributeTree.prop?.kind === 'array' ||
+          attributeTree.prop?.kind === 'map' ||
+          (attributeTree.prop?.kind === 'object' && isFirstChild)
+        "
+        :stickyTopOffset="(stickyDepth || 0) * 36"
+        :stickyZIndex="10 - (stickyDepth || 0)"
+      >
         <template #header>
           <div
             ref="headerRef"
@@ -38,7 +46,17 @@
             @keydown.enter.stop.prevent="remove"
             @keydown.delete.stop.prevent="remove"
           >
-            <div>{{ displayName }}</div>
+            <div
+              :class="
+                attributeTree.prop?.kind === 'array' ||
+                attributeTree.prop?.kind === 'map' ||
+                (stickyDepth && stickyDepth > 0)
+                  ? 'text-sm'
+                  : ''
+              "
+            >
+              {{ displayName }}
+            </div>
             <div class="flex-1" />
             <div
               v-if="attributeTree.attributeValue.externalSources?.length"
@@ -116,9 +134,9 @@
             />
           </div>
         </template>
-        <ul v-if="!bifrostingTrash">
+        <ul v-if="!bifrostingTrash" class="list-none">
           <ComponentAttribute
-            v-for="child in attributeTree.children"
+            v-for="(child, index) in attributeTree.children"
             :key="child.id"
             :component="component"
             :attributeTree="child"
@@ -129,6 +147,8 @@
               props.forceReadOnly ||
               !!attributeTree.attributeValue.externalSources?.length
             "
+            :stickyDepth="(stickyDepth || 0) + 1"
+            :isFirstChild="index === 0"
             @save="
               (path, value, propKind, connectingComponentId) =>
                 emit('save', path, value, propKind, connectingComponentId)
@@ -254,6 +274,8 @@ const props = defineProps<{
   attributeTree: AttrTree;
   forceReadOnly?: boolean;
   parentHasExternalSources?: boolean;
+  stickyDepth?: number;
+  isFirstChild?: boolean;
 }>();
 
 const hasChildren = computed(() => {


### PR DESCRIPTION
When on a component details page, we make the array and map parent items
and their children sticky. This means that you will also see the 
attribute title that you are editing

https://jam.dev/c/e74de5a8-35cb-455c-84ff-0e616d445dea