### PR TITLE
Redesign bulk edit & polish interactions

### DIFF
--- a/app/web/src/newhotness/AttributeValueBox.vue
+++ b/app/web/src/newhotness/AttributeValueBox.vue
@@ -3,6 +3,7 @@
     :class="
       clsx(
         'flex flex-row items-center gap-xs border w-fit px-3xs rounded-sm',
+        'relative',
         'max-w-full',
         themeClasses(
           'text-neutral-600 border-neutral-400 bg-neutral-100',
@@ -10,12 +11,35 @@
         ),
       )
     "
+    @mouseenter="show = true"
+    @mouseleave="show = false"
   >
     <slot />
+    <div
+      v-if="show"
+      :class="
+        clsx(
+          'absolute z-[500] bottom-[-75px] left-[-17px] w-[300px]',
+          themeClasses(
+            'text-neutral-600 border-neutral-400 bg-neutral-100',
+            'text-neutral-400 border-neutral-600 bg-neutral-900',
+          ),
+        )
+      "
+    >
+      <slot name="components" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
+import { ref } from "vue";
+
+const show = ref(false);
+
+defineProps<{
+  tooltip?: { content: string; theme: string };
+}>();
 </script>

--- a/app/web/src/newhotness/MinimizedComponentQualificationStatus.vue
+++ b/app/web/src/newhotness/MinimizedComponentQualificationStatus.vue
@@ -1,73 +1,75 @@
 <template>
   <div class="flex flex-row justify-between">
     <div class="flex flex-row items-center gap-xs">
-      <TextPill
-        v-if="
-          component.qualificationTotals.failed === 0 &&
-          component.qualificationTotals.warned === 0 &&
-          component.qualificationTotals.succeeded === 0
-        "
-        tighter
-        :class="
-          clsx(
-            'text-sm ml-auto',
-            themeClasses(
-              'border-neutral-500 bg-neutral-100 text-black',
-              'border-neutral-600 bg-neutral-900 text-white',
-            ),
-          )
-        "
-      >
-        Unknown
-      </TextPill>
-      <TextPill
-        v-else-if="
-          component.qualificationTotals.failed === 0 &&
-          component.qualificationTotals.warned === 0
-        "
-        tighter
-        :class="
-          clsx(
-            'text-xs ml-auto',
-            themeClasses(
-              'border-success-500 bg-neutral-100 text-black',
-              'border-success-600 bg-neutral-900 text-white',
-            ),
-          )
-        "
-      >
-        All passed
-      </TextPill>
-      <TextPill
-        v-else-if="component.qualificationTotals.failed > 0"
-        tighter
-        :class="
-          clsx(
-            'text-xs ml-auto',
-            themeClasses(
-              'border-destructive-500 bg-destructive-100 text-black',
-              'border-destructive-600 bg-destructive-900 text-white',
-            ),
-          )
-        "
-      >
-        {{ component.qualificationTotals.failed }} Failed
-      </TextPill>
-      <TextPill
-        v-else-if="component.qualificationTotals.warned > 0"
-        tighter
-        :class="
-          clsx(
-            'text-xs ml-auto',
-            themeClasses(
-              'border-warning-500 bg-warning-100 text-black',
-              'border-warning-600 bg-warning-900 text-white',
-            ),
-          )
-        "
-      >
-        {{ component.qualificationTotals.warned }} Warning
-      </TextPill>
+      <template v-if="!noText">
+        <TextPill
+          v-if="
+            component.qualificationTotals.failed === 0 &&
+            component.qualificationTotals.warned === 0 &&
+            component.qualificationTotals.succeeded === 0
+          "
+          tighter
+          :class="
+            clsx(
+              'text-sm ml-auto',
+              themeClasses(
+                'border-neutral-500 bg-neutral-100 text-black',
+                'border-neutral-600 bg-neutral-900 text-white',
+              ),
+            )
+          "
+        >
+          Unknown
+        </TextPill>
+        <TextPill
+          v-else-if="
+            component.qualificationTotals.failed === 0 &&
+            component.qualificationTotals.warned === 0
+          "
+          tighter
+          :class="
+            clsx(
+              'text-xs ml-auto',
+              themeClasses(
+                'border-success-500 bg-neutral-100 text-black',
+                'border-success-600 bg-neutral-900 text-white',
+              ),
+            )
+          "
+        >
+          All passed
+        </TextPill>
+        <TextPill
+          v-else-if="component.qualificationTotals.failed > 0"
+          tighter
+          :class="
+            clsx(
+              'text-xs ml-auto',
+              themeClasses(
+                'border-destructive-500 bg-destructive-100 text-black',
+                'border-destructive-600 bg-destructive-900 text-white',
+              ),
+            )
+          "
+        >
+          {{ component.qualificationTotals.failed }} Failed
+        </TextPill>
+        <TextPill
+          v-else-if="component.qualificationTotals.warned > 0"
+          tighter
+          :class="
+            clsx(
+              'text-xs ml-auto',
+              themeClasses(
+                'border-warning-500 bg-warning-100 text-black',
+                'border-warning-600 bg-warning-900 text-white',
+              ),
+            )
+          "
+        >
+          {{ component.qualificationTotals.warned }} Warning
+        </TextPill>
+      </template>
       <StatusIndicatorIcon
         type="qualification"
         size="sm"
