### PR TITLE
fix(web): don't go to lobby on index updated

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -358,7 +358,7 @@ const lobbyExit: LobbyExitFn = async (
     });
   }
 
-  await niflheim(workspaceId, changeSetId, true);
+  await niflheim(workspaceId, changeSetId, true, false);
   muspelheimStatuses.value[changeSetId] = true;
 };
 


### PR DESCRIPTION
When we get an IndexUpdated message and call lobbyExit, niflheim could "fail" because the index requests could return 202, and kick us back into the lobby. Instead of going back to the lobby just let the next index updated message come through.