### PR TITLE
fix(web): Change the colors of the QualificationPanel

### DIFF
--- a/app/web/src/components/StatusMessageBox.vue
+++ b/app/web/src/components/StatusMessageBox.vue
@@ -1,12 +1,5 @@
 <template>
-  <div :class="divClasses" class="flex p-xs border rounded items-start">
-    <StatusIndicatorIcon
-      v-if="status"
-      :type="type"
-      :status="status"
-      class="w-8 mr-2 shrink-0"
-    />
-
+  <div :class="clsx('flex p-xs rounded items-start', getDivClasses)">
     <span class="self-center grow">
       <slot></slot>
     </span>
@@ -14,27 +7,24 @@
 </template>
 
 <script lang="ts" setup>
+import clsx from "clsx";
 import { computed, PropType } from "vue";
-import StatusIndicatorIcon, {
-  IconType,
-  Status,
-} from "@/components/StatusIndicatorIcon.vue";
+import { themeClasses } from "@si/vue-lib/design-system";
+import { IconType, Status } from "@/components/StatusIndicatorIcon.vue";
 
 const props = defineProps({
   status: { type: String as PropType<Status> },
   type: { type: String as PropType<IconType>, default: "qualification" },
 });
 
-const divClasses = computed(() => {
+const getDivClasses = computed(() => {
   switch (true) {
     case props.status === "success":
-      return "border-success-600 text-success-500";
+      return themeClasses("text-success-700", "text-success-300");
     case props.status === "warning":
-      return "border-warning-600 text-warning-500";
+      return themeClasses("text-warning-700", "text-warning-200");
     case props.status === "failure":
-      return "border-destructive-600 text-destructive-600";
-    case props.status === "running":
-      return "border-action-600 text-action-500";
+      return themeClasses("text-destructive-900", "text-destructive-200");
     default:
       return "";
   }

--- a/app/web/src/newhotness/QualificationPanel.vue
+++ b/app/web/src/newhotness/QualificationPanel.vue
@@ -119,6 +119,12 @@ const qualifications = computed<Qualification[]>(() => {
     });
   }
 
-  return items;
+  // Sort qualifications with failed first, then warning, then success, then unknown
+  return items.sort((a, b) => {
+    const statusOrder = { failure: 0, warning: 1, success: 2, unknown: 3 };
+    const aOrder = statusOrder[a.status as keyof typeof statusOrder] ?? 4;
+    const bOrder = statusOrder[b.status as keyof typeof statusOrder] ?? 4;
+    return aOrder - bOrder;
+  });
 });
 </script>

--- a/app/web/src/newhotness/QualificationView.vue
+++ b/app/web/src/newhotness/QualificationView.vue
@@ -8,15 +8,7 @@
         v-if="qualification.avId"
         label="Rerun qualification"
         size="xs"
-        :class="
-          clsx(
-            '!text-sm !border !cursor-pointer !px-xs',
-            themeClasses(
-              '!text-neutral-900 !bg-neutral-200 !border-neutral-400 hover:!bg-neutral-100 hover:!border-neutral-600',
-              '!text-si-white !bg-neutral-700 !border-neutral-600 hover:!bg-neutral-600 hover:!border-neutral-600',
-            ),
-          )
-        "
+        tone="neutral"
         @click="enqueueDVU"
       />
     </div>
@@ -32,22 +24,21 @@
             qualificationStatus === 'failure' ||
             qualificationStatus === 'warning'
           "
-          class="w-full flex flex-row gap-xs"
+          class="w-full flex flex-row items-center gap-xs"
         >
           <span class="grow">
             {{ qualification.message }}
           </span>
-          <button
+          <VButton
             v-if="
               (qualification.avId || qualification.output) &&
               (qualification.message || output?.length)
             "
-            tabindex="-1"
-            class="underline text-action-400 shrink-0"
+            :label="showDetails ? 'Hide Details' : 'View Details'"
+            size="xs"
+            tone="neutral"
             @click="toggleHidden"
-          >
-            {{ showDetails ? "Hide" : "View" }} Details
-          </button>
+          />
         </div>
         <template v-else>
           The qualification has not yet ran or is actively running.
@@ -77,15 +68,13 @@
 <script lang="ts" setup>
 import { computed, ref, toRef } from "vue";
 import * as _ from "lodash-es";
-import {
-  LoadingMessage,
-  themeClasses,
-  VButton,
-} from "@si/vue-lib/design-system";
-import clsx from "clsx";
+import { LoadingMessage, VButton } from "@si/vue-lib/design-system";
 import StatusMessageBox from "@/components/StatusMessageBox.vue";
 import CodeViewer from "@/components/CodeViewer.vue";
-import { Qualification } from "@/newhotness/QualificationPanel.vue";
+import {
+  Qualification,
+  QualificationStatus,
+} from "@/newhotness/QualificationPanel.vue";
 import { routes, useApi, funcRunTypes } from "@/newhotness/api_composables";
 
 const api = useApi();
@@ -99,8 +88,7 @@ const showDetails = ref(false);
 
 const qualification = toRef(props, "qualification");
 
-const qualificationStatus = computed(() => {
-  if (_.isNil(props.qualification.status)) return undefined;
+const qualificationStatus = computed((): QualificationStatus | undefined => {
   return props.qualification.status;
 });
 


### PR DESCRIPTION
The contrasts were poor in dark and light mode so we have a new design 
for that panel. We also sort the qualifications to be in the order:

* Failed
* Warning
* Passed

<img width="497" height="323" alt="Screenshot 2025-08-12 at 22 14 14" src="https://github.com/user-attachments/assets/2f9c7288-e6df-4b36-99b4-e4d0aabfb362" />
<img width="506" height="328" alt="Screenshot 2025-08-12 at 22 21 51" src="https://github.com/user-attachments/assets/9d9a6cb9-e3bd-4fe6-a4b8-52d696d7dba9" />