@@ -89,6 +91,7 @@ import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 
 const props = defineProps<{
   component: ComponentInList | BifrostComponent;
+  noText?: boolean;
 }>();
 
 const qualificationStatus = computed(() => {

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -1,4 +1,12 @@
 <template>
+  <!-- without ref=scrollRef (which i dont need here) the component breaks -->
+  <div v-if="bulkEditing" ref="scrollRef" class="grow min-h-0">
+    <AttributePanelBulk
+      :selectedComponents="selectedComponentsMap"
+      @close="() => $emit('bulkDone')"
+      @deselect="(idx) => $emit('childDeselect', idx)"
+    />
+  </div>
   <!--
     NOTE(nick,victor,wendy): we need both divs here for the virtualizer. The first div is the
     scrolling area itself (it will be whatever height fills the spot in the overall UI, which,
@@ -7,14 +15,13 @@
     area will not change. If you mess with this, it will break in ways YOU MAY OR MAY NOT NOTICE.
     BUYER BEWARE.
   -->
-  <div ref="scrollRef" class="scrollable grow" style="overflow-anchor: none">
-    <AttributePanelBulk
-      v-if="bulkEditing"
-      :selectedComponents="selectedComponents"
-      @close="() => $emit('bulkDone')"
-    />
+  <div
+    v-else
+    ref="scrollRef"
+    class="scrollable grow"
+    style="overflow-anchor: none"
+  >
     <div
-      v-else
       data-testid="tile-container"
       class="w-full relative flex flex-col"
       :style="{
@@ -118,17 +125,21 @@ const allVisibleComponents = computed(() => {
 const focusedComponent = computed(
   () => allVisibleComponents.value[props.focusedComponentIdx ?? -1],
 );
-const selectedComponents = computed(() => {
-  const selected: ComponentInList[] = [];
+
+const selectedComponentsMap = computed(() => {
+  const selected: Record<number, ComponentInList> = {};
 
   props.selectedComponentIndexes.forEach((index) => {
     const component = allVisibleComponents.value[index];
     if (component) {
-      selected.push(component);
+      selected[index] = component;
     }
   });
 
   return selected;
+});
+const selectedComponents = computed(() => {
+  return Object.values(selectedComponentsMap.value);
 });
 
 function getScrollbarWidth(): number {

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -881,14 +881,17 @@ watch(
   { immediate: true },
 );
 
-attributeEmitter.on("selectedPath", (selectedPath) => {
-  if (selectedPath !== props.path) {
+attributeEmitter.on("selectedPath", ({ path }) => {
+  if (path !== props.path) {
     closeInput();
   }
 });
 
 const focus = () => {
-  attributeEmitter.emit("selectedPath", props.path);
+  attributeEmitter.emit("selectedPath", {
+    path: props.path,
+    name: props.displayName,
+  });
   attributeEmitter.emit("selectedDocs", {
     link: props.prop?.docLink ?? "",
     docs: props.prop?.documentation ?? "",
@@ -947,6 +950,7 @@ const createSubscriptionMutation = useMutation({
             {
               componentName: selectedConnectionData.value.componentName,
               path: selectedConnectionData.value.propPath,
+              isSecret: false,
             },
           ];
           updatedFound.attributeValue.value = `subscribing to ${selectedConnectionData.value.propPath}`;

--- a/app/web/src/newhotness/logic_composables/attribute_tree.ts
+++ b/app/web/src/newhotness/logic_composables/attribute_tree.ts
@@ -98,6 +98,22 @@ export const arrayAttrTreeIntoTree = (
   return matchesAsTree;
 };
 
+export const cleanForBulk = (t: AttrTree): AttrTree => {
+  // clear out the AVs and externalSources
+  // because we don't want them showing up in the form
+  const m = {
+    ...t,
+    attributeValue: {
+      ...t.attributeValue,
+      value: null,
+      externalSources: undefined,
+    },
+    children: t.children.map((_t) => cleanForBulk(_t)),
+  };
+  delete m.secret;
+  return m;
+};
+
 export type MakePayload = (
   path: AttributePath,
   value: string,

--- a/app/web/src/newhotness/logic_composables/emitters.ts
+++ b/app/web/src/newhotness/logic_composables/emitters.ts
@@ -44,7 +44,7 @@ export const startKeyEmitter = (document: Document) => {
 };
 
 type AttributeDetails = {
-  selectedPath: string;
+  selectedPath: { path: string; name: string };
   selectedDocs: { docs: string; link: string } | null;
 };
 

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -384,6 +384,7 @@ export interface AttributeValue {
 export interface ExternalSource {
   path: string;
   componentName: string;
+  isSecret: boolean;
 }
 
 export interface AVTree {

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -143,6 +143,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
                 let source = ExternalSource {
                     path: sub.path.to_string(),
                     component_name: comp_name,
+                    is_secret: sub.path.to_string().starts_with("/secrets/"),
                 };
                 sources.push(source);
             }

--- a/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
@@ -54,6 +54,7 @@ pub struct ValidationOutput {
 pub struct ExternalSource {
     pub component_name: String,
     pub path: String,
+    pub is_secret: bool,
 }
 
 #[derive(


### PR DESCRIPTION
## How does this PR change the system?

- match figma designs
- if you start on HEAD, hitting bulk makes a new change set
- ensure each panel scrolls with contents correctly
- click checkboxes on the left and the component leaves and paths re-render
- hover values on the right, see which components have that value
- add `isSecret` to `ExternalSources` in the MV

#### Out of Scope:

- I don't yet have the "history" concept yet. But that is next! 
- Error reporting is still in toasts, need to move that.

#### Future:
we have a lot of copy & re-used styles and stacks of components... we can really make this nicer to work with