### PR TITLE
fix(web): Ensure secret suggestions are actual secrets

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -1433,7 +1433,10 @@ const filteredConnections = computed(() => {
       // our current UI hurdle - only suggesting valid secrets as connection sources for secret props
       if (props.isSecret) {
         matches = matches.filter(
-          (m) => secretKind.value && m.path === `/secrets/${secretKind.value}`,
+          (m) =>
+            secretKind.value &&
+            m.path === `/secrets/${secretKind.value}` &&
+            m.isOriginSecret,
         );
       } else {
         matches = matches.filter((m) => !m.path.startsWith("/secrets/"));

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -100,6 +100,7 @@ export type PossibleConnection = {
   schemaName: string;
   componentId: string;
   kind: string;
+  isOriginSecret: boolean;
   suggestAsSourceFor?: PropSuggestion[];
 };
 

--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -2428,6 +2428,7 @@ const postProcess = (
             componentName: attributeTree.componentName,
             schemaName: attributeTree.schemaName,
             kind: prop.kind,
+            isOriginSecret: prop.isOriginSecret,
             suggestAsSourceFor: prop.suggestAsSourceFor,
           };
         }


### PR DESCRIPTION
When we were making suggestions for where to connect a secret, we showed
every secret prop on all assets on the workspace. Now we filter this 
down to be from origin secrets - i.e. the actual secret components

<img width="916" height="356" alt="Screenshot 2025-08-13 at 19 28 10" src="https://github.com/user-attachments/assets/b5489179-9bb5-4918-b8cb-a144ceeaa5b5" />

there are 50 components in this workspace and now only 1 suggestion :)