### PR TITLE
feat: Make inferred connections explicit if we can't migrate them

### DIFF
--- a/lib/sdf-server/src/service/v2/admin.rs
+++ b/lib/sdf-server/src/service/v2/admin.rs
@@ -98,6 +98,8 @@ pub enum AdminAPIError {
     ChangeSet(#[from] dal::ChangeSetError),
     #[error("component error: {0}")]
     Component(#[from] dal::component::ComponentError),
+    #[error("diagram error: {0}")]
+    Diagram(#[from] sdf_v1_routes_diagram::DiagramError),
     #[error("func runner error: {0}")]
     FuncRunner(#[from] FuncRunnerError),
     #[error("inferred connection graph error: {0}")]


### PR DESCRIPTION
Sometimes an inferred connection can't be migrated to a prop connection (because some socket connections don't have automatic migrations). In these cases, we still want to make the inferred connection into an explicit socket connection, to make the transition to no sockets easier. (In particular, this will make it easier for us to detect when there is an unmigrated connection, so we can display a message to the user letting them know.)

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: migrateable inferred connections still migrate
- [X] Manual test: unmigrateable inferred connections are made explicit and log a line