### PR TITLE
fix(template-gen): add region prop suggestion

### DIFF
--- a/lib/si-generate-template/templates/asset_schema.ts
+++ b/lib/si-generate-template/templates/asset_schema.ts
@@ -34,6 +34,10 @@ Running the template with the same Name Prefix more than once is an error, as it
                 .build(),
             )
             .setValidationFormat(Joi.string().required())
+            .suggestSource({
+                schema: "Region",
+                prop: "/domain/region"
+            })
             .build(),
         )
         .build();


### PR DESCRIPTION
## How does this PR change the system?

- Adds a source suggestion of domain/region to the Region prop in the aws template generator code