### PR TITLE
BUG-933: close the context menu when opening the map

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -547,8 +547,10 @@ const storeViewMode = () => {
 
   if (groupRef.value.isB) {
     localStorage.setItem(key, "grid");
+    fixContextMenu();
   } else {
     localStorage.setItem(key, "map");
+    componentContextMenuRef.value?.close();
   }
 };
 


### PR DESCRIPTION
## How was it tested?
1. go to the explore page
2. select two components
3. see the context menu open
4. open the map page

bug: the context menu was above the map, blocking it
fix: context menu is gone

5. when you flip back to the grid, the context menu re-opens

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMmplbWJ5cjdrcWl1c3plbjFvaXdiMDN3YXk0OXpybDQwb2I3YnJ1dyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26Doihi0aDf7YKpZC/giphy-downsized-medium.gif"/>