### PR TITLE
fix(web): Ensure change set button state is correct

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -280,7 +280,7 @@ const {
   changeSet: activeChangeSet,
   headChangeSetId,
   defaultApprovers,
-} = useChangeSets(ctx);
+} = useChangeSets(ctx, queriesEnabled);
 watch(defaultApprovers, () => {
   approvers.value = defaultApprovers.value;
 });

--- a/app/web/src/newhotness/logic_composables/change_set.ts
+++ b/app/web/src/newhotness/logic_composables/change_set.ts
@@ -22,7 +22,7 @@ export const useChangeSets = (
   if (!enabled) enabled = ref(true);
   const changeSetApi = useApi(ctx.value);
   const changeSetQuery = useQuery<Record<string, ChangeSet>>({
-    enabled: enabled.value,
+    enabled,
     queryKey: ["changesets"],
     staleTime: 5000,
     queryFn: async () => {


### PR DESCRIPTION
The change set query was running before the system was fully 
initialized, causing it to fail silently and return empty data. This 
left ctx.changeSet.value as undefined, which made thebutton think the 
change set status wasn't "Open".

queriesEnabled ensures queries only run after heimdall.initCompleted.value && !lobby.value are ready. Without this, the change set API call was happening too early  and failing.

TanStack Query expects a reactive ref, not the unwrapped value. Using 
.value broke the reactivity and prevented the query from waiting for the
proper initializationsignal

The button now properly waits for the system to initialize, successfully
loads the change set data, and correctly enables/disables based on the  
actual change set status rather than missing data.