### PR TITLE
Bulk Edit History (and errors)

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -157,6 +157,7 @@ import {
   computed,
   onBeforeUnmount,
   onMounted,
+  provide,
   reactive,
   ref,
   watch,
@@ -201,6 +202,9 @@ import {
   makeSavePayload,
 } from "./logic_composables/attribute_tree";
 import AttributeChildLayout from "./layout_components/AttributeChildLayout.vue";
+import { AttributeInputContext } from "./types";
+
+provide<AttributeInputContext>("ATTRIBUTEINPUT", { blankInput: false });
 
 const q = ref("");
 

--- a/app/web/src/newhotness/ResourceValuesPanel.vue
+++ b/app/web/src/newhotness/ResourceValuesPanel.vue
@@ -56,6 +56,7 @@ import {
   computed,
   onBeforeUnmount,
   onMounted,
+  provide,
   reactive,
   ref,
   watch,
@@ -73,6 +74,7 @@ import ComponentAttribute from "./layout_components/ComponentAttribute.vue";
 import { keyEmitter } from "./logic_composables/emitters";
 import { AttrTree, makeAvTree } from "./logic_composables/attribute_tree";
 import EmptyState from "./EmptyState.vue";
+import { AttributeInputContext } from "./types";
 
 const q = ref("");
 
@@ -80,6 +82,8 @@ const props = defineProps<{
   component?: BifrostComponent;
   attributeTree?: AttributeTree;
 }>();
+
+provide<AttributeInputContext>("ATTRIBUTEINPUT", { blankInput: false });
 
 // TODO(nick): move the root computation to a shared location since this is a copy from "AttributePanel".
 const root = computed<AttrTree>(() => {

--- a/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
+++ b/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
@@ -22,7 +22,7 @@
       />
       <div class="flex-none text-sm">Edit selected components</div>
     </div>
-    <div class="grow min-h-0 flex flex-row gap-xs mt-xs items-stretch">
+    <div :class="clsx('grow min-h-0 flex flex-row gap-xs mt-xs items-stretch')">
       <ul
         :class="
           clsx(
@@ -30,6 +30,10 @@
             'scrollable min-h-0',
             'w-1/4 flex-none flex flex-col gap-xs border p-sm',
             themeClasses('border-neutral-300', 'border-neutral-600'),
+            themeClasses(
+              'bg-shade-0 border-neutral-400',
+              'bg-neutral-800 border-neutral-600',
+            ),
           )
         "
       >
@@ -90,6 +94,10 @@
               'border overflow-hidden mb-[-1px]', // basis-0 makes items take equal size when multiple are open
               '[&>dl]:m-xs', // pad the child attributes
               themeClasses('border-neutral-300', 'border-neutral-600'),
+              themeClasses(
+                'bg-shade-0 border-neutral-400',
+                'bg-neutral-800 border-neutral-600',
+              ),
             )
           "
         >
@@ -142,6 +150,10 @@
             'scrollable min-h-0',
             'w-1/5 flex-none flex flex-col gap-xs scrollable border',
             themeClasses('border-neutral-300', 'border-neutral-600'),
+            themeClasses(
+              'bg-shade-0 border-neutral-400',
+              'bg-neutral-800 border-neutral-600',
+            ),
           )
         "
       >
@@ -159,86 +171,43 @@
             {{ selectedPathName }} values
           </template>
         </h3>
-        <div
-          v-if="pathValueData"
-          class="m-sm flex flex-row items-center gap-xs"
-        >
-          <template
-            v-for="[valueKey, desc] in Object.entries(pathValueData)"
-            :key="valueKey"
-          >
-            <AttributeValueBox>
-              <template #components>
-                <ul>
-                  <li
-                    v-for="component in desc.components"
-                    :key="component.componentName"
-                    :class="
-                      clsx(
-                        'ml-xs',
-                        'flex flex-row items-center gap-xs [&>*]:text-sm [&>*]:font-bold',
-                        themeClasses(
-                          '[&>*]:border-neutral-400',
-                          '[&>*]:border-neutral-600',
-                        ),
-                      )
-                    "
-                  >
-                    <TextPill
-                      mono
-                      :class="
-                        clsx(
-                          'min-w-0',
-                          themeClasses(
-                            'text-green-light-mode',
-                            'text-green-dark-mode',
-                          ),
-                        )
-                      "
-                    >
-                      <TruncateWithTooltip>
-                        {{ component.schemaName }}
-                      </TruncateWithTooltip>
-                    </TextPill>
-                    <TextPill mono class="text-purple min-w-0">
-                      <TruncateWithTooltip>
-                        {{ component.componentName }}
-                      </TruncateWithTooltip>
-                    </TextPill>
-                  </li>
-                </ul>
-              </template>
-              <div
-                :class="
-                  clsx(
-                    'max-w-full flex flex-row items-center [&>*]:min-w-0 [&>*]:flex-1 [&>*]:max-w-fit',
-                    'p-2xs text-sm font-bold',
-                    desc.isSecret &&
-                      themeClasses(
-                        'text-green-light-mode',
-                        'text-green-dark-mode',
-                      ),
-                  )
-                "
-              >
-                <TruncateWithTooltip class="text-purple">{{
-                  valueKey.split("|")[0]
-                }}</TruncateWithTooltip>
-                <div class="flex-none">/</div>
-                <TruncateWithTooltip
-                  :class="themeClasses('text-neutral-600', 'text-neutral-400')"
-                >
-                  <template
-                    v-if="!desc.isSecret && valueKey.split('|')[2] !== 'null'"
-                  >
-                    {{ valueKey.split("|")[2] }}
-                  </template>
-                  <template v-else>
-                    &lt; {{ valueKey.split("|")[1]?.replace(/^\//, "") }} &gt;
-                  </template>
-                </TruncateWithTooltip>
-              </div>
-            </AttributeValueBox>
+        <div class="m-sm flex flex-col gap-xs">
+          <template v-if="historyValueData">
+            <template
+              v-for="[valueKey, desc] in Object.entries(historyValueData)"
+              :key="valueKey"
+            >
+              <AttributeValueBox>
+                <template #components>
+                  <AttrComponentList :components="desc.components" />
+                </template>
+                <AttrValue
+                  strikeout
+                  :isSecret="desc.isSecret"
+                  :path="valueKey.split('|')[1]?.replace(/^\//, '')"
+                  :value="valueKey.split('|')[2]"
+                  :componentName="valueKey.split('|')[0]"
+                />
+              </AttributeValueBox>
+            </template>
+          </template>
+          <template v-if="pathValueData">
+            <template
+              v-for="[valueKey, desc] in Object.entries(pathValueData)"
+              :key="valueKey"
+            >
+              <AttributeValueBox>
+                <template #components>
+                  <AttrComponentList :components="desc.components" />
+                </template>
+                <AttrValue
+                  :isSecret="desc.isSecret"
+                  :path="valueKey.split('|')[1]?.replace(/^\//, '')"
+                  :value="valueKey.split('|')[2]"
+                  :componentName="valueKey.split('|')[0]"
+                />
+              </AttributeValueBox>
+            </template>
           </template>
         </div>
       </div>
@@ -249,7 +218,15 @@
 <script lang="ts" setup>
 import clsx from "clsx";
 import { useQueries } from "@tanstack/vue-query";
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  reactive,
+  ref,
+  watch,
+} from "vue";
 import {
   themeClasses,
   IconButton,
@@ -272,7 +249,8 @@ import ComponentAttribute, {
   NewChildValue,
 } from "@/newhotness/layout_components/ComponentAttribute.vue";
 import ComponentSecretAttribute from "@/newhotness/layout_components/ComponentSecretAttribute.vue";
-import AttributeValueBox from "@/newhotness/AttributeValueBox.vue";
+import AttrValue from "@/newhotness/layout_components/AttrValue.vue";
+import AttributeValueBox from "@/newhotness/layout_components/AttributeValueBox.vue";
 import AttributeChildLayout from "@/newhotness/layout_components/AttributeChildLayout.vue";
 import DelayedLoader from "@/newhotness/layout_components/DelayedLoader.vue";
 import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
@@ -280,13 +258,14 @@ import { PropKind } from "@/api/sdf/dal/prop";
 import {
   arrayAttrTreeIntoTree,
   AttrTree,
-  cleanForBulk,
   makeAvTree,
   makeSavePayload,
 } from "../logic_composables/attribute_tree";
 import { componentTypes, ok, routes, UseApi, useApi } from "../api_composables";
 import { useContext } from "../logic_composables/context";
 import MinimizedComponentQualificationStatus from "../MinimizedComponentQualificationStatus.vue";
+import AttrComponentList from "../layout_components/AttrComponentList.vue";
+import { AttributeInputContext } from "../types";
 
 const ctx = useContext();
 
@@ -332,6 +311,8 @@ type Trees = Array<{
   root: AttrTree | undefined;
   domain: AttrTree | undefined;
   secrets: AttrTree | undefined;
+  componentName: string;
+  schemaName: string;
 }>;
 const trees = computed<Trees>(() => {
   return avTrees.value
@@ -349,10 +330,86 @@ const trees = computed<Trees>(() => {
       const tree = makeAvTree(t, rootId, false);
       const domain = tree.children.find((c) => c.prop?.name === "domain");
       const secrets = tree.children.find((c) => c.prop?.name === "secrets");
-      return { domain, secrets, root: tree };
+      return {
+        domain,
+        secrets,
+        root: tree,
+        componentName: t.componentName,
+        schemaName: t.schemaName,
+      };
     })
     .filter(nonNullable);
 });
+
+const history = reactive<Record<AttributePath, PathValueData>>(
+  {} as Record<AttributePath, PathValueData>,
+);
+const showHistory = reactive<Record<AttributePath, boolean>>(
+  {} as Record<AttributePath, boolean>,
+);
+
+provide<AttributeInputContext>("ATTRIBUTEINPUT", { blankInput: true });
+
+const setHistory = (path: AttributePath) => {
+  showHistory[path] = true;
+  historyValueData.value = history[path];
+};
+
+// record history once we have the intitial set of trees.
+const onlyOnceStop = watch(
+  trees,
+  () => {
+    if (trees.value.length === 0) return;
+
+    const names = trees.value.reduce((obj, t) => {
+      if (!t.root) return obj;
+      obj[t.root.componentId] = {
+        componentName: t.componentName,
+        schemaName: t.schemaName,
+      };
+      return obj;
+    }, {} as Record<string, { componentName: string; schemaName: string }>);
+
+    const children = trees.value.flatMap((t) => {
+      const d = t.domain || { children: [] as AttrTree[] };
+      const s = t.secrets || { children: [] as AttrTree[] };
+      return [...d.children].concat([...s.children]);
+    });
+
+    while (children.length > 0) {
+      const child = children.shift();
+      if (!child) continue;
+
+      const av = child.attributeValue;
+      const source = (av.externalSources || [])[0];
+      const v =
+        typeof av.value === "object" ? JSON.stringify(av.value) : av.value;
+      const valKey: ValueKey = `${source?.componentName}|${source?.path}|${v}`;
+      let vals = history[av.path];
+      if (!vals) {
+        vals = {} as PathValueData;
+        history[av.path] = vals;
+      }
+      let data = vals[valKey];
+      if (!data) {
+        data = {
+          isSecret: !!av.secret,
+          components: [],
+        } as ComponentsWithValue;
+        vals[valKey] = data;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      data.components.push(names[child.componentId]!);
+
+      children.push(...child.children);
+    }
+
+    if (onlyOnceStop) {
+      onlyOnceStop();
+    }
+  },
+  { immediate: true },
+);
 
 // now filter them to the common AV paths present in all trees
 // the *actual* AVs will be from the very last component that has them
@@ -396,7 +453,7 @@ const commonTree = computed<{
     .map((path) => pathMap[path])
     .filter(nonNullable)
     .map((t) => {
-      return cleanForBulk(t);
+      return { ...t };
     });
   const map = matches.reduce((obj, attr) => {
     obj[attr.id] = attr;
@@ -485,6 +542,7 @@ const setKey = async (
 
   saving.value = calls.length;
   const resps = await Promise.all(calls);
+  setHistory(attributeTree.attributeValue.path);
   saving.value = 0;
   if (!resps.every((r) => ok(r.req))) {
     const errs = resps.map((r) => [r.req, r.req.status, r.req.request]);
@@ -519,6 +577,7 @@ const save = async (
   });
   saving.value = calls.length;
   const resps = await Promise.all(calls);
+  setHistory(path);
   saving.value = 0;
   if (!resps.every((r) => ok(r.req))) {
     const errs = resps.map((r) => [r.req, r.req.status, r.req.request]);
@@ -542,6 +601,7 @@ const removeSubscription = async (path: AttributePath) => {
 
   saving.value = calls.length;
   const resps = await Promise.all(calls);
+  setHistory(path);
   saving.value = 0;
   if (!resps.every((r) => ok(r.req))) {
     const errs = resps.map((r) => [r.req, r.req.status, r.req.request]);
@@ -559,6 +619,7 @@ const remove = async (path: AttributePath) => {
 
   saving.value = calls.length;
   const resps = await Promise.all(calls);
+  setHistory(path);
   saving.value = 0;
   if (!resps.every((r) => ok(r.req))) {
     const errs = resps.map((r) => [r.req, r.req.status, r.req.request]);
@@ -619,11 +680,24 @@ const valuesByAvPath = computed(() => {
 });
 
 const selectedPathName = ref<string>("");
+const selectedPathPath = ref<string>("");
 const pathValueData = ref<PathValueData | undefined>();
+const historyValueData = ref<PathValueData | undefined>();
+// find the path based data for display
 attributeEmitter.on("selectedPath", ({ path, name }) => {
   selectedPathName.value = name;
+  selectedPathPath.value = path;
   const vals = valuesByAvPath.value[path as AttributePath];
   pathValueData.value = vals;
+  if (showHistory[path as AttributePath])
+    historyValueData.value = history[path as AttributePath];
+});
+
+watch(valuesByAvPath, () => {
+  if (selectedPathPath.value) {
+    const vals = valuesByAvPath.value[selectedPathPath.value as AttributePath];
+    pathValueData.value = vals;
+  }
 });
 
 const emit = defineEmits<{

--- a/app/web/src/newhotness/layout_components/AttrComponentList.vue
+++ b/app/web/src/newhotness/layout_components/AttrComponentList.vue
@@ -1,0 +1,47 @@
+<template>
+  <ul>
+    <li
+      v-for="component in components"
+      :key="component.componentName"
+      :class="
+        clsx(
+          'ml-xs',
+          'flex flex-row items-center gap-xs [&>*]:text-sm [&>*]:font-bold',
+          themeClasses('[&>*]:border-neutral-400', '[&>*]:border-neutral-600'),
+        )
+      "
+    >
+      <TextPill
+        mono
+        :class="
+          clsx(
+            'min-w-0',
+            themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+          )
+        "
+      >
+        <TruncateWithTooltip>
+          {{ component.schemaName }}
+        </TruncateWithTooltip>
+      </TextPill>
+      <TextPill mono class="text-purple min-w-0">
+        <TruncateWithTooltip>
+          {{ component.componentName }}
+        </TruncateWithTooltip>
+      </TextPill>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import {
+  themeClasses,
+  TextPill,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
+import clsx from "clsx";
+
+defineProps<{
+  components: Array<{ componentName: string; schemaName: string }>;
+}>();
+</script>

--- a/app/web/src/newhotness/layout_components/AttrValue.vue
+++ b/app/web/src/newhotness/layout_components/AttrValue.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    :class="
+      clsx(
+        'max-w-full flex flex-row items-center [&>*]:min-w-0 [&>*]:flex-1 [&>*]:max-w-fit',
+        'p-2xs text-sm font-bold',
+        strikeout && 'line-through',
+        isSecret &&
+          themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+      )
+    "
+  >
+    <TruncateWithTooltip v-if="showComponentName" class="text-purple">
+      {{ componentName }}
+    </TruncateWithTooltip>
+    <div v-if="showComponentName" class="flex-none">/</div>
+    <TruncateWithTooltip
+      :class="themeClasses('text-neutral-600', 'text-neutral-400')"
+    >
+      <template v-if="!isSecret && value !== 'null'">
+        {{ value }}
+      </template>
+      <template v-else> &lt; {{ path }} &gt; </template>
+    </TruncateWithTooltip>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { themeClasses, TruncateWithTooltip } from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { computed } from "vue";
+
+const showComponentName = computed(() => props.componentName !== "undefined");
+
+const props = defineProps<{
+  isSecret: boolean;
+  componentName: string | undefined;
+  path: string | undefined;
+  value: string | undefined;
+  strikeout?: boolean;
+}>();
+</script>

--- a/app/web/src/newhotness/layout_components/AttributeValueBox.vue
+++ b/app/web/src/newhotness/layout_components/AttributeValueBox.vue
@@ -22,7 +22,7 @@
           'absolute z-[500] bottom-[-75px] left-[-17px] w-[300px]',
           themeClasses(
             'text-neutral-600 border-neutral-400 bg-neutral-100',
-            'text-neutral-400 border-neutral-600 bg-neutral-900',
+            'text-neutral-400 border-neutral-600 bg-neutral-800',
           ),
         )
       "

--- a/app/web/src/newhotness/logic_composables/attribute_tree.ts
+++ b/app/web/src/newhotness/logic_composables/attribute_tree.ts
@@ -98,22 +98,6 @@ export const arrayAttrTreeIntoTree = (
   return matchesAsTree;
 };
 
-export const cleanForBulk = (t: AttrTree): AttrTree => {
-  // clear out the AVs and externalSources
-  // because we don't want them showing up in the form
-  const m = {
-    ...t,
-    attributeValue: {
-      ...t.attributeValue,
-      value: null,
-      externalSources: undefined,
-    },
-    children: t.children.map((_t) => cleanForBulk(_t)),
-  };
-  delete m.secret;
-  return m;
-};
-
 export type MakePayload = (
   path: AttributePath,
   value: string,

--- a/app/web/src/newhotness/logic_composables/watched_form.ts
+++ b/app/web/src/newhotness/logic_composables/watched_form.ts
@@ -37,7 +37,7 @@ const tracer = trace.getTracer("si-vue");
  * So the user know their form submission worked and we're waiting
  * for updated data
  */
-export const useWatchedForm = <Data>(label: string) => {
+export const useWatchedForm = <Data>(label: string, resetBlank?: boolean) => {
   /**
    * Lifecycle of `bifrosting`
    *
@@ -103,7 +103,8 @@ export const useWatchedForm = <Data>(label: string) => {
         const markComplete = () => {
           bifrosting.value = false;
           rainbow.remove(ctx.changeSetId.value, label);
-          if (!wForm.state.canSubmit) wForm.reset(props.value);
+          if (!wForm.state.canSubmit)
+            wForm.reset(resetBlank ? undefined : props.value);
           if (span) {
             span.setAttribute("measured_time", Date.now() - start);
             span.end();
@@ -114,7 +115,7 @@ export const useWatchedForm = <Data>(label: string) => {
         try {
           await onSubmit(props);
           // Set the form data optimistically
-          wForm.reset(props.value);
+          wForm.reset(resetBlank ? undefined : props.value);
         } catch (e) {
           // TODO report errors and display on caller forms
           // Cancel the spinner and bifrosting on failure
@@ -136,9 +137,12 @@ export const useWatchedForm = <Data>(label: string) => {
     });
 
     // Update form data as data changes
+    // im not 100% certain we always want this behavior
     watch(
       () => toValue(data),
-      (newData) => wForm.reset(newData),
+      (newData) => {
+        wForm.reset(newData);
+      },
     );
 
     return wForm;

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -128,3 +128,8 @@ export interface ApprovalData {
   requirements: ChangeSetApprovalRequirement[];
   latestApprovals: ChangeSetApproval[];
 }
+
+// Bulk editing blanks inputs
+export interface AttributeInputContext {
+  blankInput: boolean;
+}


### PR DESCRIPTION
## How does this PR change the system?

I updated some styles to match figma better. And I created some layout components to help encapsulate & reuse things. Two main things, History, and Errors.

### History
In order to create the history, we're reading the AV trees *once*. It is in a watcher, because it comes through a query, so the data doesn't exist on mount. So we stop the watcher after the trees exist, and we process them. Then we never touch the history again. History represents the _initial_ values that you opened the bulk editing window with. It doesn't change as you save things.

In order to know when to display things, after each save, we note that the specific path we saved should now display history. We push the history value of the path into the placeholder variable the template references.

We watch the tree data (MV data) in order to update the placeholder variable for the current selected path value.

I made a big change to our approach that made sure all the input boxes in the form were blank / empty. Previously, I would strip the `av.value` and `av.externalSources` to be blank, so the form wouldn't have anything to display. That was a bad approach—it broke the watchedForm watcher that would reset the form (since the MV data would never get back to the component that it had in fact changed).

To resolve this I added a new context that is provided by `AttributePanel`, `AttributeBulkPanel`, and `ResourcesValuesPanel`, all the panels which have `AttributeInput` as a child/grandchild. That context only has one field that represents "do i want blank inputs". That value is used in several places.

### Errors
In the API composable interface for calling an endpoint now has one more return argument—the specific arguments that you provided to the API call. Why is this useful? Almost all of our endpoints identify the object being acted on via the URL path. So, if one of the calls error out, we can return with the error the arguments, and thus the object that had the error to identify in the UI however we need.

There is a handful of opt-in type magic. To start, the `EndpointArgs` was always just a `Record<string, string>` because in terms of the API layer, it doesn't care what the path arguments are in order to do a string replacement. However, if you're the caller, you expect whatever you gave it to make the calls, comes back out the other side in the response:
```
type ApiArgs = { id: ComponentId };

...

    const saveApi = useApi<ApiArgs>(ctx);
    const call = saveApi.endpoint<SuccessResp>(
      routes.UpdateComponentAttributes,
      { id: componentId },
    );

...

upsertError(resp.endpointArgs.id, path, err);
```
Without this typing, in the last line, `endpointArgs.id` would throw a type error b/c there is no guarantee that it exists in a `Record<string, string>`. So now you're adding error handling code to your error handling. Not exactly ideal 😅 

Aside: I'm _slightly_ annoying that I need to put the endpoint arguments on the `useApi` and not the `.endpoint()`, but I need to type the return values of `useApi` with the generic... so thats just gotta be how it is, such is life.

### Screenshot

<img width="1431" height="422" alt="image" src="https://github.com/user-attachments/assets/127809ba-156d-4c73-be0d-1a82622b411f" />


<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdldGtldjY1cGJob2Y4ZzdhOGJ3Z3FmaHU0dWZrbDNleDE5YWI0eXY1MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/pNX1ExVcPEqVoAXFIQ/giphy.gif"/>