### PR TITLE
Helper to run API calls against change sets other than the one in your URL

### DIFF
--- a/app/web/src/components/ChangesetRenameModal.vue
+++ b/app/web/src/components/ChangesetRenameModal.vue
@@ -50,7 +50,12 @@ import {
   VButton,
   VormInput,
 } from "@si/vue-lib/design-system";
-import { routes, useApi } from "@/newhotness/api_composables";
+import {
+  apiContextForChangeSet,
+  routes,
+  useApi,
+} from "@/newhotness/api_composables";
+import { useContext } from "@/newhotness/logic_composables/context";
 
 const modal = ref<InstanceType<typeof Modal>>();
 const inputRef = ref<InstanceType<typeof VormInput>>();
@@ -60,7 +65,7 @@ const changesetName = ref("");
 const changesetIdRef = ref<string | undefined>();
 const apiErrorMessage = ref<string | undefined>();
 
-const renameChangesetApi = useApi();
+const ctx = useContext();
 
 const submit = async () => {
   if (
@@ -70,6 +75,8 @@ const submit = async () => {
   )
     return;
 
+  const apiCtx = apiContextForChangeSet(ctx, changesetIdRef.value);
+  const renameChangesetApi = useApi(apiCtx);
   const call = renameChangesetApi.endpoint(routes.ChangeSetRename, {
     changesetId: changesetIdRef.value,
   });

--- a/app/web/src/newhotness/nav/ApprovalPendingModalCard.vue
+++ b/app/web/src/newhotness/nav/ApprovalPendingModalCard.vue
@@ -60,11 +60,10 @@ import clsx from "clsx";
 import * as _ from "lodash-es";
 import { themeClasses, VButton, Timestamp } from "@si/vue-lib/design-system";
 import { useRoute, useRouter } from "vue-router";
-import { computed } from "vue";
 import { ChangeSet, ChangeSetId } from "@/api/sdf/dal/change_set";
 import { navigateToExistingChangeSet } from "../logic_composables/change_set";
 import { useContext } from "../logic_composables/context";
-import { useApi, routes } from "../api_composables";
+import { useApi, routes, apiContextForChangeSet } from "../api_composables";
 
 defineProps<{
   changeSet: ChangeSet;
@@ -81,20 +80,16 @@ const goToChangeSet = (id: ChangeSetId) => {
 const ctx = useContext();
 
 const rejectChangeSet = (id: ChangeSetId) => {
-  // TODO(nick): create or use a helper for using another ctx.
-  const newCtx = { ...ctx };
-  newCtx.changeSetId = computed(() => id);
-  const api = useApi(newCtx);
+  const apiCtx = apiContextForChangeSet(ctx, id);
+  const api = useApi(apiCtx);
 
   const call = api.endpoint(routes.ChangeSetApprove);
   call.post({ status: "Rejected" });
 };
 
 const approveChangeSet = (id: ChangeSetId) => {
-  // TODO(nick): create or use a helper for using another ctx.
-  const newCtx = { ...ctx };
-  newCtx.changeSetId = computed(() => id);
-  const api = useApi(newCtx);
+  const apiCtx = apiContextForChangeSet(ctx, id);
+  const api = useApi(apiCtx);
 
   const call = api.endpoint(routes.ChangeSetApprove);
   call.post({ status: "Approved" });

--- a/app/web/src/newhotness/nav/Notifications.vue
+++ b/app/web/src/newhotness/nav/Notifications.vue
@@ -46,7 +46,7 @@ import { ChangeSetId, ChangeSet } from "@/api/sdf/dal/change_set";
 import { ApprovalData, approverForChangeSet } from "@/store/change_sets.store";
 import ApprovalPendingModal from "./ApprovalPendingModal.vue";
 import { useContext } from "../logic_composables/context";
-import { useApi, routes } from "../api_composables";
+import { useApi, routes, apiContextForChangeSet } from "../api_composables";
 
 const props = defineProps<{
   changeSetsNeedingApproval: ChangeSet[];
@@ -69,10 +69,8 @@ const queries = computed(() =>
       // twice.
       queryKey: ["approvalstatusbychangesetid", changeSetId],
       queryFn: async () => {
-        // TODO(nick): create or use a helper for using another ctx.
-        const newCtx = { ...ctx };
-        newCtx.changeSetId = computed(() => changeSetId);
-        const api = useApi(newCtx);
+        const apiCtx = apiContextForChangeSet(ctx, changeSetId);
+        const api = useApi(apiCtx);
 
         const call = api.endpoint<ApprovalData>(routes.ChangeSetApprovalStatus);
         const response = await call.get();


### PR DESCRIPTION
## How does this PR change the system?

The API interface defaults to using the `changeSetId` from the `Context` which is based on the URL. But, there are a few times where thats not actually the change set you want to operate against! So lets add a helper to get you the data you want, and clean up the expected fields for the API context (since it doesn't need everything hanging on the `Context` object.

We can think of the `Context` like we think of the DAL Context.

## How was it tested?

1. have multiple change sets
2. go to HEAD
3. open change set dropdown
4. click to rename a changeset
5. submit the name change
6. see the URL match the chosen change set ID

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdldGozNjR4MGo3ZHBqaTRuMWVjd3IyM2JlaWh1ZzNucGg5cGZobmRqMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/MasCzjI4J603RKQWJq/giphy-downsized-medium.gif"/>