### PR TITLE
fix(web): Navigate to created change set when moving a component

### DIFF
--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -567,9 +567,22 @@ const componentsAddToView = async (
     viewId,
   });
   close();
-  call.post({
+  const { req, newChangeSetId } = await call.post({
     componentIds,
   });
+
+  if (addToViewApi.ok(req) && newChangeSetId) {
+    addToViewApi.navigateToNewChangeSet(
+      {
+        name: "new-hotness",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+        },
+      },
+      newChangeSetId,
+    );
+  }
 };
 const componentsRemoveFromView = async (
   viewId: string,
@@ -579,9 +592,22 @@ const componentsRemoveFromView = async (
     viewId,
   });
   close();
-  await call.delete({
+  const { req, newChangeSetId } = await call.delete({
     componentIds,
   });
+
+  if (removeFromViewApi.ok(req) && newChangeSetId) {
+    removeFromViewApi.navigateToNewChangeSet(
+      {
+        name: "new-hotness",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: newChangeSetId,
+        },
+      },
+      newChangeSetId,
+    );
+  }
 };
 
 const componentsUpgrade = async (componentIds: ComponentId[]) => {

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -101,7 +101,7 @@
             <template #b="{ selected, toggle }">
               <ExploreModeTile
                 icon="map"
-                label="Map (Model)"
+                label="Map"
                 :selected="selected"
                 @toggle="toggle"
               />


### PR DESCRIPTION
When moving a component in/out of a view, we create a changeset, we just
don’t navigate to it

Also removes the word Model from the Map button