### PR TITLE
fix(web): webworker test fixes

### DIFF
--- a/app/web/src/workers/webworker.test.ts
+++ b/app/web/src/workers/webworker.test.ts
@@ -258,12 +258,12 @@ const fullDiagnosticTest = async (db: Comlink.Remote<TabDBInterface>) => {
     bind: ["HEAD"],
     returnValue: "resultRows",
   });
-  const count_old_head_snapshot_atoms = await db.oneInOne(confirm4);
+  const _count_old_head_snapshot_atoms = await db.oneInOne(confirm4);
   // one for each original atom
-  assert(
-    count_old_head_snapshot_atoms === 0,
-    `old head indexes ${String(count_old_head_snapshot_atoms)} === 0`,
-  );
+  // assert(
+  //   count_old_head_snapshot_atoms === 0,
+  //   `old head indexes ${String(count_old_head_snapshot_atoms)} === 0`,
+  // );
 
   const confirm5 = await db.exec({
     sql: `SELECT count(index_checksum) FROM index_mtm_atoms WHERE index_checksum != ?;`,
@@ -281,13 +281,13 @@ const fullDiagnosticTest = async (db: Comlink.Remote<TabDBInterface>) => {
     sql: `SELECT count(*) FROM atoms;`,
     returnValue: "resultRows",
   });
-  const count_atoms_one_more = await db.oneInOne(confirm6);
+  const _count_atoms_one_more = await db.oneInOne(confirm6);
   // the 4th atom that existed on the change set just moved to head
   // so the OG head atom was pruned off
-  assert(
-    count_atoms_one_more === 3,
-    `payload2 atoms ${String(count_atoms_one_more)} === 3`,
-  );
+  // assert(
+  //   count_atoms_one_more === 3,
+  //   `payload2 atoms ${String(count_atoms_one_more)} === 3`,
+  // );
 
   log("~~ SECOND PAYLOAD SUCCESS ~~");
 
@@ -315,31 +315,31 @@ const fullDiagnosticTest = async (db: Comlink.Remote<TabDBInterface>) => {
   const count_snapshots_after_purge = await db.oneInOne(confirm7);
   // 3 for HEAD
   assert(
-    count_snapshots_after_purge === 3,
+    count_snapshots_after_purge === 6,
     `remove new indexes ${String(count_snapshots_after_purge)} === 3`,
   );
 
-  const confirm8 = await db.exec({
+  const _confirm8 = await db.exec({
     sql: `SELECT count(*) FROM atoms;`,
     returnValue: "resultRows",
   });
-  const count_atoms_after_purge = await db.oneInOne(confirm8);
-  // still 3 atoms, haven't gained or lost anything
-  assert(
-    count_atoms_after_purge === 3,
-    `purge atoms ${String(count_atoms_after_purge)} === 3`,
-  );
+  // const count_atoms_after_purge = await db.oneInOne(confirm8);
+  // // still 3 atoms, haven't gained or lost anything
+  // assert(
+  //   count_atoms_after_purge === 3,
+  //   `purge atoms ${String(count_atoms_after_purge)} === 3`,
+  // );
 
-  const count_after_purge = await db.exec({
+  const _count_after_purge = await db.exec({
     sql: `SELECT COUNT(index_checksum) FROM index_mtm_atoms WHERE checksum = ?`,
     bind: ["tr1-new-name"],
     returnValue: "resultRows",
   });
-  const after_purge = await db.oneInOne(count_after_purge);
-  assert(
-    after_purge === 1,
-    `After purge should be 1 === ${after_purge?.toString()}`,
-  );
+  // const after_purge = await db.oneInOne(count_after_purge);
+  // assert(
+  //   after_purge === 1,
+  //   `After purge should be 1 === ${after_purge?.toString()}`,
+  // );
 
   log("~~ PURGE SUCCESS ~~");
 
@@ -424,7 +424,7 @@ const fullDiagnosticTest = async (db: Comlink.Remote<TabDBInterface>) => {
   const count_atoms_after_addremove = await db.oneInOne(confirmCount);
 
   assert(
-    count_atoms_after_addremove === 5,
+    count_atoms_after_addremove === 6,
     `after mjolnir atom count ${String(count_atoms_after_addremove)} === 5`,
   );
 
@@ -462,7 +462,7 @@ const fullDiagnosticTest = async (db: Comlink.Remote<TabDBInterface>) => {
   const count_atoms_after_hammer = await db.oneInOne(confirm9);
 
   assert(
-    count_atoms_after_hammer === 6,
+    count_atoms_after_hammer === 7,
     `after mjolnir atom count ${String(count_atoms_after_hammer)} === 6`,
   );
 


### PR DESCRIPTION
Remove and change some assertions to ensure the webworker test passes without removeOldIndex. These changes will have to be reverted / reworked when we restore garbage collection.
