### PR TITLE
feat(web): Show workspace migration warning

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -5,6 +5,30 @@
     <div
       class="main pt-xs flex flex-col gap-xs items-stretch [&>div]:mx-[12px]"
     >
+      <!-- Socket connections banner -->
+      <div
+        v-if="hasSocketConnections && !showSkeleton"
+        :class="
+          clsx(
+            'flex flex-row items-center gap-xs px-sm py-xs border my-sm',
+            themeClasses(
+              'bg-neutral-200 border-neutral-400 text-neutral-900',
+              'bg-neutral-700 border-neutral-600 text-neutral-100',
+            ),
+          )
+        "
+      >
+        <TruncateWithTooltip class="py-2xs text-sm flex-1">
+          A faster, smarter experience is here. Some component settings may be
+          incompatible.
+        </TruncateWithTooltip>
+        <VButton
+          size="sm"
+          label="Learn more"
+          @click="openWorkspaceMigrationDocumentation"
+        />
+      </div>
+
       <!-- Search and filters -->
       <ExploreSearchBarSkeleton v-if="showSkeleton" />
       <template v-else>
@@ -440,6 +464,7 @@ import {
   PillCounter,
   TextPill,
   themeClasses,
+  TruncateWithTooltip,
   VButton,
   VormInput,
 } from "@si/vue-lib/design-system";
@@ -470,7 +495,10 @@ import ExploreGridSkeleton from "@/newhotness/skeletons/ExploreGridSkeleton.vue"
 import ExploreRightColumnSkeleton from "@/newhotness/skeletons/ExploreRightColumnSkeleton.vue";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
 import Map from "./Map.vue";
-import { collapsingGridStyles } from "./util";
+import {
+  collapsingGridStyles,
+  openWorkspaceMigrationDocumentation,
+} from "./util";
 import CollapsingGridItem from "./layout_components/CollapsingGridItem.vue";
 import InstructiveVormInput from "./layout_components/InstructiveVormInput.vue";
 import { getQualificationStatus } from "./ComponentTileQualificationStatus.vue";
@@ -895,7 +923,14 @@ const placeholderSearchText = computed(
   () =>
     `Search across ${componentListQuery.data.value?.length ?? 0} Components`,
 );
-const componentList = computed(() => componentListQuery.data.value ?? []);
+const componentList = computed(() => {
+  return componentListQuery.data.value ?? [];
+});
+
+const hasSocketConnections = computed(() => {
+  if (!componentList.value) return false;
+  return componentList.value.some((c) => c.hasSocketConnections);
+});
 
 // ================================================================================================
 // PINNING, RESOURCE COUNT, ETC.

--- a/app/web/src/newhotness/Map.vue
+++ b/app/web/src/newhotness/Map.vue
@@ -797,8 +797,9 @@ const icons = reactive<IconNames[]>([
   "check-hex-outline",
   "check-hex",
   "x-hex-outline",
+  "alert-triangle-filled",
 ]);
-const tones = reactive<Tones[]>(["success", "destructive"]);
+const tones = reactive<Tones[]>(["success", "destructive", "warning"]);
 
 const connections = useQuery<IncomingConnections[]>({
   queryKey,
@@ -1792,6 +1793,22 @@ watch(
               return icon ? `url(#${icon})` : "none";
             });
         });
+
+        // Socket connections alert icon
+        if (d.component.hasSocketConnections) {
+          d3.select(this)
+            .append("path")
+            .attr("d", d3.symbol().size(1000).type(d3.symbolSquare))
+            .attr("transform", () => {
+              // Position to the right of existing icons
+              const iconOffset = d.icons.length * 23;
+              return `translate(${WIDTH - 13 - iconOffset - 23}, ${
+                HEIGHT - 9
+              })`;
+            })
+            .attr("pointer-events", "none")
+            .style("fill", "url(#alert-triangle-filled-warning)");
+        }
       });
 
       svg

--- a/app/web/src/newhotness/composables/useComponentDeletion.ts
+++ b/app/web/src/newhotness/composables/useComponentDeletion.ts
@@ -46,6 +46,7 @@ export function useComponentDeletion(viewId?: string, skipNavigation = false) {
       diffStatus,
       toDelete: component.toDelete,
       resourceId: null,
+      hasSocketConnections: false,
     };
   };
 

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -47,6 +47,19 @@
       </h3>
       <Icon v-if="component.toDelete" name="trash" size="md" />
       <Icon
+        v-else-if="component.hasSocketConnections"
+        v-tooltip="'Incompatibility found'"
+        name="alert-triangle-filled"
+        size="lg"
+        :class="
+          clsx(
+            themeClasses('text-warning-600', 'text-warning-400'),
+            'absolute top-[8px] right-[24px] rounded p-xs hover:cursor-pointer',
+            themeClasses('hover:bg-neutral-300', 'hover:bg-neutral-600'),
+          )
+        "
+      />
+      <Icon
         v-else-if="canBeUpgraded"
         name="bolt-outline"
         size="md"

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -13,7 +13,13 @@
               'pr-xs',
               themeClasses('bg-destructive-200', 'bg-newhotness-destructive'),
             ],
+            props.hasSocketConnection && 'pr-xs',
           )
+        "
+        :style="
+          props.hasSocketConnection
+            ? { backgroundColor: 'rgba(125, 74, 23, 0.25)' }
+            : {}
         "
       >
         <!-- Attribute name -->
