### PR TITLE
fix: Migrate SubnetId outputs

### DIFF
--- a/lib/dal/src/workspace_snapshot/graph/validator.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator.rs
@@ -561,6 +561,9 @@ lazy_static! {
 
         // AWS::IAM::UserPrincipal
         "awsIamUserPrincipalSetPrincipalOutput",
+
+        // Subnet
+        "si:awsSubnetIdFromResource",
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
This fixes most migration issues with Subnet ID (which make up a pretty big portion of our migration issues).

This PR fixes the issue by marking the subnet ID output socket function as being single-valued. In most cases, Subnet ID connections fail to migrate because the other side is si:normalizeToArray, and the system can't be sure the output socket function actually produces a single value (and not an array). When it's marked as such, normalizeToArray creates a new array element and subscribes to the SubnetId from there, using the Subnet ID's output socket function.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: migrations still run locally

Did NOT test that the specific functions in question get migrated: this is a result of code analysis. Am willing to wait until tomorrow, but this only affects the migrator endpoint and given the volume of issues we're fixing in the next 24 hours, is frankly easier to test with dry runs in production.