### PR TITLE
feature flag, keyboard shortcut, organizing shortcuts

### DIFF
--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>test</div>
+</template>

--- a/app/web/src/newhotness/ShortcutModal.vue
+++ b/app/web/src/newhotness/ShortcutModal.vue
@@ -3,7 +3,7 @@
     <div
       :class="
         clsx(
-          'flex flex-col gap-xs',
+          'flex flex-col gap-xs scrollable max-h-[70vh]',
           '[&>div]:flex [&>*]:flex-row [&>*]:items-center [&>*]:gap-xs',
           '[&_.keys]:w-12 [&_.keys]:flex [&_.keys]:flex-row [&_.keys]:items-center [&_.keys]:justify-center',
           '[&_.key]:text-xl [&_.key]:font-bold [&_.key]:leading-none [&_.key]:flex-grow [&_.key]:text-center',
@@ -35,6 +35,15 @@
         <div>
           Press <TextPill tighter variant="key">K</TextPill> to select the
           search bar.
+        </div>
+      </div>
+      <div v-if="featureFlagsStore.REVIEW_PAGE">
+        <div class="keys">
+          <div class="key">R</div>
+        </div>
+        <div>
+          Press <TextPill tighter variant="key">R</TextPill> to open the review
+          screen.
         </div>
       </div>
       <div>
@@ -133,10 +142,10 @@
       </div>
       <div>
         <div class="keys">
-          <div class="key">R</div>
+          <div class="key">F</div>
         </div>
         <div>
-          Press <TextPill tighter variant="key">R</TextPill> to restore the
+          Press <TextPill tighter variant="key">F</TextPill> to restore the
           selected component (if set for deletion).
         </div>
       </div>
@@ -176,8 +185,11 @@
 import { ref } from "vue";
 import { Modal, useModal, Icon, TextPill } from "@si/vue-lib/design-system";
 import clsx from "clsx";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 
 const modalRef = ref<InstanceType<typeof Modal>>();
 const { open, close } = useModal(modalRef);
 defineExpose({ open, close, isOpen: modalRef.value?.isOpen });
+
+const featureFlagsStore = useFeatureFlagsStore();
 </script>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -73,6 +73,7 @@
         :functionKind="FunctionKind.Action"
         :actionId="actionId"
       />
+      <Review v-else-if="onReviewPage" />
       <Explore v-else @openChangesetModal="openChangesetModal" />
     </main>
 
@@ -147,6 +148,7 @@ import ComponentPage from "./ComponentDetails.vue";
 import NavbarPanelLeft from "./nav/NavbarPanelLeft.vue";
 import { useChangeSets } from "./logic_composables/change_set";
 import { routes, useApi } from "./api_composables";
+import Review from "./Review.vue";
 
 const tracer = trace.getTracer("si-vue");
 const navbarPanelLeftRef = ref<InstanceType<typeof NavbarPanelLeft>>();
@@ -781,6 +783,8 @@ watch(
   },
   { immediate: true },
 );
+
+const onReviewPage = computed(() => route.name === "new-hotness-review");
 
 onBeforeUnmount(() => {
   windowResizeEmitter.off("resize", windowResizeHandler);

--- a/app/web/src/router.ts
+++ b/app/web/src/router.ts
@@ -134,6 +134,12 @@ const routes: RouteRecordRaw[] = [
         props: true,
         component: () => import("@/newhotness/Workspace.vue"),
       },
+      {
+        name: "new-hotness-review",
+        path: "r",
+        props: true,
+        component: () => import("@/newhotness/Workspace.vue"),
+      },
     ],
   },
   {

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -22,6 +22,7 @@ const USER_FLAG_MAPPING = {
   SQLITE_TOOLS: "sqlite-tools",
   PROPS_TO_PROPS_CONNECTIONS: "props-to-props-connections",
   ENABLE_NEW_EXPERIENCE: "enable-new-experience",
+  REVIEW_PAGE: "review-page",
 } as const;
 const WORKSPACE_FLAG_MAPPING = {
   FRONTEND_ARCH_VIEWS: "workspace-frontend-arch-views",


### PR DESCRIPTION
## How does this PR change the system?

- Add keyboard shortcut for opening the review screen behind a feature flag
- Refactor the messy keyboard shortcuts system in Explore (was in our way!)
- Add keyboard shortcut for opening the review screen to the ShortcutModal (behind feature flag)

#### Out of Scope:

We will actually implement the first iteration of the review screen in our next PR!

## How was it tested?

Checked every single shortcut to make sure that they were not broken by the refactor.