### PR TITLE
fix: Migrate ECS port/name socket connections

### DIFF
--- a/lib/dal/examples/snapshot-surfer/main.rs
+++ b/lib/dal/examples/snapshot-surfer/main.rs
@@ -51,6 +51,7 @@ async fn main() -> Result<()> {
     // so we needed to remove it
     // let node_id = "01JTXGMYKFFPY7H2ZNV7SKFQ9X";
     // remove_node_by_id(&mut graph, node_id)?;
+    println!("root id: {}", graph.get_node_weight(graph.root())?.id());
     for arg in args {
         let node_id = Ulid::from_string(&arg)?;
         let node_idx = graph.get_node_index_by_id(node_id)?;
@@ -111,6 +112,7 @@ fn node_ident(graph: &WorkspaceSnapshotGraph, index: NodeIndex) -> Result<String
         None => NodeWeightDiscriminants::from(node).to_string(),
     };
     let extra = match node {
+        NodeWeight::Category(category) => Some(format!(" ({})", category.kind())),
         NodeWeight::AttributeValue(_) => match graph.target_opt(index, EdgeWeightKind::Prop)? {
             Some(prop_index) => {
                 let prop = graph.get_node_weight(prop_index)?.as_prop_node_weight()?;

--- a/lib/dal/src/workspace_snapshot/graph/validator.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator.rs
@@ -447,6 +447,13 @@ lazy_static! {
         // AWS::IAM::UserPolicy
         "awsIamUserPolicySetUserNameFromInput",
         "awsIamIdentityPolicyArnFromInputSocket",
+
+        // ECS Load Balancer Configuration
+        "containerNameToLBConfigContainerName",
+        "containerPortToLBConfigContainerPort",
+
+        // ECS Container Definition Port Mapping
+        "containerPortToOutputSocket",
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
Socket connections to older versions of ECS Load Balancer Configuration and ECS Container Definition Port Mapping often don't get migrated, because there are functions on both the source and destination side.

Some of those functions literally just return their inputs. This PR fixes the problem by adding those functions to a list of functions treated as `si:identity` equivalents; the system can essentially ignore these, and has a well-tested rules for handling connections where one side is `si:identity`. This will allow complex connections to migrate by (for example) using the function on the other side (the source, if it's an output socket, or the destination if it's an input socket). 

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: migrations still run locally

Did NOT test that the specific functions in question get migrated: this is a result of code analysis. Am willing to wait until tomorrow, but this only affects the migrator endpoint and given the volume of issues we're fixing in the next 24 hours, is frankly easier to test with dry runs in production.