### PR TITLE
Temporarily disable the flakey check in the workspace management cypress test

### DIFF
--- a/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
+++ b/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
@@ -35,7 +35,8 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
         return false;
       });
 
-      cy.appModelPageLoaded();
+      // TODO: This needs to be updated to check for the new experience loading
+      // cy.appModelPageLoaded();
     });
   });
 });


### PR DESCRIPTION

This test has become flakey with the cut over to the new experience and needs to be updated accordingly.  This is just a temporary change until we do this work this week.
