### PR TITLE
Restore luminork API tests with 53 error code

### DIFF
--- a/.github/workflows/run-api-test.yml
+++ b/.github/workflows/run-api-test.yml
@@ -144,50 +144,59 @@ jobs:
           name: ${{ matrix.tests.name }}
           path: artifacts/${{ matrix.tests.name }}
 
-  # luminork-api-test:
-  #   name: API Test Luminork
-  #   environment: ${{ inputs.environment }}
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     LUMINORK_API_URL: ${{ vars.LUMINORK_API_URL }}
-  #     LUMINORK_WORKSPACE_ID: ${{ vars.LUMINORK_WORKSPACE_ID }}
-  #     LUMINORK_AUTH_TOKEN: ${{ secrets.LUMINORK_AUTH_TOKEN }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  luminork-api-test:
+    name: API Test Luminork
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    env:
+      LUMINORK_API_URL: ${{ vars.LUMINORK_API_URL }}
+      LUMINORK_WORKSPACE_ID: ${{ vars.LUMINORK_WORKSPACE_ID }}
+      LUMINORK_AUTH_TOKEN: ${{ secrets.LUMINORK_AUTH_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Install Deno
-  #       uses: denoland/setup-deno@v2
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
 
-  #     - name: Run the deno exec with retry
-  #       run: |
-  #         cd bin/si-luminork-api-tests
-  #         ./scripts/run-tests.sh || exit_code=$?
+      - name: Run the deno exec with retry
+        run: |
+          cd bin/si-luminork-api-tests
+          ./scripts/run-tests.sh || exit_code=$?
 
-  #         # Check the exit code
-  #         if [ -z "$exit_code" ]; then
-  #           echo "Deno task succeeded [ or the orchestration failed for a totally non-valid reason ]!"
-  #           exit 0
-  #         else
-  #           echo "Luminork API tests failed"
-  #           cd ../..
-  #           mkdir -p artifacts/luminork_tests
-  #           echo "failure-marker" > artifacts/luminork_tests/failure-marker
-  #           exit "$exit_code"
-  #         fi
+          # Check the exit code
+          if [ -z "$exit_code" ]; then
+            echo "Deno task succeeded [ or the orchestration failed for a totally non-valid reason ]!"
+            exit 0
+          else
+            echo "Luminork API tests failed"
+            cd ../..
+            mkdir -p artifacts/luminork_tests
+            echo "failure-marker" > artifacts/luminork_tests/failure-marker
+            exit "$exit_code"
+          fi
 
-  #     - name: Upload artifacts
-  #       if: failure()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: luminork_tests
-  #         path: artifacts/luminork_tests
+      - name: Upload artifact if exit code 53
+        if: failure()
+        run: |
+          if [ "${{ env.last_exit_code }}" == "53" ]; then
+            echo "Uploading marker for test luminork_tests"
+            mkdir -p artifacts/luminork_tests
+            echo "failure-marker" > artifacts/luminork_tests/failure-marker
+          fi
+
+      - name: Upload artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: luminork_tests
+          path: artifacts/luminork_tests
 
   on-failure:
     runs-on: ubuntu-latest
     needs:
       - api-test
-      # - luminork-api-test
+      - luminork-api-test
     environment: ${{ inputs.environment }}
     if: failure()
     steps:

--- a/bin/si-luminork-api-tests/run-tests.ts
+++ b/bin/si-luminork-api-tests/run-tests.ts
@@ -2,7 +2,7 @@
 
 /**
  * Command-line script to run tests with parameters
- * 
+ *
  * Usage:
  *   deno run -A run-tests.ts --help
  *   deno run -A run-tests.ts --api-url=http://localhost:5380 --auth-token=YOUR_TOKEN --workspace-id=YOUR_WORKSPACE_ID
@@ -15,7 +15,7 @@ function printUsage() {
   console.log(`
 Luminork API Test Runner
 
-Usage: 
+Usage:
   deno run -A run-tests.ts [options]
 
 Options:
@@ -85,10 +85,10 @@ console.log(`Running test files matching: ${testFiles}`);
 // Run the tests
 const testProcess = Deno.run({
   cmd: [
-    "deno", 
-    "test", 
-    "--allow-env", 
-    "--allow-net", 
+    "deno",
+    "test",
+    "--allow-env",
+    "--allow-net",
     "--allow-read",
     testFiles
   ],
@@ -99,5 +99,6 @@ const testProcess = Deno.run({
 // Wait for the tests to complete
 const status = await testProcess.status();
 
-// Exit with the same status as the test process
-Deno.exit(status.code);
+// Use exit code "53" for test failures
+const exitCode = status.success ? 0 : 53;
+Deno.exit(exitCode);


### PR DESCRIPTION
This change restores the luminork API test suite, but ensures that we use the 53 error code the differentiate between actual test failures and transient ones.
