### PR TITLE
Indicate whether Components (and attribute values) have socket connections so we can warn users migration wasn't cleanly possible

### DIFF
--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -50,6 +50,11 @@ pub async fn assemble_in_list(
         .workspace_snapshot()?
         .external_source_count(component_id)
         .await?;
+    let has_socket_connections = ctx
+        .workspace_snapshot()?
+        .has_socket_connections(component_id)
+        .await?;
+
     let diff_status = map_diff_status(Component::has_diff_from_head(ctx, component_id).await?);
     let to_delete = Component::is_set_to_delete(ctx, component_id)
         .await?
@@ -85,6 +90,7 @@ pub async fn assemble_in_list(
         diff_status,
         to_delete,
         resource_id,
+        has_socket_connections,
     })
 }
 

--- a/lib/dal/src/workspace_snapshot/graph/traits/component.rs
+++ b/lib/dal/src/workspace_snapshot/graph/traits/component.rs
@@ -9,4 +9,6 @@ pub trait ComponentExt {
     fn root_attribute_value(&self, component_id: ComponentId) -> ComponentResult<AttributeValueId>;
 
     fn external_source_count(&self, component_id: ComponentId) -> ComponentResult<usize>;
+
+    fn has_socket_connections(&self, component_id: ComponentId) -> ComponentResult<bool>;
 }

--- a/lib/dal/src/workspace_snapshot/graph/v4/component.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4/component.rs
@@ -19,6 +19,8 @@ use crate::{
     WorkspaceSnapshotError,
     component::ComponentResult,
     workspace_snapshot::{
+        NodeWeight,
+        content_address::ContentAddress,
         edge_weight::EdgeWeightKindDiscriminants,
         graph::{
             WorkspaceSnapshotGraphError,
@@ -168,6 +170,64 @@ impl WorkspaceSnapshotGraphV4 {
             _ => Ok(petgraph::visit::Control::Continue),
         }
     }
+    fn has_socket_connections_dfs_event(
+        event: DfsEvent<NodeIndex>,
+        has_connections: &mut bool,
+        component_id: ComponentId,
+        graph: &Self,
+    ) -> WorkspaceSnapshotGraphResult<Control<()>> {
+        match event {
+            DfsEvent::Discover(node_idx, _) => {
+                let node_weight = graph.get_node_weight(node_idx)?;
+
+                match node_weight {
+                    // Found an APA Node weight - let's see if it has targets and if the component in question is the destination
+                    NodeWeight::AttributePrototypeArgument(apa_node_weight) => {
+                        if let Some(targets) = apa_node_weight.targets() {
+                            if targets.destination_component_id == component_id {
+                                *has_connections = true;
+                                return Ok(petgraph::visit::Control::Break(()));
+                            }
+                        }
+                        Ok(petgraph::visit::Control::Continue)
+                    }
+                    NodeWeight::Content(content_node_weight) => {
+                        match content_node_weight.content_address() {
+                            // we really only care about these I think. The rest can be pruned
+                            ContentAddress::AttributePrototype(_)
+                            | ContentAddress::InputSocket(_) => {
+                                Ok(petgraph::visit::Control::Continue)
+                            }
+
+                            _ => Ok(petgraph::visit::Control::Prune),
+                        }
+                    }
+                    // If we see any of these, keep walking
+                    NodeWeight::SchemaVariant(_)
+                    | NodeWeight::InputSocket(_)
+                    | NodeWeight::Prop(_) => Ok(petgraph::visit::Control::Continue),
+                    // All of these can be pruned, they don't lead to the answer
+                    NodeWeight::Action(_)
+                    | NodeWeight::AttributeValue(_)
+                    | NodeWeight::Component(_)
+                    | NodeWeight::ActionPrototype(_)
+                    | NodeWeight::Category(_)
+                    | NodeWeight::DependentValueRoot(_)
+                    | NodeWeight::FinishedDependentValueRoot(_)
+                    | NodeWeight::Ordering(_)
+                    | NodeWeight::Geometry(_)
+                    | NodeWeight::View(_)
+                    | NodeWeight::DiagramObject(_)
+                    | NodeWeight::ApprovalRequirementDefinition(_)
+                    | NodeWeight::ManagementPrototype(_)
+                    | NodeWeight::Func(_)
+                    | NodeWeight::FuncArgument(_)
+                    | NodeWeight::Secret(_) => Ok(petgraph::visit::Control::Prune),
+                }
+            }
+            _ => Ok(petgraph::visit::Control::Continue),
+        }
+    }
 }
 
 impl ComponentExt for WorkspaceSnapshotGraphV4 {
@@ -195,5 +255,28 @@ impl ComponentExt for WorkspaceSnapshotGraphV4 {
         )?;
 
         Ok(count)
+    }
+
+    fn has_socket_connections(&self, component_id: ComponentId) -> ComponentResult<bool> {
+        // Start DFS
+        // Path: Component -> SchemaVariant → InputSocket → AttributePrototype (Content) → AttributePrototypeArgument
+        let mut has_connections = false;
+
+        let schema_variant_id = self.schema_variant_id_for_component_id(component_id)?;
+
+        petgraph::visit::depth_first_search(
+            &self.graph,
+            Some(self.get_node_index_by_id(schema_variant_id)?),
+            |event| {
+                Self::has_socket_connections_dfs_event(
+                    event,
+                    &mut has_connections,
+                    component_id,
+                    self,
+                )
+            },
+        )?;
+
+        Ok(has_connections)
     }
 }

