### PR TITLE
Update remove connection language to subscription

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -179,8 +179,8 @@
             "
             v-tooltip="
               props.isSecret
-                ? 'Remove connection to Secret'
-                : 'Remove connection'
+                ? 'Remove subscription to Secret'
+                : 'Remove subscription'
             "
             name="x"
             size="sm"


### PR DESCRIPTION
This is part of our ongoing efforts to replace "connection" with "subscription" in the product.
