### PR TITLE
Resurrect workspace approvals

### DIFF
--- a/app/web/src/newhotness/InsetApprovalModal.vue
+++ b/app/web/src/newhotness/InsetApprovalModal.vue
@@ -1,0 +1,452 @@
+<template>
+  <!-- 'xl:max-w-[50vw] xl:min-w-[680px] max-h-full', -->
+  <div
+    v-if="mode !== 'error'"
+    :class="
+      clsx(
+        'flex flex-col gap-sm p-sm',
+        'rounded shadow-2xl overflow-hidden',
+        themeClasses('bg-shade-0 border', 'bg-neutral-900'),
+      )
+    "
+  >
+    <!-- HEADER -->
+    <div class="flex flex-row flex-none gap-md mb-sm items-center">
+      <div class="flex flex-col max-w-[66%] min-w-[50%]">
+        <TruncateWithTooltip class="font-bold italic pb-2xs">
+          {{ changeSetName }}
+        </TruncateWithTooltip>
+        <TruncateWithTooltip class="font-bold pb-2xs">{{
+          modalData.title
+        }}</TruncateWithTooltip>
+        <div v-if="modalData.date" class="text-sm italic">
+          <Timestamp :date="modalData.date" showTimeIfToday size="extended" />
+        </div>
+      </div>
+
+      <ErrorMessage
+        :tone="modalData.messageTone"
+        :icon="modalData.messageIcon"
+        variant="block"
+        class="rounded grow"
+      >
+        <template v-if="mode === 'requested'">
+          There are approvals that must be met before the change set can be
+          applied.
+        </template>
+        <template v-else-if="mode === 'approved'">
+          <p>
+            {{ requesterIsYou ? "Your" : "The" }} request to
+            <span class="font-bold">Apply</span> change set
+            <span class="font-bold">{{ changeSetName }}</span> has been
+            approved.
+          </p>
+        </template>
+        <template v-else>
+          ERROR - this message should not ever show. Something has gone wrong!
+        </template>
+      </ErrorMessage>
+    </div>
+
+    <div
+      :class="
+        clsx('flex flex-row gap-xs flex-1 overflow-hidden place-content-evenly')
+      "
+    >
+      <div
+        :class="
+          clsx('flex flex-col gap-xs overflow-hidden text-center basis-1/2')
+        "
+      >
+        <RouterLink
+          :to="{
+            name: 'workspace-audit',
+            params: { changeSetId: 'auto' },
+          }"
+          target="_blank"
+          class="text-action-500 hover:underline pl-4 pb-2xs text-sm font-bold"
+          >See the breakdown of changes
+          <Icon
+            size="sm"
+            name="logs-pop-square"
+            class="ml-2xs inline-block mb-[-.3em]"
+          />
+        </RouterLink>
+      </div>
+    </div>
+
+    <!-- MAIN SECTION -->
+    <div
+      :class="
+        clsx('flex flex-row gap-xs flex-1 overflow-hidden place-content-evenly')
+      "
+    >
+      <div class="flex flex-col basis-1/2 text-sm gap-xs overflow-y-auto">
+        <div
+          v-for="group in requirementGroups"
+          :key="group.key"
+          class="border-neutral-200 dark:border-neutral-700 border"
+        >
+          <div class="bg-neutral-200 dark:bg-neutral-700 p-xs">
+            {{ group.requiredCount }} of the following users for{{
+              group.labels.length > 1
+                ? ` ${group.labels.length} requirements:`
+                : ""
+            }}
+            <span v-if="group.labels.length === 1" class="italic">{{
+              group.labels[0]
+            }}</span>
+            <TruncateWithTooltip
+              v-else
+              expandOnClick
+              :expandableStringArray="group.labels"
+              class="italic break-all"
+            />
+          </div>
+          <ul>
+            <li
+              v-for="vote in group.votes"
+              :key="vote.user.id"
+              :class="
+                clsx(
+                  'flex flex-row items-center gap-xs px-xs py-2xs',
+                  themeClasses('even:bg-neutral-100', 'even:bg-neutral-800'),
+                )
+              "
+            >
+              <TruncateWithTooltip class="flex-grow"
+                >{{ vote.user.name }} ({{
+                  vote.user.email
+                }})</TruncateWithTooltip
+              >
+              <div
+                :class="
+                  clsx(
+                    'flex flex-col items-center flex-none w-[60px]',
+                    vote.status ? 'font-bold' : 'italic',
+                    vote.status === 'Rejected' && 'text-destructive-500',
+                    vote.status === 'Approved' && 'text-success-500',
+                  )
+                "
+              >
+                <div v-if="!vote.status">Waiting...</div>
+                <div v-else>{{ vote.status }}</div>
+              </div>
+              <span class="flex flex-row items-center flex-none">
+                <Icon
+                  size="md"
+                  name="thumbs-up"
+                  tone="success"
+                  :class="clsx(vote.status !== 'Approved' ? 'opacity-20' : '')"
+                />
+                <Icon
+                  size="md"
+                  name="thumbs-down"
+                  tone="error"
+                  :class="clsx(vote.status !== 'Rejected' ? 'opacity-20' : '')"
+                />
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- BUTTONS -->
+    <div class="flex flex-row flex-none gap-sm justify-center mt-sm">
+      <VButton
+        label="Withdraw Request"
+        tone="warning"
+        variant="ghost"
+        icon="x"
+        @click="withdraw"
+      />
+      <template v-if="userIsApprover">
+        <VButton
+          :disabled="iRejected"
+          label="Reject Request"
+          tone="destructive"
+          icon="thumbs-down"
+          @click="rejectHandler"
+        />
+        <VButton
+          :disabled="iApproved"
+          label="Approve Request"
+          tone="success"
+          icon="thumbs-up"
+          @click="approve"
+        />
+      </template>
+      <VButton
+        :disabled="mode !== 'approved'"
+        tone="success"
+        :loading="mode === 'approved' ? applyingChangeSet : false"
+        loadingText="Applying..."
+        @click="apply"
+      >
+        <span class="dark:text-neutral-800">Apply Change Set</span>
+        <template #icon>
+          <Icon name="tools" size="sm" class="dark:text-neutral-800" />
+        </template>
+      </VButton>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import {
+  VButton,
+  Timestamp,
+  Tones,
+  ErrorMessage,
+  Icon,
+  IconNames,
+  Modal,
+  themeClasses,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
+import { computed, ref } from "vue";
+import { RouterLink } from "vue-router";
+import clsx from "clsx";
+import {
+  ApprovalData,
+  ApprovalStatus,
+  approverForChangeSet,
+} from "@/store/change_sets.store";
+import { WorkspaceUser } from "@/store/auth.store";
+import { ChangeSetStatus, ChangeSet } from "@/api/sdf/dal/change_set";
+import { User } from "@/api/sdf/dal/user";
+import { useContext } from "./logic_composables/context";
+import { routes, useApi } from "./api_composables";
+import { useApplyChangeSet } from "./logic_composables/change_set";
+
+const props = defineProps<{
+  approvalData: ApprovalData | undefined;
+  changeSet: ChangeSet;
+  workspaceUsers: Record<string, WorkspaceUser>;
+  user: User;
+}>();
+
+export type InsetApprovalModalMode =
+  | "requested"
+  | "approved"
+  | "rejected"
+  | "error";
+
+const changeSetName = computed(() => props.changeSet.name);
+
+interface RequirementGroup {
+  key: string;
+  labels: string[];
+  votes: Vote[];
+  satisfied: boolean;
+  requiredCount: number;
+}
+interface Vote {
+  user: WorkspaceUser;
+  status?: ApprovalStatus;
+}
+
+const requirementGroups = computed(() => {
+  const groups: Map<Set<string>, RequirementGroup> = new Map();
+  props.approvalData?.requirements.forEach((r) => {
+    const userIds = Object.values(r.approverGroups)
+      .flat()
+      .concat(r.approverIndividuals);
+    const votes: Vote[] = [];
+    userIds.forEach((id) => {
+      const user = props.workspaceUsers[id];
+      if (!user) {
+        return;
+      }
+      const submitted = props.approvalData?.latestApprovals.find(
+        (a) =>
+          a.isValid &&
+          a.userId === id &&
+          r.applicableApprovalIds.includes(a.id),
+      );
+      const vote: Vote = { user };
+      if (submitted) vote.status = submitted.status;
+      votes.push(vote);
+    });
+
+    let label;
+    if (r.entityKind === "ApprovalRequirementDefinition") {
+      label = ["Approval Requirement change"];
+    }
+    // else if (r.entityKind === "Schema") {
+    //   const variantForSchema = assetStore.schemaVariants.find(
+    //     (thing) => thing.schemaId === r.entityId,
+    //   );
+    //   label = variantForSchema?.schemaName
+    //     ? `Asset named ${variantForSchema?.schemaName}`
+    //     : "an Asset";
+    // } else if (r.entityKind === "SchemaVariant") {
+    //   let name = assetStore.variantFromListById[r.entityId]?.displayName;
+    //   if (!name) {
+    //     name = assetStore.variantFromListById[r.entityId]?.schemaName;
+    //   }
+    //   label = name ? `Asset named ${name}` : "Asset (name not found)";
+    // }
+    // } else if (r.entityKind === "View") {
+    //   const name = viewStore.viewsById[r.entityId]?.name;
+    //   label = [name ? `View named ${name}` : "View (name not found)"];
+    else {
+      label = ["Workspace change"];
+    }
+
+    const group: RequirementGroup = {
+      key: r.entityId,
+      labels: label,
+      votes,
+      satisfied: r.isSatisfied,
+      requiredCount: r.requiredCount,
+    };
+
+    // Check if this RequirementGroup has the same votes and/or label as an existing one and group/filter accordingly
+    const key = new Set(group.votes.map((vote) => vote.user.id));
+    const check = [...groups.entries()].find(
+      ([k, _]) => k.size === key.size && [...k].every((i) => key.has(i)),
+    );
+    if (check) {
+      const [_, set] = check;
+      const label = group.labels[0];
+      if (label && !set.labels.includes(label)) {
+        // different label and same votes - group together
+        set.labels.push(label);
+      }
+      // same label and same votes - don't push in
+    } else {
+      groups.set(key, group);
+    }
+  });
+  return [...groups.values()];
+});
+
+const satisfied = computed(
+  () => !props.approvalData?.requirements.some((r) => r.isSatisfied === false),
+);
+
+const myVote = computed(() =>
+  props.approvalData?.latestApprovals.find(
+    (a) => a.isValid && a.userId === props.user.pk,
+  ),
+);
+
+const iApproved = computed(() => myVote.value?.status === "Approved");
+
+const iRejected = computed(() => myVote.value?.status === "Rejected");
+
+const mode = computed(() => {
+  if (satisfied.value === true) return "approved";
+  switch (props.changeSet.status) {
+    case ChangeSetStatus.NeedsApproval:
+      return "requested";
+    case ChangeSetStatus.Approved:
+      return "approved";
+    case ChangeSetStatus.Rejected:
+      return "rejected";
+    default:
+      return "error";
+  }
+});
+
+const requesterIsYou = computed(
+  () => props.changeSet.mergeRequestedByUserId === props.user.pk,
+);
+const userIsApprover = computed(() => {
+  if (props.approvalData)
+    return approverForChangeSet(props.user.pk, props.approvalData);
+  return false;
+});
+
+const approverEmail = computed(() => props.changeSet.reviewedByUser);
+const requesterEmail = computed(() => props.changeSet.mergeRequestedByUser);
+
+const approveDate = computed(() => props.changeSet.reviewedAt as IsoDateString);
+const requestDate = computed(
+  () => props.changeSet.mergeRequestedAt as IsoDateString,
+);
+
+const modalData = computed(() => {
+  if (mode.value === "requested") {
+    return {
+      title: `Approval Requested by ${
+        requesterIsYou.value ? "You" : requesterEmail.value
+      }`,
+      date: requestDate.value,
+      messageTone: "warning" as Tones,
+      messageIcon: "exclamation-circle" as IconNames,
+    };
+    // approved & rejected are deprecating with the new approach
+  } else if (mode.value === "approved") {
+    return {
+      title: approverEmail.value
+        ? `Approval Granted by ${approverEmail.value}`
+        : "Approval Granted",
+      date: approveDate.value,
+      messageTone: "success" as Tones,
+      messageIcon: "check-circle" as IconNames,
+    };
+  } else if (mode.value === "rejected") {
+    return {
+      title: `Approval Rejected by ${approverEmail.value}`,
+      date: approveDate.value,
+      messageTone: "destructive" as Tones,
+      messageIcon: "exclamation-circle" as IconNames,
+    };
+  }
+
+  return {
+    title: "ERROR! Go back to HEAD",
+    date: new Date(),
+    messageTone: "destructive" as Tones,
+  };
+});
+
+const ctx = useContext();
+
+const approveApi = useApi(ctx);
+
+const approve = () => {
+  const call = approveApi.endpoint(routes.ChangeSetApprove);
+  call.post({ status: "Approved" });
+};
+
+const { applyChangeSet, disableApplyChangeSet: _disable } = useApplyChangeSet();
+const applyingChangeSet = computed(() => applyChangeSet.loading.value);
+
+const apply = () => {
+  applyChangeSet.performApply();
+};
+
+const reopenApi = useApi(ctx);
+const cancelApi = useApi(ctx);
+
+const withdraw = () => {
+  if (mode.value === "rejected") {
+    const reopenCall = reopenApi.endpoint(routes.ChangeSetReopen);
+    reopenCall.post({});
+  } else {
+    const cancelCall = cancelApi.endpoint(
+      routes.ChangeSetCancelApprovalRequest,
+    );
+    cancelCall.post({});
+  }
+};
+
+const rejectApi = useApi(ctx);
+
+const rejectHandler = () => {
+  const call = rejectApi.endpoint(routes.ChangeSetApprove);
+  call.post({ status: "Rejected" });
+};
+
+const modalRef = ref<InstanceType<typeof Modal> | null>(null);
+async function openModalHandler() {
+  // if (ctx?.onHead.value) return;
+  modalRef.value?.open();
+}
+defineExpose({ open: openModalHandler });
+</script>

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -24,7 +24,12 @@ export enum routes {
   ActionRetry = "ActionRetry",
   ActionFuncRunId = "ActionFuncRunId",
   ApplyChangeSet = "ApplyChangeSet",
+  ChangeSetApprovalStatus = "ChangeSetApprovalStatus",
+  ChangeSetApprove = "ChangeSetApprove",
+  ChangeSetCancelApprovalRequest = "ChangeSetCancelApprovalRequest",
   ChangeSetRename = "ChangeSetRename",
+  ChangeSetReopen = "ChangeSetReopen",
+  ChangeSetRequestApproval = "ChangeSetRequestApproval",
   CreateComponent = "CreateComponent",
   CreateSecret = "CreateSecret",
   CreateTemplate = "CreateTemplate",
@@ -54,6 +59,7 @@ export enum routes {
   AbandonChangeSet = "AbandonChangeSet",
   Workspaces = "Workspaces",
   ChangeSets = "ChangeSets",
+  WorkspaceListUsers = "WorkspaceListUsers",
 }
 
 /**
@@ -82,7 +88,12 @@ const _routes: Record<routes, string> = {
   ActionRetry: "/action/<id>/retry",
   ActionFuncRunId: "/action/<id>/func_run_id",
   ApplyChangeSet: "/apply",
+  ChangeSetApprove: "/approve",
+  ChangeSetApprovalStatus: "/approval_status",
+  ChangeSetCancelApprovalRequest: "/cancel_approval_request",
   ChangeSetRename: "/rename",
+  ChangeSetReopen: "/reopen",
+  ChangeSetRequestApproval: "/request_approval",
   CreateComponent: "/views/<viewId>/component",
   CreateSecret: "/components/<id>/secret",
   CreateTemplate: "/management/generate_template/<viewId>",
@@ -113,6 +124,7 @@ const _routes: Record<routes, string> = {
   AbandonChangeSet: "/change_set/abandon_change_set",
   Workspaces: "/workspaces", // not a v2 url
   ChangeSets: "CHANGESETS", // a short v2 url
+  WorkspaceListUsers: "WORKSPACELISTUSERS", // a short v2 url
 } as const;
 
 // the mechanics
@@ -181,6 +193,9 @@ export class APICall<Response> {
     }
     if ([_routes.ChangeSets].includes(this.path)) {
       return `v2/workspaces/${this.workspaceId}/change-sets`;
+    }
+    if ([_routes.WorkspaceListUsers].includes(this.path)) {
+      return `v2/workspaces/${this.workspaceId}/users`;
     }
     const API_PREFIX = `v2/workspaces/${this.workspaceId}/change-sets/${this.changeSetId}`;
     return `${API_PREFIX}${this.path}`;

--- a/app/web/src/newhotness/nav/ApprovalPendingModal.vue
+++ b/app/web/src/newhotness/nav/ApprovalPendingModal.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <Modal ref="modalRef" title="Pending Approvals" size="lg">
+      <div class="max-h-[70vh] overflow-hidden flex flex-col gap-xs">
+        <div class="text-md pb-xs">
+          These change sets have been submitted for approval to be merged to
+          HEAD. Select one to approve or reject it.
+        </div>
+        <ApprovalPendingModalCard
+          v-for="changeSet in changeSetsNeedingApproval"
+          :key="changeSet.id"
+          :changeSet="changeSet"
+          @closeModal="closeModalHandler"
+        />
+      </div>
+    </Modal>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import * as _ from "lodash-es";
+import { Modal } from "@si/vue-lib/design-system";
+import { ref } from "vue";
+import { ChangeSet } from "@/api/sdf/dal/change_set";
+import ApprovalPendingModalCard from "./ApprovalPendingModalCard.vue";
+
+defineProps<{
+  changeSetsNeedingApproval: ChangeSet[];
+}>();
+
+const modalRef = ref<InstanceType<typeof Modal> | null>(null);
+
+function openModalHandler() {
+  modalRef.value?.open();
+}
+
+function closeModalHandler() {
+  modalRef.value?.close();
+}
+
+defineExpose({ open: openModalHandler });
+</script>

--- a/app/web/src/newhotness/nav/ApprovalPendingModalCard.vue
+++ b/app/web/src/newhotness/nav/ApprovalPendingModalCard.vue
@@ -1,0 +1,106 @@
+<template>
+  <div
+    :class="
+      clsx(
+        'group/pendingcard',
+        'border rounded flex flex-row gap-xs items-center p-2xs cursor-pointer',
+        themeClasses(
+          'border-neutral-200 hover:border-action-500 hover:text-action-500 text-shade-100',
+          'border-neutral-700 hover:border-action-300 hover:text-action-300 text-shade-0',
+        ),
+      )
+    "
+    @click="goToChangeSet(changeSet.id)"
+  >
+    <div class="group-hover/pendingcard:underline flex-1 min-w-0">
+      <div class="font-bold line-clamp-2">
+        {{ changeSet.name }}
+      </div>
+      <div
+        :class="
+          clsx(
+            'text-xs italic',
+            themeClasses(
+              'text-neutral-500 group-hover/pendingcard:text-action-500',
+              'text-neutral-400 group-hover/pendingcard:text-action-300',
+            ),
+          )
+        "
+      >
+        <Timestamp
+          :date="changeSet.mergeRequestedAt"
+          showTimeIfToday
+          size="extended"
+        />
+
+        by {{ changeSet.mergeRequestedByUser }}
+      </div>
+    </div>
+    <div class="flex gap-xs flex-none">
+      <VButton
+        size="xs"
+        label="Reject"
+        variant="ghost"
+        tone="destructive"
+        @click.stop="rejectChangeSet(changeSet.id)"
+      />
+      <VButton
+        size="xs"
+        tone="success"
+        class="grow"
+        label="Approve"
+        @click.stop="approveChangeSet(changeSet.id)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import clsx from "clsx";
+import * as _ from "lodash-es";
+import { themeClasses, VButton, Timestamp } from "@si/vue-lib/design-system";
+import { useRoute, useRouter } from "vue-router";
+import { computed } from "vue";
+import { ChangeSet, ChangeSetId } from "@/api/sdf/dal/change_set";
+import { navigateToExistingChangeSet } from "../logic_composables/change_set";
+import { useContext } from "../logic_composables/context";
+import { useApi, routes } from "../api_composables";
+
+defineProps<{
+  changeSet: ChangeSet;
+}>();
+
+const route = useRoute();
+const router = useRouter();
+
+const goToChangeSet = (id: ChangeSetId) => {
+  navigateToExistingChangeSet(id, route, router);
+  emit("closeModal");
+};
+
+const ctx = useContext();
+
+const rejectChangeSet = (id: ChangeSetId) => {
+  // TODO(nick): create or use a helper for using another ctx.
+  const newCtx = { ...ctx };
+  newCtx.changeSetId = computed(() => id);
+  const api = useApi(newCtx);
+
+  const call = api.endpoint(routes.ChangeSetApprove);
+  call.post({ status: "Rejected" });
+};
+
+const approveChangeSet = (id: ChangeSetId) => {
+  // TODO(nick): create or use a helper for using another ctx.
+  const newCtx = { ...ctx };
+  newCtx.changeSetId = computed(() => id);
+  const api = useApi(newCtx);
+
+  const call = api.endpoint(routes.ChangeSetApprove);
+  call.post({ status: "Approved" });
+};
+
+const emit = defineEmits<{
+  (e: "closeModal"): void;
+}>();
+</script>

--- a/app/web/src/newhotness/nav/NavbarPanelRight.vue
+++ b/app/web/src/newhotness/nav/NavbarPanelRight.vue
@@ -3,7 +3,7 @@
     class="flex flex-row flex-1 basis-1/2 items-center min-w-0 h-full justify-end"
   >
     <Collaborators />
-    <Notifications />
+    <Notifications :changeSetsNeedingApproval="changeSetsNeedingApproval" />
 
     <template v-if="featureFlagsStore.SQLITE_TOOLS">
       <NavbarButton icon="odin" size="sm">
@@ -96,7 +96,7 @@ import { URLPattern, describePattern } from "@si/vue-lib";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import * as heimdall from "@/store/realtime/heimdall";
 import { sdfApiInstance } from "@/store/apis.web";
-import { ChangeSetId } from "@/api/sdf/dal/change_set";
+import { ChangeSetId, ChangeSet } from "@/api/sdf/dal/change_set";
 import { EntityKind } from "@/workers/types/entity_kind_types";
 import ApplyChangeSetButton from "@/newhotness/ApplyChangeSetButton.vue";
 import NavbarButton from "@/components/layout/navbar/NavbarButton.vue";
@@ -108,6 +108,7 @@ import ProfileButton from "./ProfileButton.vue";
 const props = defineProps<{
   changeSetId: string;
   workspaceId: string;
+  changeSetsNeedingApproval: ChangeSet[];
 }>();
 
 const featureFlagsStore = useFeatureFlagsStore();

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -7,6 +7,26 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { SchemaId } from "@/api/sdf/dal/schema";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
+import { WorkspacePk } from "./api_composables/si_id";
+
+type InstanceEnvType = "LOCAL" | "PRIVATE" | "SI";
+
+export type AuthApiWorkspace = {
+  creatorUserId: string;
+  displayName: string;
+  id: WorkspacePk;
+  pk: WorkspacePk; // not actually in the response, but we backfill
+  instanceEnvType: InstanceEnvType;
+  instanceUrl: string;
+  role: "OWNER" | "EDITOR";
+  token: string;
+  isHidden: boolean;
+  approvalsEnabled: boolean;
+};
+
+export interface Workspaces {
+  workspaces: ComputedRef<Record<WorkspacePk, AuthApiWorkspace> | undefined>;
+}
 
 export interface Context {
   workspacePk: ComputedRef<string>;


### PR DESCRIPTION
## Introduction

This change brings back workspace-level approvals and the approvals subsystem with an eye for the future. The inset modal has been converted into a box within the flow modal. The notifications system, including approving from another change set, has been brought back too. Grab a chair. This ended up being a big one.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMnFyZnRmOGd2bHdueWUyaTB3bjFsbTEzc3V0ZzZtNzFrNzJiMGQ4aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/13zeE9qQNC5IKk/giphy.gif"/>

## Strategy

The conversion and naming of "InsetApprovalModal" were both intentional. It is no longer inset, but retains the name temporarily for reviewers and to cleanly convey intent about what it does. There will be a quick follow-up change to fix any inconsistent naming, potential anti-patterns, etc. This name will have to change.

The style of the buttons and inner content of that modal are retained as well. You may notice that the apply button is the old one. This is entirely intentional. In the last attempt (PR https://github.com/systeminit/si/pull/6816), part of what made it a total pain to debug was that the outer "apply" button in "ApprovalFlowModal.vue" was also taking on the loading, disabling, labeling, clicking, and styling functionality of the inner "InsertApprovalModal". We have specifically aimed to not touch the style since only two workspaces are using this future.

The strategy was essentially to cleanly port that inset modal into a box within the flow modal, but the key was to ensure that clicking "withdraw request" and "request approval" would flip between the two modes. The modal dynamically sizes with a transition when you flip between modes... and I think it looks cool!

In the long term, we should consider integrating the two Vue components further (particularly the apply/request button), but for now, this should be functional, easy to debug, and a clean separation of the approvals feature from the main flow.

## Only One Approval Kind

This change does not explicitly block other kinds of approvals from existing in the backend and on the graph, but since the UI does not expose the ability to customize approvals, it will show all existing requirements as workspace-level changes. Since there are only two workspaces using approvals and they are workspace-level approvals, we are covered.

## Feature Flagging

Due to the nest of pinia stores in the old UI, the feature was flagged pretty aggressively. In this change, the feature is only flagged in "ApprovalFlowModal.vue". Why? Well, everything else is driven by a prop being passed down through components, like "Notifications.vue". That prop has all change sets with a status of "NeedsApproval". You cannot request approval for a change set outside of the flow modal, so all affected components will not be running queries or even loaded into the UI without the feature enabled.

## Testing

This was tested using a workspace with an owner and a collaborator in two different browsers. Both components with and without actions were tested. The flag was enabled/disabled via code by changing the computed value in "ApprovalFlowModal.vue".

## Other Things We Benefit From

- Added ability to work on another change set from another change set using the "newCtx" pattern (will require a helper eventually)
- Added ability to provide a "WORKSPACE" context to anyone who needs it in the new UI (this was all @jobelenus who put the now-squashed commit in my branch)
- Added ability to navigate to an existing change set with a helper
- Added ability to list and track users in the workspace

## Near Future Work

- Rename and refactor anything related to "inset" language
- Fix the change set rename modal anti-pattern and replace it with the "newCtx" pattern (seen in PR https://github.com/systeminit/si/pull/6816)
- Move all types from stores to either "@/api/sdf/dal" or any of the new directories (e.g. ActionProposedView, approversForChangeSet)

## Screenshots

Waiting to be approved...

<img width="1269" height="626" alt="Screenshot 2025-08-05 at 1 10 02 PM" src="https://github.com/user-attachments/assets/53f01ead-4820-4e5e-b175-6bf311841011" />

...approved!

<img width="958" height="546" alt="Screenshot 2025-08-05 at 1 10 12 PM" src="https://github.com/user-attachments/assets/a34c853c-02af-4e61-8050-690f2efadfca" />

## Context

This change is a successor to PR https://github.com/systeminit/si/pull/6816 and both were inspired by PR https://github.com/systeminit/si/pull/6633. This required multiple attempts due to the nature of converting an inset approval into a regular component in the new UI, dealing with entirely non-MV content and dealing with workspace-level objects (e.g. users and the "approvals enabled" flag). This attempt was successful due to re-learning about the domain and finding all the dragons, but also taking a commit-by-commit, Vue component-by-component approach to a compiling "newhotness" UI with additional functionality on an iterative basis. Big commit squash party!