--- a/lib/dal/src/workspace_snapshot/selector.rs
+++ b/lib/dal/src/workspace_snapshot/selector.rs
@@ -1060,6 +1060,13 @@ impl ComponentExt for WorkspaceSnapshotSelector {
             Self::SplitSnapshot(snapshot) => snapshot.external_source_count(id).await,
         }
     }
+
+    async fn has_socket_connections(&self, id: ComponentId) -> ComponentResult<bool> {
+        match self {
+            Self::LegacySnapshot(snapshot) => snapshot.has_socket_connections(id).await,
+            Self::SplitSnapshot(snapshot) => snapshot.has_socket_connections(id).await,
+        }
+    }
 }
 
 #[async_trait]

--- a/lib/dal/src/workspace_snapshot/split_snapshot.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot.rs
@@ -1867,4 +1867,9 @@ impl ComponentExt for SplitSnapshot {
             .await
             .external_source_count(component_id)
     }
+    async fn has_socket_connections(&self, component_id: ComponentId) -> ComponentResult<bool> {
+        self.working_copy()
+            .await
+            .has_socket_connections(component_id)
+    }
 }

--- a/lib/dal/src/workspace_snapshot/split_snapshot/graph.rs
+++ b/lib/dal/src/workspace_snapshot/split_snapshot/graph.rs
@@ -23,11 +23,13 @@ use crate::{
         EntityKindResult,
     },
     workspace_snapshot::{
+        content_address::ContentAddress,
         graph::traits::{
             attribute_value::AttributeValueExt,
             component::ComponentExt,
             entity_kind::EntityKindExt,
         },
+        node_weight::NodeWeight,
         split_snapshot::SplitSnapshotGraphV1,
     },
 };
@@ -64,6 +66,25 @@ impl ComponentExt for SplitSnapshotGraphV1 {
 
         Ok(count)
     }
+
+    fn has_socket_connections(&self, component_id: ComponentId) -> ComponentResult<bool> {
+        // Start DFS
+        // Path: Component -> SchemaVariant → InputSocket → AttributePrototype (Content) → AttributePrototypeArgument
+        let mut has_connections = false;
+
+        // Find schema variant by following "Use" edge from component
+        let schema_variant_id = self
+            .outgoing_targets(component_id.into(), EdgeWeightKindDiscriminants::Use)
+            .map_err(WorkspaceSnapshotError::from)?
+            .next()
+            .ok_or(ComponentError::SchemaVariantNotFound(component_id))?;
+
+        petgraph::visit::depth_first_search(self, Some(schema_variant_id), |event| {
+            has_socket_connections_dfs_event(event, &mut has_connections, component_id, self)
+        })?;
+
+        Ok(has_connections)
+    }
 }
 
 impl EntityKindExt for SplitSnapshotGraphV1 {
@@ -71,6 +92,65 @@ impl EntityKindExt for SplitSnapshotGraphV1 {
         self.node_weight(id.into())
             .ok_or(EntityKindError::NodeNotFound(id))
             .map(Into::into)
+    }
+}
+fn has_socket_connections_dfs_event(
+    event: DfsEvent<Ulid>,
+    has_connections: &mut bool,
+    component_id: ComponentId,
+    graph: &SplitSnapshotGraphV1,
+) -> ComponentResult<Control<()>> {
+    match event {
+        DfsEvent::Discover(node_id, _) => {
+            let Some(node_weight) = graph.node_weight(node_id) else {
+                return Ok(petgraph::visit::Control::Continue);
+            };
+
+            match node_weight {
+                // Found an APA Node weight - let's see if it has targets and if the component in question is the destination
+                NodeWeight::AttributePrototypeArgument(apa_node_weight) => {
+                    if let Some(targets) = apa_node_weight.targets() {
+                        if targets.destination_component_id == component_id {
+                            *has_connections = true;
+                            return Ok(petgraph::visit::Control::Break(()));
+                        }
+                    }
+                    Ok(petgraph::visit::Control::Continue)
+                }
+                NodeWeight::Content(content_node_weight) => {
+                    match content_node_weight.content_address() {
+                        // we really only care about these I think. The rest can be pruned
+                        ContentAddress::AttributePrototype(_) | ContentAddress::InputSocket(_) => {
+                            Ok(petgraph::visit::Control::Continue)
+                        }
+
+                        _ => Ok(petgraph::visit::Control::Prune),
+                    }
+                }
+                // If we see any of these, keep walking
+                NodeWeight::SchemaVariant(_) | NodeWeight::InputSocket(_) | NodeWeight::Prop(_) => {
+                    Ok(petgraph::visit::Control::Continue)
+                }
+                // All of these can be pruned, they don't lead to the answer
+                NodeWeight::Action(_)
+                | NodeWeight::AttributeValue(_)
+                | NodeWeight::Component(_)
+                | NodeWeight::ActionPrototype(_)
+                | NodeWeight::Category(_)
+                | NodeWeight::DependentValueRoot(_)
+                | NodeWeight::FinishedDependentValueRoot(_)
+                | NodeWeight::Ordering(_)
+                | NodeWeight::Geometry(_)
+                | NodeWeight::View(_)
+                | NodeWeight::DiagramObject(_)
+                | NodeWeight::ApprovalRequirementDefinition(_)
+                | NodeWeight::ManagementPrototype(_)
+                | NodeWeight::Func(_)
+                | NodeWeight::FuncArgument(_)
+                | NodeWeight::Secret(_) => Ok(petgraph::visit::Control::Prune),
+            }
+        }
+        _ => Ok(petgraph::visit::Control::Continue),
     }
 }
 

