### PR TITLE
feat(dal): default subs for arrays and type checking

### DIFF
--- a/lib/dal/src/attribute/attributes.rs
+++ b/lib/dal/src/attribute/attributes.rs
@@ -568,6 +568,10 @@ impl From<AttributeValueId> for AttributeValueIdent {
 }
 
 impl AttributeValueIdent {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
     pub fn path(&self) -> &str {
         &self.0
     }

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -66,6 +66,7 @@ use crate::{
     Prop,
     PropId,
     PropKind,
+    SchemaVariantError,
     Secret,
     SecretError,
     TransactionsError,
@@ -264,6 +265,8 @@ pub enum AttributeValueError {
     PropMoreThanOneChild(PropId),
     #[error("prop not found for attribute value: {0}")]
     PropNotFound(AttributeValueId),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("secret error: {0}")]
     Secret(#[from] Box<SecretError>),
     #[error("serde_json: {0}")]

--- a/lib/dal/src/component/new.rs
+++ b/lib/dal/src/component/new.rs
@@ -1,0 +1,405 @@
+use std::{
+    collections::{
+        BTreeMap,
+        VecDeque,
+    },
+    sync::Arc,
+};
+
+use si_events::{
+    ContentHash,
+    Timestamp,
+};
+use si_id::{
+    AttributeValueId,
+    SchemaVariantId,
+    ViewId,
+};
+use telemetry::prelude::*;
+
+use super::{
+    Component,
+    ComponentResult,
+};
+use crate::{
+    AttributeValue,
+    ComponentError,
+    DalContext,
+    EdgeWeightKind,
+    InputSocket,
+    OutputSocket,
+    Prop,
+    PropKind,
+    SchemaVariant,
+    action::{
+        Action,
+        prototype::ActionKind,
+    },
+    attribute::value::default_subscription::{
+        DefaultSubscription,
+        DefaultSubscriptionSource,
+        detect_possible_default_subscription_for_prop,
+    },
+    dependency_graph::DependencyGraph,
+    diagram::geometry::Geometry,
+    layer_db_types::{
+        ComponentContent,
+        ComponentContentV2,
+    },
+    validation::ValidationOutput,
+    workspace_snapshot::{
+        DependentValueRoot,
+        node_weight::{
+            NodeWeight,
+            category_node_weight::CategoryNodeKind,
+        },
+    },
+};
+
+#[derive(Debug, Clone)]
+enum PotentialSubscription {
+    Existing {
+        source_av_id: AttributeValueId,
+        dest_av_id: AttributeValueId,
+    },
+    ArrayElem {
+        source_av_id: AttributeValueId,
+        parent_av_id: AttributeValueId,
+    },
+}
+
+impl PotentialSubscription {
+    pub async fn subscribe(&self, ctx: &DalContext) -> ComponentResult<()> {
+        let (source_av_id, dest_av_id) = match self {
+            PotentialSubscription::Existing {
+                source_av_id,
+                dest_av_id,
+            } => (*source_av_id, *dest_av_id),
+            PotentialSubscription::ArrayElem {
+                source_av_id,
+                parent_av_id,
+            } => {
+                let dest_av_id = AttributeValue::insert(ctx, *parent_av_id, None, None).await?;
+                (*source_av_id, dest_av_id)
+            }
+        };
+
+        let default_sub = DefaultSubscription {
+            source_av_id,
+            dest_av_id,
+        };
+
+        default_sub.subscribe(ctx).await?;
+
+        Ok(())
+    }
+}
+
+impl Component {
+    pub async fn new_component_inner(
+        ctx: &DalContext,
+        name: impl Into<String>,
+        schema_variant_id: SchemaVariantId,
+        content_address: ContentHash,
+        default_sources: Option<&[DefaultSubscriptionSource]>,
+    ) -> ComponentResult<Self> {
+        let name: String = name.into();
+
+        let component_schema_name =
+            SchemaVariant::schema_for_schema_variant_id(ctx, schema_variant_id)
+                .await?
+                .name()
+                .to_owned();
+
+        let mut component_av_graph = DependencyGraph::new();
+
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        let id = workspace_snapshot.generate_ulid().await?;
+        let lineage_id = workspace_snapshot.generate_ulid().await?;
+
+        let node_weight = NodeWeight::new_component(id, lineage_id, content_address);
+
+        // Attach component to category and add use edge to schema variant
+        workspace_snapshot.add_or_replace_node(node_weight).await?;
+
+        // Root --> Component Category --> Component (this)
+        let component_category_id = workspace_snapshot
+            .get_category_node_or_err(CategoryNodeKind::Component)
+            .await?;
+        Self::add_category_edge(
+            ctx,
+            component_category_id,
+            id.into(),
+            EdgeWeightKind::new_use(),
+        )
+        .await?;
+
+        // Create attribute values for all socket corresponding to input and output sockets.
+        for input_socket_id in
+            InputSocket::list_ids_for_schema_variant(ctx, schema_variant_id).await?
+        {
+            let attribute_value =
+                AttributeValue::new(ctx, input_socket_id, Some(id.into()), None, None).await?;
+
+            DependentValueRoot::add_dependent_value_root(
+                ctx,
+                DependentValueRoot::Unfinished(attribute_value.id().into()),
+            )
+            .await?;
+        }
+        for output_socket_id in
+            OutputSocket::list_ids_for_schema_variant(ctx, schema_variant_id).await?
+        {
+            let attribute_value =
+                AttributeValue::new(ctx, output_socket_id, Some(id.into()), None, None).await?;
+
+            DependentValueRoot::add_dependent_value_root(
+                ctx,
+                DependentValueRoot::Unfinished(attribute_value.id().into()),
+            )
+            .await?;
+        }
+
+        // Walk all the props for the schema variant and create attribute values for all of them
+        let root_prop_id = SchemaVariant::get_root_prop_id(ctx, schema_variant_id).await?;
+        let mut work_queue = VecDeque::from([(root_prop_id, None::<AttributeValueId>, None)]);
+        let mut default_subscriptions = BTreeMap::new();
+
+        while let Some((prop_id, maybe_parent_attribute_value_id, key)) = work_queue.pop_front() {
+            // If we came in with a key, we're the child of a map. We should not descend deeper
+            // into it because the value should be governed by its prototype function and will
+            // create child values when that function is executed
+            let should_descend = key.is_none();
+
+            let prop_weight = workspace_snapshot
+                .get_node_weight(prop_id)
+                .await?
+                .get_prop_node_weight()?;
+
+            let prop_kind = prop_weight.kind();
+
+            // Create an attribute value for the prop.
+            let attribute_value = AttributeValue::new(
+                ctx,
+                prop_id,
+                Some(id.into()),
+                maybe_parent_attribute_value_id,
+                key.clone(),
+            )
+            .await?;
+
+            component_av_graph.add_id(attribute_value.id());
+            if let Some(parent_av_id) = maybe_parent_attribute_value_id {
+                component_av_graph.id_depends_on(parent_av_id, attribute_value.id());
+            }
+
+            if let Some(source_av_id) = detect_possible_default_subscription_for_prop(
+                ctx,
+                component_schema_name.clone(),
+                prop_id,
+                default_sources,
+            )
+            .await?
+            {
+                let dest_av_id = attribute_value.id();
+                default_subscriptions.insert(
+                    dest_av_id,
+                    PotentialSubscription::Existing {
+                        source_av_id,
+                        dest_av_id,
+                    },
+                );
+            }
+
+            if ValidationOutput::get_format_for_attribute_value_id(ctx, attribute_value.id())
+                .await?
+                .is_some()
+            {
+                ctx.enqueue_compute_validations(attribute_value.id())
+                    .await?;
+            }
+
+            match prop_kind {
+                PropKind::Object => {
+                    if should_descend {
+                        let ordered_children = workspace_snapshot
+                            .ordered_children_for_node(prop_id)
+                            .await?
+                            .ok_or(ComponentError::ObjectPropHasNoOrderingNode(prop_id))?;
+
+                        for child_prop_id in ordered_children {
+                            work_queue.push_back((
+                                child_prop_id.into(),
+                                Some(attribute_value.id()),
+                                None,
+                            ));
+                        }
+                    }
+                }
+                PropKind::Map => {
+                    let element_prop_id = Prop::direct_single_child_prop_id(ctx, prop_id).await?;
+
+                    if should_descend {
+                        for (key, _) in Prop::prototypes_by_key(ctx, element_prop_id).await? {
+                            if key.is_some() {
+                                work_queue.push_back((
+                                    element_prop_id,
+                                    Some(attribute_value.id()),
+                                    key,
+                                ))
+                            }
+                        }
+                    }
+                }
+                PropKind::Array => {
+                    let element_prop_id = Prop::direct_single_child_prop_id(ctx, prop_id).await?;
+
+                    if let Some(source_av_id) = detect_possible_default_subscription_for_prop(
+                        ctx,
+                        component_schema_name.clone(),
+                        element_prop_id,
+                        default_sources,
+                    )
+                    .await?
+                    {
+                        let parent_av_id = attribute_value.id();
+                        default_subscriptions.insert(
+                            parent_av_id,
+                            PotentialSubscription::ArrayElem {
+                                source_av_id,
+                                parent_av_id,
+                            },
+                        );
+                    }
+                }
+                // We want to only add leaves to the DVU roots
+                _ => {
+                    DependentValueRoot::add_dependent_value_root(
+                        ctx,
+                        DependentValueRoot::Unfinished(attribute_value.id().into()),
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        let (node_weight, content) = Self::get_node_weight_and_content(ctx, id.into()).await?;
+        let component = Self::assemble(&node_weight, content);
+
+        // Component (this) --> Schema Variant
+        Component::add_edge_to_schema_variant(
+            ctx,
+            component.id,
+            schema_variant_id,
+            EdgeWeightKind::new_use(),
+        )
+        .await?;
+
+        component.set_name(ctx, &name).await?;
+
+        //set a component specific prototype for the root/si/type as we don't want it to ever change other than manually
+        let sv_type = SchemaVariant::get_by_id(ctx, schema_variant_id)
+            .await?
+            .get_type(ctx)
+            .await?;
+        if let Some(sv_type) = sv_type {
+            component.set_type(ctx, sv_type).await?;
+        }
+
+        // Create all the default subscriptions discovered while creating the
+        // component attribute tree
+        for (dest_av_id, potential_sub) in &default_subscriptions {
+            // Use the dep graph to determine if a parent value of the
+            // destination attribute has a subscription or is set by a dynamic
+            // function
+            let all_parents_of = component_av_graph.all_parents_of(*dest_av_id);
+            let mut has_parent_with_sub_or_dynamic_func = false;
+            for parent_av_id in all_parents_of {
+                if default_subscriptions.contains_key(&parent_av_id) {
+                    has_parent_with_sub_or_dynamic_func = true;
+                    break;
+                }
+
+                if AttributeValue::is_set_by_dependent_function(ctx, parent_av_id).await? {
+                    has_parent_with_sub_or_dynamic_func = true;
+                    break;
+                }
+            }
+
+            if has_parent_with_sub_or_dynamic_func {
+                continue;
+            }
+
+            potential_sub.subscribe(ctx).await?;
+        }
+
+        // Find all create action prototypes for the variant and create actions for them.
+        for prototype_id in SchemaVariant::find_action_prototypes_by_kind(
+            ctx,
+            schema_variant_id,
+            ActionKind::Create,
+        )
+        .await?
+        {
+            Action::new(ctx, prototype_id, Some(component.id)).await?;
+        }
+
+        Ok(component)
+    }
+
+    /// Create new component node but retain existing content address
+    /// This is used to create the replacement nodes on upgrade, so geometries for it need
+    /// to be created by hand. Anywhere else you want to use [Self::new](Self::new)
+    pub async fn new_with_content_address_and_no_geometry_no_default_subscriptions(
+        ctx: &DalContext,
+        name: impl Into<String>,
+        schema_variant_id: SchemaVariantId,
+        content_address: ContentHash,
+    ) -> ComponentResult<Self> {
+        Self::new_component_inner(ctx, name, schema_variant_id, content_address, None).await
+    }
+
+    #[instrument(
+        name = "component.new",
+        level = "info",
+        skip_all,
+        fields(
+            schema_variant.id = ?schema_variant_id
+        ))]
+    pub async fn new(
+        ctx: &DalContext,
+        name: impl Into<String>,
+        schema_variant_id: SchemaVariantId,
+        view_id: ViewId,
+    ) -> ComponentResult<Self> {
+        let content = ComponentContentV2 {
+            timestamp: Timestamp::now(),
+        };
+
+        let (hash, _) = ctx.layer_db().cas().write(
+            Arc::new(ComponentContent::V2(content.clone()).into()),
+            None,
+            ctx.events_tenancy(),
+            ctx.events_actor(),
+        )?;
+
+        let sources = AttributeValue::get_default_subscription_sources(ctx).await?;
+        let component = Self::new_component_inner(
+            ctx,
+            name,
+            schema_variant_id,
+            hash,
+            if sources.is_empty() {
+                None
+            } else {
+                Some(sources.as_slice())
+            },
+        )
+        .await?;
+
+        // Create geometry node
+        Geometry::new_for_component(ctx, component.id, view_id).await?;
+
+        Ok(component)
+    }
+}

--- a/lib/dal/src/dependency_graph.rs
+++ b/lib/dal/src/dependency_graph.rs
@@ -1,5 +1,7 @@
 use std::collections::{
     HashMap,
+    HashSet,
+    VecDeque,
     hash_map::Entry,
 };
 
@@ -62,6 +64,30 @@ impl<T: Copy + std::cmp::Eq + std::cmp::PartialEq + std::hash::Hash> DependencyG
                 .filter_map(|edge_ref| self.graph.node_weight(edge_ref.target()).copied())
                 .collect(),
         }
+    }
+
+    pub fn all_parents_of(&self, id: T) -> Vec<T> {
+        let mut result = vec![];
+        let mut seen_list = HashSet::new();
+        let mut work_queue = VecDeque::from([id]);
+
+        while let Some(current_id) = work_queue.pop_front() {
+            if let Some(value_idx) = self.id_to_index_map.get(&current_id) {
+                for parent_id in self
+                    .graph
+                    .edges_directed(*value_idx, Incoming)
+                    .filter_map(|edge_ref| self.graph.node_weight(edge_ref.source()).copied())
+                {
+                    if !seen_list.contains(&parent_id) {
+                        result.push(parent_id);
+                        work_queue.push_back(parent_id);
+                        seen_list.insert(parent_id);
+                    }
+                }
+            }
+        }
+
+        result
     }
 
     pub fn direct_reverse_dependencies_of(&self, id: T) -> Vec<T> {

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -119,7 +119,6 @@ use crate::{
     prop::{
         PropError,
         PropPath,
-        ResolvedPropSuggestion,
     },
     schema::variant::{
         leaves::{
@@ -2531,38 +2530,6 @@ impl SchemaVariant {
     ) -> SchemaVariantResult<String> {
         let variant = Self::get_by_id(ctx, id).await?;
         Ok(variant.display_name.to_string())
-    }
-
-    pub async fn props_suggested_as_sources(
-        ctx: &DalContext,
-        id: SchemaVariantId,
-    ) -> SchemaVariantResult<Vec<ResolvedPropSuggestion>> {
-        let mut result = vec![];
-
-        let props = Self::all_props(ctx, id).await?;
-
-        for prop in props {
-            let suggested_as_sources_for = prop.suggested_as_source_for(ctx).await?;
-            result.extend(suggested_as_sources_for);
-        }
-
-        Ok(result)
-    }
-
-    pub async fn props_suggested_as_destinations(
-        ctx: &DalContext,
-        id: SchemaVariantId,
-    ) -> SchemaVariantResult<Vec<ResolvedPropSuggestion>> {
-        let mut result = vec![];
-
-        let props = Self::all_props(ctx, id).await?;
-
-        for prop in props {
-            let suggested_sources_for = prop.suggested_sources_for(ctx).await?;
-            result.extend(suggested_sources_for);
-        }
-
-        Ok(result)
     }
 }
 

--- a/lib/dal/tests/integration_test/attribute_value/subscription/default_subscriptions.rs
+++ b/lib/dal/tests/integration_test/attribute_value/subscription/default_subscriptions.rs
@@ -1,13 +1,22 @@
 use dal::{
     AttributeValue,
+    AttributeValueId,
     Component,
     DalContext,
+    Prop,
     SchemaVariantId,
-    attribute::value::default_subscription::{
-        DefaultSubscription,
-        calculate_all_prop_suggestions_for_change_set,
-        detect_possible_default_connections,
+    attribute::{
+        attributes::{
+            AttributeValueIdent,
+            Source,
+        },
+        value::default_subscription::{
+            DefaultSubscription,
+            detect_possible_default_connections,
+        },
     },
+    diagram::view::View,
+    prop::PropPath,
 };
 use dal_test::{
     Result,
@@ -21,9 +30,7 @@ use pretty_assertions_sorted::assert_eq;
 
 #[test]
 async fn test_set_as_default_subscription_source(ctx: &DalContext) -> Result<()> {
-    variants_with_prop_suggestions(ctx).await?;
-
-    let suggestions_for_change_set = calculate_all_prop_suggestions_for_change_set(ctx).await?;
+    let (_, _, default_dest_a_variant_id, _) = variants_with_prop_suggestions(ctx).await?;
 
     let source_component_a_id = component::create(ctx, "default_source_a", "default_source_a")
         .await
@@ -65,13 +72,15 @@ async fn test_set_as_default_subscription_source(ctx: &DalContext) -> Result<()>
         default_source_av_ids.push(av_id);
     }
 
-    let mut sources = AttributeValue::get_default_subscription_sources(ctx).await?;
+    let sources = AttributeValue::get_default_subscription_sources(ctx).await?;
 
-    sources.sort();
+    let mut sources_as_av_ids: Vec<AttributeValueId> =
+        sources.iter().map(|source| source.av_id).collect();
+    sources_as_av_ids.sort();
     default_source_av_ids.sort();
 
     assert_eq!(
-        default_source_av_ids, sources,
+        sources_as_av_ids, default_source_av_ids,
         "default source av ids should match"
     );
 
@@ -105,10 +114,9 @@ async fn test_set_as_default_subscription_source(ctx: &DalContext) -> Result<()>
         });
     }
 
-    let mut possible_defaults =
-        detect_possible_default_connections(ctx, dest_component_b_id, &suggestions_for_change_set)
-            .await
-            .expect("should be able to detect possible default connections");
+    let mut possible_defaults = detect_possible_default_connections(ctx, dest_component_b_id)
+        .await
+        .expect("should be able to detect possible default connections");
 
     possible_defaults.sort();
     expected_defaults.sort();
@@ -136,13 +144,204 @@ async fn test_set_as_default_subscription_source(ctx: &DalContext) -> Result<()>
         .await
         .expect("should be able to set as default subscription source");
 
-    let possible_defaults_two =
-        detect_possible_default_connections(ctx, dest_component_b_id, &suggestions_for_change_set)
-            .await
-            .expect("should be able to detect possible default connections");
+    let possible_defaults_two = detect_possible_default_connections(ctx, dest_component_b_id)
+        .await
+        .expect("should be able to detect possible default connections");
 
     // one of the suggestions is now ambiguous since it could be either of the two source components
     assert_eq!(possible_defaults_two.len(), 2);
+
+    let source_object_a_av_id = Component::attribute_values_for_prop_by_id(
+        ctx,
+        source_component_a_id,
+        &["root", "domain", "source_object_a"],
+    )
+    .await
+    .expect("should be able to find avs for prop")
+    .pop()
+    .expect("should have a an av id");
+
+    AttributeValue::set_as_default_subscription_source(ctx, source_object_a_av_id)
+        .await
+        .expect("should be able to set as default subscription source");
+
+    let frank_drebin = Component::new(
+        ctx,
+        "frank drebin, jr.",
+        default_dest_a_variant_id,
+        View::get_id_for_default(ctx).await?,
+    )
+    .await?;
+
+    let sources = Component::sources(ctx, frank_drebin.id()).await?;
+    let expected_sources = vec![
+        (
+            AttributeValueIdent::new("/si/name"),
+            Source::Value("frank drebin, jr.".into()),
+        ),
+        (
+            AttributeValueIdent::new("/si/type"),
+            Source::Value("component".into()),
+        ),
+        (
+            AttributeValueIdent::new("/domain/dest_string"),
+            Source::Subscription {
+                component: source_component_a_id.into(),
+                path: "/domain/source_string".into(),
+                keep_existing_subscriptions: None,
+                func: None,
+            },
+        ),
+        (
+            AttributeValueIdent::new("/domain/dest_array_of_object_1/0"),
+            Source::Subscription {
+                component: source_component_a_id.into(),
+                path: "/domain/source_object_a".into(),
+                keep_existing_subscriptions: None,
+                func: None,
+            },
+        ),
+        (
+            AttributeValueIdent::new("/domain/dest_integer"),
+            Source::Subscription {
+                component: source_component_a_id.into(),
+                path: "/domain/source_integer".into(),
+                keep_existing_subscriptions: None,
+                func: None,
+            },
+        ),
+    ];
+
+    assert_eq!(expected_sources, sources);
+
+    Ok(())
+}
+
+#[test]
+async fn test_is_same_type_as(ctx: &DalContext) -> Result<()> {
+    variants_with_prop_suggestions(ctx).await?;
+
+    let default_source_a_id = variant::id(ctx, "default_source_a")
+        .await
+        .expect("should be able to find variant id");
+    let default_source_b_id = variant::id(ctx, "default_source_b")
+        .await
+        .expect("should be able to find variant id");
+
+    let source_object_a_from_a = Prop::find_prop_by_path(
+        ctx,
+        default_source_a_id,
+        &PropPath::new(["root", "domain", "source_object_a"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    let source_object_a_from_b = Prop::find_prop_by_path(
+        ctx,
+        default_source_b_id,
+        &PropPath::new(["root", "domain", "source_object_a"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    assert!(
+        source_object_a_from_a
+            .is_same_type_as(ctx, &source_object_a_from_b)
+            .await
+            .expect("should be able to compare types")
+    );
+
+    let source_object_b = Prop::find_prop_by_path(
+        ctx,
+        default_source_a_id,
+        &PropPath::new(["root", "domain", "source_object_b"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    assert_eq!(
+        false,
+        source_object_a_from_a
+            .is_same_type_as(ctx, &source_object_b)
+            .await
+            .expect("should be able to compare types"),
+    );
+    assert_eq!(
+        false,
+        source_object_a_from_b
+            .is_same_type_as(ctx, &source_object_b)
+            .await
+            .expect("should be able to compare types"),
+    );
+
+    let source_array_of_string = Prop::find_prop_by_path(
+        ctx,
+        default_source_a_id,
+        &PropPath::new(["root", "domain", "source_array_of_string"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    let source_array_of_integer = Prop::find_prop_by_path(
+        ctx,
+        default_source_a_id,
+        &PropPath::new(["root", "domain", "source_array_of_integer"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    assert_eq!(
+        false,
+        source_array_of_integer
+            .is_same_type_as(ctx, &source_array_of_string)
+            .await
+            .expect("should be able to compare types"),
+    );
+    assert_eq!(
+        false,
+        source_array_of_string
+            .is_same_type_as(ctx, &source_array_of_integer)
+            .await
+            .expect("should be able to compare types"),
+    );
+
+    let source_array_of_object_1_from_a = Prop::find_prop_by_path(
+        ctx,
+        default_source_a_id,
+        &PropPath::new(["root", "domain", "source_array_of_object_1"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    let source_array_of_object_2 = Prop::find_prop_by_path(
+        ctx,
+        default_source_a_id,
+        &PropPath::new(["root", "domain", "source_array_of_object_2"]),
+    )
+    .await
+    .expect("should be able to find prop");
+    let source_array_of_object_1_from_b = Prop::find_prop_by_path(
+        ctx,
+        default_source_b_id,
+        &PropPath::new(["root", "domain", "source_array_of_object_1"]),
+    )
+    .await
+    .expect("should be able to find prop");
+
+    assert!(
+        source_array_of_object_1_from_a
+            .is_same_type_as(ctx, &source_array_of_object_1_from_b)
+            .await
+            .expect("should be able to compare types"),
+    );
+
+    assert_eq!(
+        false,
+        source_array_of_object_1_from_a
+            .is_same_type_as(ctx, &source_array_of_object_2)
+            .await
+            .expect("should be able to compare types"),
+    );
 
     Ok(())
 }
@@ -168,6 +367,125 @@ async fn variants_with_prop_suggestions(
                 suggestAsSourceFor: [
                     { schema: "default_destination_a", prop: "/domain/dest_boolean" },
                 ]
+            },
+            {
+                name: "source_object_a",
+                kind: "object",
+                children: [
+                    {
+                        name: "child_bool",
+                        kind: "boolean",
+                    },
+                    {
+                        name: "child_string",
+                        kind: "string",
+                    },
+                ],
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_object_a" },
+                ]
+            },
+            {
+                name: "source_object_b",
+                kind: "object",
+                children: [
+                    {
+                        name: "child_integer",
+                        kind: "integer",
+                    },
+                    {
+                        name: "child_string",
+                        kind: "string",
+                    },
+                ],
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_object_a" },
+                ]
+            },
+            {
+                name: "source_object_b",
+                kind: "object",
+                children: [
+                    {
+                        name: "child_integer",
+                        kind: "integer",
+                    },
+                    {
+                        name: "child_string",
+                        kind: "string",
+                    },
+                ],
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_object_a" },
+                ]
+            },
+            {
+                name: "source_array_of_string",
+                kind: "array",
+                entry: {
+                    name: "child_string",
+                    kind: "string",
+                },
+            },
+            {
+                name: "source_array_of_object_1",
+                kind: "array",
+                entry: {
+                    name: "child_object",
+                    kind: "object",
+                    children: [
+                        {
+                            name: "child_string",
+                            kind: "string",
+                        },
+                        {
+                            name: "child_integer",
+                            kind: "integer",
+                        },
+                    ],
+                },
+            },
+            {
+                name: "source_array_of_object_2",
+                kind: "array",
+                entry: {
+                    name: "child_object",
+                    kind: "object",
+                    children: [
+                        {
+                            name: "child_bool",
+                            kind: "boolean",
+                        },
+                        {
+                            name: "child_integer",
+                            kind: "integer",
+                        },
+                    ],
+                },
+            },
+            {
+                name: "source_array_of_integer",
+                kind: "array",
+                entry: {
+                    name: "child_integer",
+                    kind: "integer",
+                },
+            },
+            {
+                name: "source_map_of_string",
+                kind: "map",
+                entry: {
+                    name: "child_string",
+                    kind: "string",
+                },
+            },
+            {
+                name: "source_map_of_bool",
+                kind: "map",
+                entry: {
+                    name: "child_bool",
+                    kind: "boolean",
+                },
             },
             {
                 name: "source_string",
@@ -197,6 +515,41 @@ async fn variants_with_prop_suggestions(
         function main() {
         return {
             props: [
+            {
+                name: "source_object_a",
+                kind: "object",
+                children: [
+                    {
+                        name: "child_bool",
+                        kind: "boolean",
+                    },
+                    {
+                        name: "child_string",
+                        kind: "string",
+                    },
+                ],
+                suggestAsSourceFor: [
+                    { schema: "default_destination_a", prop: "/domain/dest_object_a" },
+                ]
+            },
+            {
+                name: "source_array_of_object_1",
+                kind: "array",
+                entry: {
+                    name: "child_object",
+                    kind: "object",
+                    children: [
+                        {
+                            name: "child_string",
+                            kind: "string",
+                        },
+                        {
+                            name: "child_integer",
+                            kind: "integer",
+                        },
+                    ],
+                },
+            },
             {
                 name: "source_bool",
                 kind: "boolean",
@@ -239,6 +592,44 @@ async fn variants_with_prop_suggestions(
                         { schema: "default_source_a", prop: "/domain/source_string" },
                         { schema: "default_source_b", prop: "/domain/source_string" },
                     ]
+                },
+                {
+                    name: "dest_object_a",
+                    kind: "object",
+                    children: [
+                        {
+                            name: "child_integer",
+                            kind: "integer",
+                        },
+                        {
+                            name: "child_string",
+                            kind: "string",
+                        },
+                    ],
+                    suggestSources: [
+                        { schema: "default_source_a", prop: "/domain/source_object_a" },
+                    ]
+                },
+                {
+                    name: "dest_array_of_object_1",
+                    kind: "array",
+                    entry: {
+                        name: "child_object",
+                        kind: "object",
+                        children: [
+                            {
+                                name: "child_bool",
+                                kind: "boolean",
+                            },
+                            {
+                                name: "child_string",
+                                kind: "string",
+                            },
+                        ],
+                        suggestSources: [
+                            { schema: "default_source_a", prop: "/domain/source_object_a" },
+                        ]
+                    }
                 },
                 {
                     name: "dest_integer",


### PR DESCRIPTION
Component::new will now create default subscriptions if a default subscription source is present that matches a prop suggestion for any prop in the component prop tree. No api routes create these default subscription sources yet, so no default subs will be created yet.

Default subs for maps do not currently make sense, since we need a way to specify the key for the value that has a default subscription.

