### PR TITLE
Re-work grid dependencies

### DIFF
--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -622,11 +622,10 @@ const createTemplateStart = () => {
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-const anchor = ref<Object | undefined>(undefined);
+const anchor = ref<HTMLElement | object | undefined>(undefined);
 
 function open(
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  anchorTo: Object,
+  anchorTo: HTMLElement | object,
   componentsForMenu: ComponentInList[],
 ) {
   const oldAnchor = anchor.value;

--- a/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
+++ b/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
@@ -42,7 +42,9 @@
         </li>
         <!-- i took these styles and html nesting from connection panel, we should create a component that does this -->
         <li
-          v-for="[idx, component] in Object.entries(selectedComponents)"
+          v-for="[idx, component] in Object.entries(
+            exploreContext.selectedComponentsMap.value,
+          )"
           :key="component.id"
           :class="clsx('ml-xs', 'flex flex-col gap-2xs')"
         >
@@ -253,6 +255,7 @@ import clsx from "clsx";
 import { useQueries } from "@tanstack/vue-query";
 import {
   computed,
+  inject,
   onBeforeUnmount,
   onMounted,
   provide,
@@ -304,23 +307,28 @@ import {
 import { useContext } from "../logic_composables/context";
 import MinimizedComponentQualificationStatus from "../MinimizedComponentQualificationStatus.vue";
 import AttrComponentList from "../layout_components/AttrComponentList.vue";
-import { AttributeInputContext } from "../types";
+import {
+  assertIsDefined,
+  AttributeInputContext,
+  ExploreContext,
+} from "../types";
 
 const ctx = useContext();
-
-const props = defineProps<{
-  selectedComponents: Record<number, ComponentInList>;
-}>();
+const exploreContext = inject<ExploreContext>("EXPLORE_CONTEXT");
+assertIsDefined<ExploreContext>(exploreContext);
 
 const deselect = (index: number) => {
   emit("deselect", index);
 };
 
 const componentMap = computed(() =>
-  Object.values(props.selectedComponents).reduce((obj, component) => {
-    obj[component.id] = component;
-    return obj;
-  }, {} as Record<string, ComponentInList>),
+  Object.values(exploreContext.selectedComponentsMap.value).reduce(
+    (obj, component) => {
+      obj[component.id] = component;
+      return obj;
+    },
+    {} as Record<string, ComponentInList>,
+  ),
 );
 const componentIds = computed(() => Object.keys(componentMap.value));
 

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -1,12 +1,10 @@
 <template>
-  <!-- without ref=scrollRef (which i dont need here) the component breaks -->
-  <div v-if="bulkEditing" ref="scrollRef" class="grow min-h-0">
-    <AttributePanelBulk
-      :selectedComponents="selectedComponentsMap"
-      @close="() => $emit('bulkDone')"
-      @deselect="(idx) => $emit('childDeselect', idx)"
-    />
-  </div>
+  <!-- eslint-disable vue/no-multiple-template-root -->
+  <AttributePanelBulk
+    v-if="bulkEditing"
+    @close="() => $emit('bulkDone')"
+    @deselect="(idx) => $emit('childDeselect', idx)"
+  />
   <!--
     NOTE(nick,victor,wendy): we need both divs here for the virtualizer. The first div is the
     scrolling area itself (it will be whatever height fills the spot in the overall UI, which,
@@ -17,293 +15,60 @@
   -->
   <div
     v-else
-    ref="scrollRef"
-    class="scrollable grow"
-    style="overflow-anchor: none"
+    data-testid="tile-container"
+    class="w-full relative flex flex-col"
+    :style="{
+      ['overflow-anchor']: 'none',
+      height: `${virtualListHeight}px`,
+    }"
   >
-    <div
-      data-testid="tile-container"
-      class="w-full relative flex flex-col"
+    <ExploreGridRow
+      v-for="row in componentRowsVirtualItemsList"
+      :key="`${row.key}`"
+      data-testid="component-tile"
+      :data-index="row.index"
+      :class="clsx('absolute top-0 left-0 w-full')"
       :style="{
-        ['overflow-anchor']: 'none',
-        height: `${virtualListHeight}px`,
+        height: `${rowHeights[row.index]}px`,
+        transform: `translateY(${row.start}px)`,
       }"
-    >
-      <ExploreGridRow
-        v-for="row in componentRowsVirtualItemsList"
-        :key="`${row.key}`"
-        ref="exploreGridRowRefs"
-        data-testid="component-tile"
-        :data-index="row.index"
-        :class="clsx('absolute top-0 left-0 w-full')"
-        :style="{
-          height: `${rowHeights[row.index]}px`,
-          transform: `translateY(${row.start}px)`,
-        }"
-        :lanesCount="virtualizerLanes"
-        :row="gridRows[row.index]!"
-        :focusedComponentId="focusedComponent?.id"
-        :selectedComponentIndexes="selectedComponentIndexes"
-        :componentsWithFailedActions="componentsWithFailedActions"
-        :componentsWithRunningActions="componentsWithRunningActions"
-        :componentsPendingActionNames="componentsPendingActionNames"
-        @childClicked="(e, c, idx) => $emit('childClicked', e, c, idx)"
-        @childSelect="(idx) => $emit('childSelect', idx)"
-        @childDeselect="(idx) => $emit('childDeselect', idx)"
-        @childHover="(componentId) => $emit('childHover', componentId)"
-        @childUnhover="(componentId) => $emit('childUnhover', componentId)"
-        @clickCollapse="clickCollapse"
-        @unpin="(componentId) => $emit('unpin', componentId)"
-        @resetFilter="$emit('resetFilter')"
-      />
-    </div>
+      :row="gridRows[row.index]!"
+      @childClicked="(e, c, idx) => $emit('childClicked', e, c, idx)"
+      @childSelect="(idx) => $emit('childSelect', idx)"
+      @childDeselect="(idx) => $emit('childDeselect', idx)"
+      @childHover="(componentId) => $emit('childHover', componentId)"
+      @childUnhover="(componentId) => $emit('childUnhover', componentId)"
+      @clickCollapse="clickCollapse"
+      @unpin="(componentId) => $emit('unpin', componentId)"
+      @resetFilter="$emit('resetFilter')"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
 import clsx from "clsx";
-import { computed, ref, watch } from "vue";
+import { computed, inject, watch } from "vue";
 import * as _ from "lodash-es";
 import { useVirtualizer } from "@tanstack/vue-virtual";
-import { ComponentInList } from "@/workers/types/entity_kind_types";
 import { ComponentId } from "@/api/sdf/dal/component";
-import { windowWidthReactive } from "../logic_composables/emitters";
 import ExploreGridRow, { ExploreGridRowData } from "./ExploreGridRow.vue";
-import ComponentCard from "../ComponentCard.vue";
-import ExploreGridTile, { GRID_TILE_HEIGHT } from "./ExploreGridTile.vue";
+import { GRID_TILE_HEIGHT } from "./ExploreGridTile.vue";
 import AttributePanelBulk from "./AttributePanelBulk.vue";
+import { assertIsDefined, ExploreContext } from "../types";
+
+const exploreContext = inject<ExploreContext>("EXPLORE_CONTEXT");
+assertIsDefined<ExploreContext>(exploreContext);
 
 const props = defineProps<{
   bulkEditing: boolean;
-  components: Record<string, ComponentInList[]>;
-  focusedComponentIdx?: number;
-  selectedComponentIndexes: Set<number>;
-  componentsWithFailedActions: Set<ComponentId>;
-  componentsWithRunningActions: Set<ComponentId>;
-  componentsPendingActionNames: Map<
-    ComponentId,
-    Record<string, { count: number; hasFailed: boolean }>
-  >;
-  showFilteredCounter?: boolean;
-  filteredCount?: number;
-  totalCount?: number;
+  gridRows: ExploreGridRowData[];
+  scrollRef: HTMLDivElement | undefined;
 }>();
 
-const MIN_GRID_TILE_WIDTH = 250;
 const GRID_TILE_GAP = 16; // this is being used for both the X and Y gap
 
-const scrollRef = ref<HTMLDivElement>();
-const exploreGridRowRefs = ref<InstanceType<typeof ExploreGridRow>[]>();
-
-const exploreGridComponentRefs = computed(() => {
-  if (!exploreGridRowRefs.value) return [];
-
-  const componentRefs: InstanceType<
-    typeof ComponentCard | typeof ExploreGridTile
-  >[] = [];
-
-  for (const row of exploreGridRowRefs.value) {
-    if (!row.exploreGridComponentRefs) continue;
-
-    componentRefs.push(...row.exploreGridComponentRefs);
-  }
-
-  return componentRefs;
-});
-
-const allVisibleComponents = computed(() => {
-  // this excludes components which are inside collapsed groups
-  const components: ComponentInList[] = [];
-  for (const row of gridRows.value) {
-    if (row.type === "contentRow") {
-      components.push(...row.components);
-    }
-  }
-  return components;
-});
-
-const focusedComponent = computed(
-  () => allVisibleComponents.value[props.focusedComponentIdx ?? -1],
-);
-
-const selectedComponentsMap = computed(() => {
-  const selected: Record<number, ComponentInList> = {};
-
-  props.selectedComponentIndexes.forEach((index) => {
-    const component = allVisibleComponents.value[index];
-    if (component) {
-      selected[index] = component;
-    }
-  });
-
-  return selected;
-});
-const selectedComponents = computed(() => {
-  return Object.values(selectedComponentsMap.value);
-});
-
-function getScrollbarWidth(): number {
-  const temp = document.createElement("div");
-  const inner = document.createElement("div");
-
-  temp.style.visibility = "hidden";
-  temp.style.overflow = "scroll";
-  document.body.appendChild(temp);
-  temp.appendChild(inner);
-
-  const scrollbarWidth = temp.offsetWidth - inner.offsetWidth;
-  temp.parentNode?.removeChild(temp);
-
-  return scrollbarWidth;
-}
-
-const getGridComponentRefByIndex = (idx: number) => {
-  if (!exploreGridComponentRefs.value) return undefined;
-
-  return exploreGridComponentRefs.value.find(
-    (t) => Number(t.$el.dataset.index) === idx,
-  );
-};
-
-// The expected number of components in a row based on the width of the scroll area
-const virtualizerLanes = computed(() => {
-  // We need to force a recompute of this value when the screen is resized
-  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-  windowWidthReactive.value;
-
-  // We also need to force a recompute of this value if the number of tiles changes
-  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-  exploreGridComponentRefs.value;
-
-  // Our grid is based on the minimum tile width... so how many tiles can we fit?
-  let newLanes = 0;
-  let availableSpace = scrollRef.value?.getBoundingClientRect().width ?? 0;
-  if (
-    scrollRef.value &&
-    scrollRef.value.scrollHeight > scrollRef.value.clientHeight
-  ) {
-    // need to account for the width of the scrollbar!
-    availableSpace -= getScrollbarWidth();
-  }
-  while (availableSpace > 0) {
-    availableSpace -= MIN_GRID_TILE_WIDTH; // width of one grid tile
-    if (availableSpace > 0) {
-      newLanes++;
-    }
-    availableSpace -= GRID_TILE_GAP; // gap between grid tiles
-  }
-  return newLanes;
-});
-
-// This is how we show no headers when "group by" functionality is in use. This relies on the
-// fact that using "group by" will create at least two groups. If you find yourself working on
-// "group by", but only wanting to show one group, this is why you're not seeing any headers.
-const hasMultipleSections = computed(() => _.keys(props.components).length > 1);
-
-const gridRows = computed(() => {
-  const rows: ExploreGridRowData[] = [];
-  let dataIndex = 0;
-
-  for (const groupName in props.components) {
-    const components = props.components[groupName];
-    if (!components) continue;
-
-    // First, handle pinned components. They take up and entire row, so we can handle them upfront
-    // without having to worry about chunking. We'll add a footer for each one.
-    if (groupName === "Pinned") {
-      for (const component of components) {
-        rows.push({
-          type: "pinnedContentRow",
-          component,
-          dataIndex,
-        });
-        dataIndex += 1;
-        rows.push({
-          type: "footer",
-        });
-      }
-
-      // Move on after dealing with the pinned group.
-      continue;
-    }
-
-    const count = components.length;
-    let collapsed = collapseTracker.value[groupName];
-
-    // Handle the very first time everything is loaded. We want empty sections to begin collapsed
-    // and non-empty sections to be expanded by default. The "Unconnected" section should always
-    // start collapsed.
-    if (collapsed === undefined) {
-      collapsed = count === 0 || groupName === "Unconnected";
-    }
-
-    if (hasMultipleSections.value) {
-      rows.push({
-        type: "header",
-        title: groupName,
-        count,
-        collapsed,
-      });
-    }
-
-    // Only populate the component rows if the header is not collapsed. Note that this removes them
-    // from the virtualizer. We may eventually want to "hide" components instead to keep them
-    // virtualized (e.g. "zero height").
-    if (!collapsed) {
-      const componentChunks = _.chunk(components, virtualizerLanes.value);
-
-      if (componentChunks.length) {
-        for (const components of componentChunks) {
-          rows.push({
-            type: "contentRow",
-            components,
-            chunkInitialId: dataIndex,
-            insideSection: hasMultipleSections.value,
-          });
-
-          // We need to increase the current index by the length of the row for the next iteration.
-          dataIndex += components.length;
-        }
-      } else {
-        rows.push({
-          type: "emptyRow",
-          groupName,
-        });
-      }
-    }
-
-    // Whether or not we collapse the group, we need the footer.
-    if (hasMultipleSections.value) {
-      rows.push({
-        type: "footer",
-      });
-    }
-  }
-
-  // Remove the last footer when dealing with "group by" functionality.
-  if (hasMultipleSections.value) rows.pop();
-
-  // Add filtered counter row if needed
-  if (
-    props.showFilteredCounter &&
-    props.filteredCount !== undefined &&
-    props.totalCount !== undefined
-  ) {
-    const hiddenCount = props.totalCount - props.filteredCount;
-    if (hiddenCount > 0) {
-      rows.push({
-        type: "filteredCounterRow",
-        hiddenCount,
-      });
-    }
-  }
-
-  return rows;
-});
-
-const collapseTracker = ref<Record<string, boolean>>({});
 const clickCollapse = (title: string, collapsed: boolean) => {
-  collapseTracker.value[title] = collapsed;
+  emit("collapse", title, collapsed);
 };
 
 const componentRowsVirtualItemsList = computed(() =>
@@ -312,14 +77,17 @@ const componentRowsVirtualItemsList = computed(() =>
 
 // Rows need a unique item key, so the virtualizer internal watcher knows when to recompute sizes
 const getItemKey = (rowIndex: number) => {
-  const row = gridRows.value[rowIndex];
+  const row = props.gridRows[rowIndex];
   if (!row) return rowIndex;
 
   switch (row.type) {
     case "header":
       return `header-${row.title}`;
     case "contentRow":
-      if (!hasMultipleSections.value && rowIndex === gridRows.value.length - 1)
+      if (
+        !exploreContext.hasMultipleSections.value &&
+        rowIndex === props.gridRows.length - 1
+      )
         return `contentRow-final-${rowIndex}`;
       else return `contentRow-${rowIndex}`;
     case "emptyRow":
@@ -337,12 +105,15 @@ const GROUP_FOOTER_HEIGHT = 10;
 const GROUP_FILTERED_ROW_HEIGHT = 40;
 
 const rowHeights = computed(() => {
-  return gridRows.value.map((row, index) => {
+  return props.gridRows.map((row, index) => {
     switch (row.type) {
       case "header":
         return GROUP_HEADER_HEIGHT;
       case "contentRow":
-        if (!hasMultipleSections.value && index === gridRows.value.length - 1) {
+        if (
+          !exploreContext.hasMultipleSections.value &&
+          index === props.gridRows.length - 1
+        ) {
           return GRID_TILE_HEIGHT;
         } else {
           return GRID_TILE_HEIGHT + GRID_TILE_GAP;
@@ -360,13 +131,13 @@ const rowHeights = computed(() => {
 });
 
 const virtualizerOptions = computed(() => ({
-  count: gridRows.value.length,
+  count: props.gridRows.length,
   // `virtualizerLanes` gives virtualizer a "second-dimension" (aka columns for vertical lists and rows for horizontal lists)
   // https://tanstack.com/virtual/latest/docs/api/virtualizer#lanes
   // Our grid is based on the minimum tile width... so how many tiles can we fit?
   // thats the value of `virtualizerLanes`
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  getScrollElement: () => scrollRef.value!,
+  getScrollElement: () => props.scrollRef!,
   estimateSize: (i: number) => rowHeights.value[i] ?? 0,
   // The item key is essential for reactivity and was found by @vbustamante and his valiant
   // efforts. Without this, the virtualizer will not re-compute, even with new components.
@@ -385,8 +156,8 @@ const virtualListHeight = computed(() => virtualList.value.getTotalSize());
 const getRowIndexByGridTileIndex = (idx: number) => {
   let lastValidRowIndex = 0;
 
-  for (let rowIndex = 0; rowIndex < gridRows.value.length; rowIndex++) {
-    const row = gridRows.value[rowIndex];
+  for (let rowIndex = 0; rowIndex < props.gridRows.length; rowIndex++) {
+    const row = props.gridRows[rowIndex];
 
     if (row?.type === "contentRow") {
       if (row.chunkInitialId > idx) {
@@ -404,9 +175,10 @@ const getRowIndexByGridTileIndex = (idx: number) => {
 const scrollCurrentTileIntoView = () => {
   // don't scroll if the index is out of bounds
   if (
-    props.focusedComponentIdx === undefined ||
-    props.focusedComponentIdx < 0 ||
-    props.focusedComponentIdx > allVisibleComponents.value.length - 1
+    exploreContext.focusedComponentIdx.value === undefined ||
+    exploreContext.focusedComponentIdx.value < 0 ||
+    exploreContext.focusedComponentIdx.value >
+      exploreContext.allVisibleComponents.value.length - 1
   )
     return;
 
@@ -414,20 +186,21 @@ const scrollCurrentTileIntoView = () => {
   // so that even if the DOM element doesn't exist
   // it will still work!
   virtualList.value.scrollToIndex(
-    getRowIndexByGridTileIndex(props.focusedComponentIdx),
+    getRowIndexByGridTileIndex(exploreContext.focusedComponentIdx.value),
     { behavior: "smooth" },
   );
 };
 
-watch([() => props.focusedComponentIdx], scrollCurrentTileIntoView);
+watch([() => exploreContext.focusedComponentIdx], scrollCurrentTileIntoView);
 
-defineEmits<{
+const emit = defineEmits<{
   (e: "bulkDone"): void;
   (e: "unpin", componentId: ComponentId): void;
   (e: "childSelect", componentIdx: number): void;
   (e: "childDeselect", componentIdx: number): void;
   (e: "childHover", componentId: ComponentId): void;
   (e: "childUnhover", componentId: ComponentId): void;
+  (e: "collapse", title: string, collapsed: boolean): void;
   (e: "resetFilter"): void;
   (
     e: "childClicked",
@@ -436,13 +209,6 @@ defineEmits<{
     componentIdx: number,
   ): void;
 }>();
-
-defineExpose({
-  getGridComponentRefByIndex,
-  focusedComponent,
-  selectedComponents,
-  allVisibleComponents,
-});
 </script>
 
 <style lang="css" scoped>

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="gridTile"
     :class="
       clsx(
         'component tile',
@@ -222,7 +223,7 @@ import {
   TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { computed, inject } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import {
   ComponentInList,
   ComponentDiffStatus,
@@ -253,6 +254,8 @@ assertIsDefined<ExploreContext>(explore);
 const outgoing = computed(
   () => ctx.outgoingCounts.value[props.component.id] ?? 0,
 );
+
+const gridTile = ref<HTMLElement | undefined>();
 
 const canBeUpgraded = computed(() =>
   explore.upgradeableComponents.value.has(props.component.id),
@@ -333,6 +336,20 @@ const getPendingActionTooltip = (
     return `${count} pending ${actionWord} action${plural}`;
   }
 };
+
+watch(
+  () => [explore.focusedComponentIdx, gridTile],
+  () => {
+    if (
+      gridTile.value &&
+      gridTile.value.dataset.index ===
+        explore.focusedComponentIdx.value?.toString()
+    ) {
+      explore.focusedComponentRef.value = gridTile.value;
+    }
+  },
+  { immediate: true, deep: true },
+);
 
 const emit = defineEmits<{
   (e: "select"): void;

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -1,8 +1,9 @@
-import { ComputedRef, Ref } from "vue";
+import { ComputedRef, Reactive, Ref } from "vue";
 import { User } from "@/api/sdf/dal/user";
 import { ComponentId } from "@/api/sdf/dal/component";
 import {
   ComponentDetails,
+  ComponentInList,
   SchemaMembers,
 } from "@/workers/types/entity_kind_types";
 import { SchemaId } from "@/api/sdf/dal/schema";
@@ -64,10 +65,27 @@ export function assertIsDefined<T>(value: T | undefined): asserts value is T {
   }
 }
 
+export interface ComponentsHaveActionsWithState {
+  failed: Set<ComponentId>;
+  running: Set<ComponentId>;
+}
+
 export interface ExploreContext {
   viewId: ComputedRef<string>;
   upgradeableComponents: ComputedRef<Set<string>>;
   showSkeleton: ComputedRef<boolean>;
+  lanesCount: ComputedRef<number>;
+  focusedComponentIdx: Ref<number | undefined>;
+  selectedComponentsMap: ComputedRef<Record<number, ComponentInList>>;
+  focusedComponent: ComputedRef<ComponentInList | undefined>;
+  componentsHaveActionsWithState: ComputedRef<ComponentsHaveActionsWithState>;
+  selectedComponentIndexes: Reactive<Set<number>>;
+  componentsPendingActionNames: ComputedRef<
+    Map<ComponentId, Record<string, { count: number; hasFailed: boolean }>>
+  >;
+  allVisibleComponents: ComputedRef<ComponentInList[]>;
+  hasMultipleSections: ComputedRef<boolean>;
+  focusedComponentRef: Ref<HTMLElement | undefined>;
 }
 
 // Define an enum for function kinds

--- a/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenu.vue
@@ -140,7 +140,7 @@ interface SubmenuParent {
 const props = defineProps({
   // Set an anchorTo element if you want the DropdownMenu to be attached to a DOM element
   // If no anchorTo element is used, each open() event for this Dropdown will try to determine where to anchor based on the mouse position or event target
-  anchorTo: { type: Object }, // TODO: figure out right type to say "template ref / dom element"
+  anchorTo: { type: Object || HTMLElement },
 
   // You can add DropdownMenuItems via this prop or in a template
   items: {
@@ -297,7 +297,11 @@ function open(e?: MouseEvent, anchorToMouse?: boolean) {
 
   if (props.anchorTo) {
     // can anchor to a specific element via props
-    anchorEl.value = props.anchorTo.$el;
+    if (props.anchorTo instanceof HTMLElement) {
+      anchorEl.value = props.anchorTo;
+    } else {
+      anchorEl.value = props.anchorTo.$el;
+    }
   } else if (e && (anchorToMouse || !clickTargetIsElement)) {
     // or can anchor to mouse position if anchorToMouse is true (or event has not target)
     anchorEl.value = undefined;


### PR DESCRIPTION
## How does this PR change the system?

For [BUG-933](https://linear.app/system-initiative/issue/BUG-933/right-click-context-menu-bugs) leaving the bulk editing "mode" was causing the context modal to float at 0,0 because the template refs due to the show / hiding are getting lost. It seems the menu still has the _old_ template refs, which aren't in the DOM anymore, so the bounding box is all zeros (per spec).

The interdependent components (where `Explore` puts `ExploreGrid` into the Vue tree, but uses the `ExploreGrid` exposed functions in order for `Explore` to function correctly... became very trick because bulk editing _hides_ the `ExploreGrid`!

Unraveling the circular dependency and expanding the context object is a path to a resolution, both for the bug, and making this a bit easier to reason about.

## How was it tested?

Everything on the grid seems to work the same way it did before!
1. sort by
2. group by
3. searching
4. resizing
5. context menu selecting components
6. start bulk edit, close bulk edit, menu stays!

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZ2J4cGg2OXZneXRiNXZ2cThwMHlhNGd1OXJvMHBobWZwNHJ3a285bSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT3i1eoSQBxd8hcSE8/giphy.gif"/>