### PR TITLE
feat(web): Show progress number on last step of lobby

### DIFF
--- a/app/web/src/newhotness/Lobby.vue
+++ b/app/web/src/newhotness/Lobby.vue
@@ -29,9 +29,10 @@
           <LobbyTerminalOutputLine
             v-for="(data, index) in visibleSentences"
             :key="index"
-            :message="data.sentence"
+            :message="unref(data.sentence)"
             :isActive="index === visibleSentences.length - 1"
             :isLoader="data.isLoader"
+            :isLastElement="index === visibleSentences.length - 1"
           />
         </div>
       </div>
@@ -40,10 +41,24 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, unref, watch } from "vue";
 import clsx from "clsx";
 import { sleep } from "@si/ts-lib/src/async-sleep";
 import LobbyTerminalOutputLine from "@/newhotness/LobbyTerminalOutputLine.vue";
+
+const props = defineProps({
+  /// The number of loading steps that exist and whether they are complete
+  loadingSteps: { type: Array<boolean>, required: true },
+});
+
+const loadingSummaryText = computed(() => {
+  const totalLoadingSteps = props.loadingSteps.length;
+  const completedLoadingSteps = props.loadingSteps.filter(
+    (f) => f === true,
+  ).length;
+
+  return `${completedLoadingSteps}/${totalLoadingSteps}`;
+});
 
 const sentences = [
   { sentence: "Welcome to System Initiative!" },
@@ -72,7 +87,7 @@ const sentences = [
   { sentence: "Locating intent in a sea of configuration" },
   { sentence: "Applying structure without limiting flexibility" },
   { sentence: "Bringing your workspace to you — clean, clear, and traceable" },
-  { sentence: "Finalizing..." },
+  { sentence: computed(() => `Finalizing... (${loadingSummaryText.value})`) },
 ];
 
 const showPanel = ref(false);

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -85,7 +85,10 @@
       leaveFromClass="opacity-100"
       leaveToClass="transform opacity-0"
     >
-      <Lobby v-if="!tokenFail && lobby" />
+      <Lobby
+        v-if="!tokenFail && lobby"
+        :loadingSteps="_.values(muspelheimStatuses)"
+      />
     </Transition>
 
     <main v-if="lobby && tokenFail" class="grow min-h-0">
@@ -126,6 +129,7 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { SchemaId } from "@/api/sdf/dal/schema";
 import { ChangeSet, ChangeSetStatus } from "@/api/sdf/dal/change_set";
+import { muspelheimStatuses } from "@/store/realtime/heimdall";
 import NavbarPanelRight from "./nav/NavbarPanelRight.vue";
 import Lobby from "./Lobby.vue";
 import Explore, { GroupByUrlQuery, SortByUrlQuery } from "./Explore.vue";


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

- When showing the last message of the lobby (Finalizing...) we also show the number of muspelheim tasks remaining before the system is ready. This is to show some progress if loading takes too long
- Also fixes an issue were upon coming back to a tab with the lobby, the user would see multiple lines animating at once instead of only the last one

#### Screenshots:
<img width="819" height="522" alt="Screenshot 2025-08-12 at 16 57 16" src="https://github.com/user-attachments/assets/67635e34-543e-49b5-bf1b-70dca069f669" />

