### PR TITLE
feat(luminork): Add duplicate components endpoint to luminork

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -63,6 +63,10 @@ pub use components::{
         CreateComponentV1Response,
     },
     delete_component::DeleteComponentV1Response,
+    duplicate_components::{
+        DuplicateComponentsV1Request,
+        DuplicateComponentsV1Response,
+    },
     execute_management_function::{
         ExecuteManagementFunctionV1Request,
         ExecuteManagementFunctionV1Response,
@@ -154,6 +158,7 @@ pub use crate::api_types::func_run::v1::{
         components::execute_management_function::execute_management_function,
         components::add_action::add_action,
         components::manage_component::manage_component,
+        components::duplicate_components::duplicate_components,
         schemas::list_schemas::list_schemas,
         schemas::find_schema::find_schema,
         schemas::get_schema::get_schema,
@@ -203,6 +208,8 @@ pub use crate::api_types::func_run::v1::{
             UpdateComponentV1Request,
             UpdateComponentV1Response,
             DeleteComponentV1Response,
+            DuplicateComponentsV1Request,
+            DuplicateComponentsV1Response,
             ExecuteManagementFunctionV1Request,
             ExecuteManagementFunctionV1Response,
             ComponentPropKey,

--- a/lib/luminork-server/src/service/v1/components/duplicate_components.rs
+++ b/lib/luminork-server/src/service/v1/components/duplicate_components.rs
@@ -1,0 +1,104 @@
+use axum::response::Json;
+use dal::{
+    Component,
+    ComponentId,
+    diagram::view::View,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use si_id::ViewId;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use crate::{
+    extract::{
+        PosthogEventTracker,
+        change_set::ChangeSetDalContext,
+    },
+    service::v1::ComponentsError,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/components/duplicate",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+    ),
+    tag = "components",
+    request_body = DuplicateComponentsV1Request,
+    summary = "Duplicate a list of components",
+    responses(
+        (status = 200, description = "Components duplicated successfully", body = DuplicateComponentsV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn duplicate_components(
+    ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    payload: Result<Json<DuplicateComponentsV1Request>, axum::extract::rejection::JsonRejection>,
+) -> Result<Json<DuplicateComponentsV1Response>, ComponentsError> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(ComponentsError::NotPermittedOnHead);
+    }
+
+    let prefix = payload.prefix.unwrap_or("copy of".to_string());
+
+    let view_id: ViewId;
+    if let Some(view_name) = payload.view_name {
+        if let Some(view) = View::find_by_name(ctx, view_name.as_str()).await? {
+            view_id = view.id();
+        } else {
+            let view = View::new(ctx, view_name.as_str()).await?;
+            view_id = view.id()
+        }
+    } else {
+        let default_view = View::get_id_for_default(ctx).await?;
+        view_id = default_view
+    };
+
+    let duplicated_components =
+        Component::duplicate(ctx, view_id, payload.components, &prefix).await?;
+
+    tracker.track(
+        ctx,
+        "api_duplicate_components",
+        json!({
+            "duplicated_components": duplicated_components.len(),
+            "prefix": prefix,
+            "view": view_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(DuplicateComponentsV1Response {
+        components: duplicated_components,
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DuplicateComponentsV1Request {
+    #[schema(value_type = Vec<Vec<String>>, example = json!(["01H9ZQD35JPMBGHH69BT0Q79AA", "01H9ZQD35JPMBGHH69BT0Q79BB", "01H9ZQD35JPMBGHH69BT0Q79CC"]))]
+    pub components: Vec<ComponentId>,
+    #[schema(example = "copy-of-", required = false)]
+    pub prefix: Option<String>,
+    #[schema(example = "MyView")]
+    pub view_name: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DuplicateComponentsV1Response {
+    #[schema(value_type = Vec<Vec<String>>, example = json!(["01H9ZQD35JPMBGHH69BT0Q79AA", "01H9ZQD35JPMBGHH69BT0Q79BB", "01H9ZQD35JPMBGHH69BT0Q79CC"]))]
+    pub components: Vec<ComponentId>,
+}

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -72,6 +72,7 @@ pub mod add_action;
 pub mod connections;
 pub mod create_component;
 pub mod delete_component;
+pub mod duplicate_components;
 pub mod execute_management_function;
 pub mod find_component;
 pub mod get_component;
@@ -775,6 +776,10 @@ pub fn routes() -> Router<AppState> {
         .route("/", get(list_components::list_components))
         .route("/find", get(find_component::find_component))
         .route("/search", post(search_components::search_components))
+        .route(
+            "/duplicate",
+            post(duplicate_components::duplicate_components),
+        )
         .nest(
             "/:component_id",
             Router::new()


### PR DESCRIPTION
you can use /componnets/duplicate and pass something like this:

```
{
  "components": [
    "01H9ZQD35JPMBGHH69BT0Q79AA",
    "01H9ZQD35JPMBGHH69BT0Q79BB",
    "01H9ZQD35JPMBGHH69BT0Q79CC"
  ],
  "prefix": "copy-of-",
  "viewName": "MyView"
}
```