--- a/lib/dal/src/workspace_snapshot/traits/component.rs
+++ b/lib/dal/src/workspace_snapshot/traits/component.rs
@@ -18,6 +18,7 @@ pub trait ComponentExt {
     ) -> ComponentResult<AttributeValueId>;
 
     async fn external_source_count(&self, id: ComponentId) -> ComponentResult<usize>;
+    async fn has_socket_connections(&self, id: ComponentId) -> ComponentResult<bool>;
 }
 
 #[async_trait]
@@ -31,5 +32,8 @@ impl ComponentExt for WorkspaceSnapshot {
 
     async fn external_source_count(&self, id: ComponentId) -> ComponentResult<usize> {
         self.working_copy().await.external_source_count(id)
+    }
+    async fn has_socket_connections(&self, id: ComponentId) -> ComponentResult<bool> {
+        self.working_copy().await.has_socket_connections(id)
     }
 }

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -145,6 +145,7 @@ pub struct ComponentInList {
     pub input_count: usize,
     pub diff_status: ComponentDiffStatus,
     pub to_delete: bool,
+    pub has_socket_connections: bool,
 }
 
 #[derive(

--- a/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
@@ -72,13 +72,13 @@ pub struct AttributeValue {
     pub path: String,
     pub prop_id: Option<PropId>,
     pub value: serde_json::Value,
-    pub can_be_set_by_socket: bool, // true if this prop value is currently driven by a socket, even if the socket isn't in use
     pub external_sources: Option<Vec<ExternalSource>>, // this is the detail of where the subscriptions are from
     pub is_controlled_by_ancestor: bool, // if ancestor of prop is set by dynamic func, ID of ancestor that sets it
     pub is_controlled_by_dynamic_func: bool, // props driven by non-dynamic funcs have a statically set value
     pub overridden: bool, // true if this prop has a different controlling func id than the default for this asset
     pub validation: Option<ValidationOutput>,
     pub secret: Option<Secret>,
+    pub has_socket_connection: bool,
 }
 
 #[derive(


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

This change implements a method `has_socket_connections()` on `WorkspaceSnapshotSelector` which determines whether a component has at least one input socket with a connection, using lower level abstractions to reduce the performance hit of this work.

We include this data in the `ComponentInListMV` and, when true, for each `AttributeValue` we'll attempt to find if the attribute value is bein set by a socket. 

I've also removed `canBeSetBySocket` from the MV as we do not use this data in newhotness
<!-- Why: briefly what problem this solves and what the aim is as an overview -->
While we have a process for migration from a socket world to a prop subscription world, some of our older Builtins and various assets authored are not able to be cleanly migrated automatically. This leaves us in a bit of a mixed state - the Component's data is correct in the new experience, but how it came to be is no longer functional.  As most workspaces ARE able to migrate MOST socket connections cleanly, we're adding this to the MV so we can indicate in the new experience when there's a component that is incompatible for modification in the new experience. 

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Integration tests - added a new integration test that ensures these values are correct, including accounting for a simple migration case

## In short: [:link:](https://giphy.com/)

<div><img src="https://media2.giphy.com/media/1g0NvvLSFiBjZEqYny/giphy.gif?cid=5a38a5a2ip14tcyklkgou3hxe3glwbiekg26iwi791r8ebfb&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g&amp;epb=ad.kevel.949056cfdf63" style="border:0;height:225px;width:300px"/><br/>via <a href="https://giphy.com/hyperrpg/">Hyper RPG</a> on <a href="https://giphy.com/gifs/hyperrpg-yes-agree-agreed-1g0NvvLSFiBjZEqYny">GIPHY</a></div>