### PR TITLE
fix(dal): give mgmt func state transitions a fresh connection state

### DIFF
--- a/lib/dal-test/src/helpers/component.rs
+++ b/lib/dal-test/src/helpers/component.rs
@@ -55,6 +55,23 @@ pub async fn create(
     )
 }
 
+/// Find a management prototype by the prototype name (NOT THE FUNC NAME)
+pub async fn find_management_prototype(
+    ctx: &DalContext,
+    component_id: ComponentId,
+    prototype_name: &str,
+) -> Result<ManagementPrototype> {
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
+
+    let management_prototype = ManagementPrototype::list_for_variant_id(ctx, schema_variant_id)
+        .await?
+        .into_iter()
+        .find(|proto| proto.name() == prototype_name)
+        .expect("could not find prototype");
+
+    Ok(management_prototype)
+}
+
 /// Execute a the management function and apply the result to the component
 pub async fn execute_management_func(
     ctx: &DalContext,

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -940,6 +940,16 @@ impl DalContext {
         Ok(())
     }
 
+    /// Start with a new connection state in this context, with new pg pool and
+    /// nats connections, and an empty job queue.
+    pub async fn restart_connections(&mut self) -> TransactionsResult<()> {
+        self.conns_state = Arc::new(Mutex::new(ConnectionState::new_from_conns(
+            self.services_context().connections().await?,
+        )));
+
+        Ok(())
+    }
+
     /// Rolls all inner transactions back, discarding all changes made within them.
     ///
     /// This is equivalent to the transaction's `Drop` implementations, but provides any error


### PR DESCRIPTION
By providing the management func state transitions with a fresh connection state, they should have an empty job queue, without impacting the "parent" context.

Without this change, when we would update the func state, we were also dispatching (in this case) validation jobs, but as we hadn't actually rebased the work resulting from the management operations, the validation job had the old value still. 

Also added an integration test for this scenario. 