### PR TITLE
chore(ci): Adding a workflow dispatch to update clover assets

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # weekly
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   update-schemas:
@@ -29,6 +30,3 @@ jobs:
           commit-message: clover schema update
           title: "chore: clover schema update"
           body: "Update for clover schemas. Check the diff comment to understand what has changed."
-          add-paths: |
-              *
-              !deno.lock


### PR DESCRIPTION
Removing the deno.lock pathspec as it’s no longer reqiored