### PR TITLE
chore(deps): Fix deno.lock version

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "5",
+  "version": "4",
   "specifiers": {
     "jsr:@cliffy/command@^1.0.0-rc.7": "1.0.0-rc.8",
     "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",


### PR DESCRIPTION
The clover asset pipeline changes this file so I need to change it back