@@ -67,6 +73,11 @@
                       'border-destructive-600',
                       'border-destructive-400',
                     ),
+                  ]
+                : props.hasSocketConnection
+                ? [
+                    'mt-xs',
+                    themeClasses('border-neutral-400', 'border-neutral-600'),
                   ]
                 : themeClasses('border-neutral-400', 'border-neutral-600'),
 
@@ -208,6 +219,17 @@
       >
         <span>
           {{ props.validation.message }}
+        </span>
+      </div>
+
+      <!-- socket connections incompatibility message -->
+      <div
+        v-if="!inputOpen && props.hasSocketConnection"
+        :class="clsx('flex flex-row p-xs text-xs')"
+        :style="{ backgroundColor: 'rgba(125, 74, 23, 0.25)' }"
+      >
+        <span>
+          This attribute setting is incompatible with the new experience
         </span>
       </div>
 
@@ -709,6 +731,7 @@ const props = defineProps<{
   isSecret?: boolean;
   disableInputWindow?: boolean;
   forceReadOnly?: boolean;
+  hasSocketConnection?: boolean;
 }>();
 
 const showAllPossibleConnections = ref(false);

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -15,6 +15,7 @@
     :isArray="false"
     :isMap="false"
     :forceReadOnly="false"
+    :hasSocketConnection="hasSocketConnections"
     @close="closeSubscriptionInput"
     @save="(...args) => emit('save', ...args)"
   />
@@ -237,6 +238,7 @@
         :isArray="attributeTree.prop?.kind === 'array'"
         :isMap="attributeTree.prop?.kind === 'map'"
         :forceReadOnly="props.forceReadOnly || parentHasExternalSources"
+        :hasSocketConnection="hasSocketConnections"
         @save="(...args) => emit('save', ...args)"
         @delete="(...args) => emit('delete', ...args)"
         @remove-subscription="(...args) => emit('removeSubscription', ...args)"
@@ -295,6 +297,11 @@ const isBuildable = computed(
     ["array", "map"].includes(props.attributeTree.prop?.kind ?? "") &&
     !props.component.toDelete,
 );
+
+const hasSocketConnections = computed(() => {
+  if (!props.attributeTree || !props.attributeTree.attributeValue) return false;
+  return props.attributeTree.attributeValue.hasSocketConnection;
+});
 
 const displayName = computed(() => {
   if (props.attributeTree.attributeValue.key)

--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -111,3 +111,7 @@ export const findAttributeValueInTree = (
 export function objectKeys<T extends object>(obj: T): Array<keyof T> {
   return Object.keys(obj) as Array<keyof T>;
 }
+
+export const openWorkspaceMigrationDocumentation = () => {
+  globalThis.window?.open("https://docs.systeminit.com", "_blank");
+};

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -309,6 +309,7 @@ export interface ComponentInList {
   diffStatus: ComponentDiffStatus;
   toDelete: boolean;
   resourceId: string | null;
+  hasSocketConnections: boolean;
 }
 
 export interface BifrostComponentList {
@@ -377,6 +378,7 @@ export interface AttributeValue {
   overriden: boolean;
   validation?: ValidationOutput;
   secret: Secret | null;
+  hasSocketConnection: boolean;
 }
 
 export interface ExternalSource {

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -166,6 +166,7 @@ import CarbonMaximize from "~icons/carbon/maximize";
 import CarbonTransformCode from "~icons/carbon/code"; // using this one as a placeholder for now
 import SettingsEdit from "~icons/carbon/settings-edit";
 import CarbonWarningAlt from "~icons/carbon/warning-alt";
+import CarbonWarningAltFilled from "~icons/carbon/warning-alt-filled";
 import Pin from "~icons/carbon/pin-filled";
 import Renew from "~icons/carbon/renew";
 import CarbonApps from "~icons/carbon/apps";
@@ -242,6 +243,7 @@ export const ICONS = Object.freeze({
   "alert-circle": AlertCircle,
   "alert-square": AlertSquare,
   "alert-triangle": AlertTriangle,
+  "alert-triangle-filled": CarbonWarningAltFilled,
   "alert-triangle-outline": CarbonWarningAlt,
   "arrows-out": PhArrowsOutCardinal,
   backspace: MaterialSymbolsBackspaceOutline,


### PR DESCRIPTION
We are going to show a migration warning when a workspace has been 
migrated from socket connections to prop connections. This is going to 
be keyed off a hasSocketConnection property that will only show if they 
have an existing socket connection

the warning is going to link to a documentation page that we will add 
details to about what the new structure is and possible reasons why it 
didn’t migrate and what they would do about it

https://jam.dev/c/35174a28-b11e-442c-a7c3-8747315c6a02

<img width="927" height="515" alt="Screenshot 2025-08-02 at 22 03 03" src="https://github.com/user-attachments/assets/52ea1494-ed14-41b8-960b-e507b699211d" />
<img width="1915" height="321" alt="Screenshot 2025-08-02 at 21 51 54" src="https://github.com/user-attachments/assets/aa6bbfcf-e22b-4c3a-bc26-ad09fa4c1cb7" />
<img width="1338" height="291" alt="Screenshot 2025-08-02 at 21 47 55" src="https://github.com/user-attachments/assets/75d04fe8-3d58-491a-b98d-7732aafc2ea9" />
<img width="1914" height="396" alt="Screenshot 2025-08-02 at 21 31 55" src="https://github.com/user-attachments/assets/79b52445-12c4-4dd8-8c85-e3333c86f648" />
