### PR TITLE
chore(ci): Ensure we don't change deno.lock on asset changes

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -29,3 +29,5 @@ jobs:
           commit-message: clover schema update
           title: "chore: clover schema update"
           body: "Update for clover schemas. Check the diff comment to understand what has changed."
+          add-paths: |
+              !deno.lock


### PR DESCRIPTION
https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#add-specific-paths

We are going to exclude the deno.lock file as that shouldn’t change as 
part of this PR