### PR TITLE
feat: hardcode schema information for some things in the mcp server

### DIFF
--- a/bin/si-mcp-server/src/data/cfDb.ts
+++ b/bin/si-mcp-server/src/data/cfDb.ts
@@ -155,10 +155,192 @@ export function getAttributesForService(
   }
 }
 
+function getManualSchemaDocumentation(
+  schemaName: string,
+  schemaAttributePath: string,
+): string | null {
+  switch (schemaName) {
+    case "AWS::IAM::User":
+      switch (schemaAttributePath) {
+        case "/domain/UserName":
+          return "The name of the user. Do not include the path in this value.\nIAM user, group, role, and policy names must be unique within the account. Names are not distinguished by case. For example, you cannot create resources named both `MyResource` and `myresource`.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html#API_CreateUser_RequestParameters";
+        case "/domain/Path":
+          return "The path for the user name. For more information about paths, see [IAM identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide.\nThis parameter is optional. If it is not included, it defaults to a slash (/).\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\\u0021) through the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html#API_CreateUser_RequestParameters";
+        case "/domain/PermissionsBoundary":
+          return "The ARN of the managed policy that is used to set the permissions boundary for the user.\nA permissions boundary policy defines the maximum permissions that identity-based policies can grant to an entity, but does not grant permissions. Permissions boundaries do not define the maximum permissions that a resource-based policy can grant to an entity. To learn more, see [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) in the IAM User Guide.\nFor more information about policy types, see [Policy types](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types) in the IAM User Guide.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html#API_CreateUser_RequestParameters";
+        case "/domain/Tags/[array]/Key":
+          return "The tag key.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/Tags/[array]/Value":
+          return "The tag value.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/IdentityType":
+          return "The type of identity this user represents. Used to categorize the user within the IAM system.";
+        default:
+          return null;
+      }
+
+    case "AWS::IAM::Role":
+      switch (schemaAttributePath) {
+        case "/domain/RoleName":
+          return "The name of the role. Do not include the path in this value.\nIAM user, group, role, and policy names must be unique within the account. Names are not distinguished by case. For example, you cannot create resources named both `MyResource` and `myresource`.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_RequestParameters";
+        case "/domain/AssumeRolePolicyDocument":
+          return "The trust relationship policy document as a prettified JSON string, that grants an entity permission to assume the role.\nUpon success, the response includes the same trust policy in JSON format.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_RequestParameters";
+        case "/domain/Description":
+          return "A description of the role.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_RequestParameters";
+        case "/domain/MaxSessionDuration":
+          return "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default value of one hour is applied. This setting can have a value from 1 hour to 12 hours.\nAnyone who assumes the role from the CLI or API can use the `DurationSeconds` API parameter or the `duration-seconds` CLI parameter to request a longer session. The `MaxSessionDuration` setting determines the maximum duration that can be requested using the `DurationSeconds` parameter. If users don't specify a value for the `DurationSeconds` parameter, their security credentials are valid for one hour by default. This applies when you use the `AssumeRole*` API operations or the `assume-role*` CLI operations but does not apply when you use those operations to create a console URL. For more information, see [Using IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the IAM User Guide.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_RequestParameters";
+        case "/domain/Path":
+          return "The path to the group. For more information about paths, see [IAM identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide.\nThis parameter is optional. If it is not included, it defaults to a slash (/).\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\\u0021) through the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_RequestParameters";
+        case "/domain/PermissionsBoundary":
+          return "The ARN of the managed policy that is used to set the permissions boundary for the role.\nA permissions boundary policy defines the maximum permissions that identity-based policies can grant to an entity, but does not grant permissions. Permissions boundaries do not define the maximum permissions that a resource-based policy can grant to an entity. To learn more, see [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) in the IAM User Guide.\nFor more information about policy types, see [Policy types](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types) in the IAM User Guide.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_RequestParameters";
+        case "/domain/IdentityType":
+          return "The type of identity this role represents. Used to categorize the role within the IAM system.";
+        case "/domain/Tags/[array]/Key":
+          return "The tag key.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/Tags/[array]/Value":
+          return "The tag value.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/extra/Region":
+          return "The AWS region where this role is managed. While IAM roles are global, this specifies which region context to use for management operations.";
+        default:
+          return null;
+      }
+
+    case "AWS::IAM::Group":
+      switch (schemaAttributePath) {
+        case "/domain/GroupName":
+          return "The name of the group. Do not include the path in this value.\nIAM user, group, role, and policy names must be unique within the account. Names are not distinguished by case. For example, you cannot create resources named both `MyResource` and `myresource`.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateGroup.html#API_CreateGroup_RequestParameters";
+        case "/domain/Path":
+          return "The path to the group. For more information about paths, see [IAM identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide.\nThis parameter is optional. If it is not included, it defaults to a slash (/).\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\\u0021) through the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateGroup.html#API_CreateGroup_RequestParameters";
+        case "/domain/Users/[array]":
+          return "The name of the user to add.\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `_+=,.@-`.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html#API_AddUserToGroup_RequestParameters";
+        case "/domain/IdentityType":
+          return "The type of identity this group represents. Used to categorize the group within the IAM system.";
+        default:
+          return null;
+      }
+
+    case "AWS::IAM::ManagedPolicy":
+      switch (schemaAttributePath) {
+        case "/domain/PolicyName":
+          return 'The friendly name of the policy.\nIAM user, group, role, and policy names must be unique within the account. Names are not distinguished by case. For example, you cannot create resources named both "MyResource" and "myresource".\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html#API_CreatePolicy_RequestParameters';
+        case "/domain/PolicyDocument":
+          return "The JSON policy document as a prettified JSON string that you want to use as the content for the new IAM policy. To learn more about JSON policy grammar, see [Grammar of the IAM JSON policy language](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html) in the IAM User Guide.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html#API_CreatePolicy_RequestParameters";
+        case "/domain/Path":
+          return "The path for the policy. For more information about paths, see [IAM identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide.\nThis parameter is optional. If it is not included, it defaults to a slash (/).\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\\u0021) through the DEL character (\\u007F), including most punctuation characters, digits, and upper and lowercased letters.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html#API_CreatePolicy_RequestParameters";
+        case "/domain/Description":
+          return 'A friendly description of the policy.\nTypically used to store information about the permissions defined in the policy. For example, "Grants access to production DynamoDB tables".\nThe policy description is immutable. After a value is assigned, it cannot be changed.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html#API_CreatePolicy_RequestParameters';
+        case "/domain/Tags/[array]/Key":
+          return "The tag key.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/Tags/[array]/Value":
+          return "The tag value.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/extra/Region":
+          return "The AWS region where this policy is managed. While IAM policies are global, this specifies which region context to use for management operations.";
+        default:
+          return null;
+      }
+
+    case "AWS::IAM::UserPolicy":
+      switch (schemaAttributePath) {
+        case "/domain/UserName":
+          return "The name (friendly name, not ARN) of the IAM user to attach the policy to.\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `_+=,.@-`\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html#API_AttachUserPolicy_RequestParameters";
+        case "/domain/PolicyArn":
+          return "The Amazon Resource Name (ARN) of the IAM policy you want to attach.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html#API_AttachUserPolicy_RequestParameters";
+        case "/domain/PolicyType":
+          return "The type of policy attachment. Specifies whether this is an inline policy or a managed policy attachment.";
+        default:
+          return null;
+      }
+
+    case "AWS::IAM::RolePolicy":
+      switch (schemaAttributePath) {
+        case "/domain/RoleName":
+          return "The name (friendly name, not ARN) of the role to attach the policy to.\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `_+=,.@-`\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachRolePolicy.html#API_AttachRolePolicy_RequestParameters";
+        case "/domain/PolicyArn":
+          return "The Amazon Resource Name (ARN) of the IAM policy you want to attach.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachRolePolicy.html#API_AttachRolePolicy_RequestParameters";
+        case "/domain/PolicyType":
+          return "The type of policy attachment. Specifies whether this is an inline policy or a managed policy attachment.";
+        case "/domain/IdentityType":
+          return "The type of identity this policy attachment represents. Used to categorize the policy attachment within the IAM system.";
+        default:
+          return null;
+      }
+
+    case "AWS::IAM::InstanceProfile":
+      switch (schemaAttributePath) {
+        case "/domain/InstanceProfileName":
+          return "The name of the instance profile to create.\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `_+=,.@-`\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html#API_CreateInstanceProfile_RequestParameters";
+        case "/domain/Path":
+          return "The path to the instance profile. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the IAM User Guide.\nThis parameter is optional. If it is not included, it defaults to a slash (/).\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the (`\\u0021`) through the DEL character (`\\u007F`), including most punctuation characters, digits, and upper and lowercased letters.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html#API_CreateInstanceProfile_RequestParameters";
+        case "/domain/RoleName":
+          return "The name of the role to add.\nThis parameter allows (through its [regex pattern](http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `_+=,.@-`\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html#API_CreateInstanceProfile_RequestParameters";
+        case "/domain/Tags/[array]/Key":
+          return "The tag key.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/Tags/[array]/Value":
+          return "The tag value.\n\nDocumentation: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Tag.html";
+        case "/domain/extra/Region":
+          return "The AWS region where this instance profile is managed. While IAM instance profiles are global, this specifies which region context to use for management operations.";
+        default:
+          return null;
+      }
+
+    case "String Template":
+      switch (schemaAttributePath) {
+        case "/domain/Template":
+          return 'The string you want to see, with template syntax to fill in Variables\' values.\n\n`<%= VariableName %>` will be replaced with the corresponding Variables\' values.\n\nExample AWS policy document template:\n\n```json\n{\n   "Version": "2012-10-17",\n   "Statement": [\n       {\n           "Sid": "AllowBucketAccess",\n           "Effect": "Allow",\n           "Action": [ "s3:PutObject", "s3:GetObject", "s3:ListBucket", "s3:DeleteObject" ],\n           "Resource": [\n               "<%= BucketArn %>/*",\n               "<%= BucketArn %>"\n           ]\n       }\n   ]\n}\n```';
+        case "/domain/Variables/[map]":
+          return "A variable value that can be substituted into the template. The key represents the variable name and the value is what gets substituted.";
+        case "/domain/Rendered/Value":
+          return "The final string, with Variables replaced. This is what you subscribe to when you use the string. DO NOT SET THIS YOURSELF.";
+        case "/domain/Rendered/Error":
+          return "If there was an error rendering the template, it's stored here.";
+        default:
+          return null;
+      }
+
+    case "Region":
+      switch (schemaAttributePath) {
+        case "/domain/region":
+          return "The AWS region identifier (e.g., us-east-1, eu-west-1). Must be a valid AWS region. See https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html for the complete list of available regions.";
+        default:
+          return null;
+      }
+
+    case "AWS Credential":
+      switch (schemaAttributePath) {
+        case "/secrets/AWS Credential/SessionToken":
+          return "The session token for temporary AWS credentials. Used with access key and secret key when assuming roles or using temporary credentials. This field is optional and only required when using temporary credentials.";
+        case "/secrets/AWS Credential/AccessKeyId":
+          return "The AWS access key ID. This is the public part of the AWS credential pair used for authentication. Required for programmatic access to AWS services.";
+        case "/secrets/AWS Credential/SecretAccessKey":
+          return "The AWS secret access key. This is the private part of the AWS credential pair and must be kept secure. Never share or expose this value. Required for programmatic access to AWS services.";
+        case "/secrets/AWS Credential/AssumeRole":
+          return "The ARN of an IAM role to assume when using these credentials. This allows cross-account access or elevated permissions. Optional field used when you need to assume a different role than the one associated with the base credentials.";
+        case "/secrets/AWS Credential/Endpoint":
+          return "The custom endpoint URL for AWS services. Typically used for testing with LocalStack or custom AWS-compatible services. Optional field - leave empty to use standard AWS endpoints.";
+        default:
+          return null;
+      }
+
+    default:
+      return null;
+  }
+}
+
 export function getSchemaAttributeDocumentation(
   schemaName: string,
   schemaAttributePath: string,
 ): string | null {
+  // We are hardcoding some documentation of props so that the MCP server can handle IAM
+  // assets that ARE NOT installed on the graph it's able to query. This allows the MCP
+  // server to respond with more appropariate documentation for the associated props and
+  // schemas for IAM specifically.
+  const manualDoc = getManualSchemaDocumentation(
+    schemaName,
+    schemaAttributePath,
+  );
+  if (manualDoc) {
+    return manualDoc;
+  }
+
   try {
     const cfSchema = getServiceByName(schemaName);
 

--- a/bin/si-mcp-server/src/tools/schemaAttributesList.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesList.ts
@@ -36,6 +36,9 @@ const ListSchemaAttributesOutputSchemaRaw = {
 const ListSchemaAttributesOutputSchema = z.object(
   ListSchemaAttributesOutputSchemaRaw,
 );
+type ListSchemaAttributesOutput = z.infer<
+  typeof ListSchemaAttributesOutputSchema
+>;
 
 export function schemaAttributesListTool(server: McpServer) {
   server.registerTool(
@@ -54,13 +57,325 @@ export function schemaAttributesListTool(server: McpServer) {
       outputSchema: ListSchemaAttributesOutputSchemaRaw,
     },
     ({ schemaName }): CallToolResult => {
-      const attributes = getAttributesForService(schemaName);
+      let responseData: ListSchemaAttributesOutput["data"];
+
+      if (schemaName == "AWS::IAM::User") {
+        responseData = {
+          schemaName: "AWS::IAM::User",
+          "attributes": [
+            {
+              "name": "UserName",
+              "path": "/domain/UserName",
+              "required": true,
+            },
+            {
+              "name": "Path",
+              "path": "/domain/Path",
+              "required": false,
+            },
+            {
+              "name": "PermissionsBoundary",
+              "path": "/domain/PermissionsBoundary",
+              "required": false,
+            },
+            {
+              "name": "Key",
+              "path": "/domain/Tags/[array]/Key",
+              "required": true,
+            },
+            {
+              "name": "Value",
+              "path": "/domain/Tags/[array]/Value",
+              "required": true,
+            },
+            {
+              "name": "IdentityType",
+              "path": "/domain/IdentityType",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS::IAM::Role") {
+        responseData = {
+          schemaName: "AWS::IAM::Role",
+          "attributes": [
+            {
+              "name": "RoleName",
+              "path": "/domain/RoleName",
+              "required": true,
+            },
+            {
+              "name": "AssumeRolePolicyDocument",
+              "path": "/domain/AssumeRolePolicyDocument",
+              "required": true,
+            },
+            {
+              "name": "Description",
+              "path": "/domain/Description",
+              "required": false,
+            },
+            {
+              "name": "MaxSessionDuration",
+              "path": "/domain/MaxSessionDuration",
+              "required": false,
+            },
+            {
+              "name": "Path",
+              "path": "/domain/Path",
+              "required": false,
+            },
+            {
+              "name": "PermissionsBoundary",
+              "path": "/domain/PermissionsBoundary",
+              "required": false,
+            },
+            {
+              "name": "IdentityType",
+              "path": "/domain/IdentityType",
+              "required": false,
+            },
+            {
+              "name": "Key",
+              "path": "/domain/Tags/[array]/Key",
+              "required": true,
+            },
+            {
+              "name": "Value",
+              "path": "/domain/Tags/[array]/Value",
+              "required": true,
+            },
+            {
+              "name": "Region",
+              "path": "/domain/extra/Region",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS::IAM::Group") {
+        responseData = {
+          schemaName: "AWS::IAM::Group",
+          "attributes": [
+            {
+              "name": "GroupName",
+              "path": "/domain/GroupName",
+              "required": true,
+            },
+            {
+              "name": "Path",
+              "path": "/domain/Path",
+              "required": false,
+            },
+            {
+              "name": "UserName",
+              "path": "/domain/Users/[array]",
+              "required": false,
+            },
+            {
+              "name": "IdentityType",
+              "path": "/domain/IdentityType",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS::IAM::ManagedPolicy") {
+        responseData = {
+          schemaName: "AWS::IAM::ManagedPolicy",
+          "attributes": [
+            {
+              "name": "PolicyName",
+              "path": "/domain/PolicyName",
+              "required": true,
+            },
+            {
+              "name": "PolicyDocument",
+              "path": "/domain/PolicyDocument",
+              "required": true,
+            },
+            {
+              "name": "Path",
+              "path": "/domain/Path",
+              "required": false,
+            },
+            {
+              "name": "Description",
+              "path": "/domain/Description",
+              "required": false,
+            },
+            {
+              "name": "Key",
+              "path": "/domain/Tags/[array]/Key",
+              "required": true,
+            },
+            {
+              "name": "Value",
+              "path": "/domain/Tags/[array]/Value",
+              "required": true,
+            },
+            {
+              "name": "Region",
+              "path": "/domain/extra/Region",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS::IAM::UserPolicy") {
+        responseData = {
+          schemaName: "AWS::IAM::UserPolicy",
+          "attributes": [
+            {
+              "name": "UserName",
+              "path": "/domain/UserName",
+              "required": true,
+            },
+            {
+              "name": "PolicyArn",
+              "path": "/domain/PolicyArn",
+              "required": true,
+            },
+            {
+              "name": "PolicyType",
+              "path": "/domain/PolicyType",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS::IAM::RolePolicy") {
+        responseData = {
+          schemaName: "AWS::IAM::RolePolicy",
+          "attributes": [
+            {
+              "name": "RoleName",
+              "path": "/domain/RoleName",
+              "required": true,
+            },
+            {
+              "name": "PolicyArn",
+              "path": "/domain/PolicyArn",
+              "required": true,
+            },
+            {
+              "name": "PolicyType",
+              "path": "/domain/PolicyType",
+              "required": false,
+            },
+            {
+              "name": "IdentityType",
+              "path": "/domain/IdentityType",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS::IAM::InstanceProfile") {
+        responseData = {
+          schemaName: "AWS::IAM::InstanceProfile",
+          "attributes": [
+            {
+              "name": "InstanceProfileName",
+              "path": "/domain/InstanceProfileName",
+              "required": true,
+            },
+            {
+              "name": "Path",
+              "path": "/domain/Path",
+              "required": false,
+            },
+            {
+              "name": "RoleName",
+              "path": "/domain/RoleName",
+              "required": false,
+            },
+            {
+              "name": "Key",
+              "path": "/domain/Tags/[array]/Key",
+              "required": true,
+            },
+            {
+              "name": "Value",
+              "path": "/domain/Tags/[array]/Value",
+              "required": true,
+            },
+            {
+              "name": "Region",
+              "path": "/domain/extra/Region",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "String Template") {
+        responseData = {
+          schemaName: "String Template",
+          "attributes": [
+            {
+              "name": "Template",
+              "path": "/domain/Template",
+              "required": false,
+            },
+            {
+              "name": "Value",
+              "path": "/domain/Variables/[map]",
+              "required": false,
+            },
+            {
+              "name": "Value",
+              "path": "/domain/Rendered/Value",
+              "required": false,
+            },
+            {
+              "name": "Error",
+              "path": "/domain/Rendered/Error",
+              "required": false,
+            },
+          ],
+        };
+      } else if (schemaName == "Region") {
+        responseData = {
+          schemaName: "Region",
+          "attributes": [
+            {
+              "name": "region",
+              "path": "/domain/region",
+              "required": true,
+            },
+          ],
+        };
+      } else if (schemaName == "AWS Credential") {
+        responseData = {
+          schemaName: "AWS Credential",
+          "attributes": [
+            {
+              "name": "SessionToken",
+              "path": "/secrets/AWS Credential/SessionToken",
+              "required": false,
+            },
+            {
+              "name": "AccessKeyId",
+              "path": "/secrets/AWS Credential/AccessKeyId",
+              "required": false,
+            },
+            {
+              "name": "SecretAccessKey",
+              "path": "/secrets/AWS Credential/SecretAccessKey",
+              "required": false,
+            },
+            {
+              "name": "AssumeRole",
+              "path": "/secrets/AWS Credential/AssumeRole",
+              "required": false,
+            },
+            {
+              "name": "Endpoint",
+              "path": "/secrets/AWS Credential/Endpoint",
+              "required": false,
+            },
+          ],
+        };
+      } else {
+        const attributes = getAttributesForService(schemaName);
+        responseData = { schemaName, attributes };
+      }
       return successResponse(
-        {
-          schemaName,
-          attributes,
-        },
-        "If this is an AWS resource, the attributes map 1:1 to to the Cloudformation resource, where the path is calculated by looking at the Cloudformation resources nesting. You can look up the documentation for any attribute by its schemaName and path with the schema-attributes-documentation tool.",
+        responseData,
+        "If this is an AWS resource, the attributes map 1:1 to to the Cloudformation resource, where the path is calculated by looking at the Cloudformation resources nesting. You should look up the documentation for any attribute by its schemaName and path with the schema-attributes-documentation tool before setting any values.",
       );
     },
   );

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -119,17 +119,158 @@ export function schemaFindTool(server: McpServer) {
             schemaId: null,
           };
         }
+        if (schemaNameOrId.startsWith("AWS::IAM")) {
+          switch (schemaNameOrId) {
+            case "AWS::IAM::User":
+            case "AWS::IAM::Role":
+            case "AWS::IAM::Group":
+            case "AWS::IAM::ManagedPolicy":
+            case "AWS::IAM::UserPolicy":
+            case "AWS::IAM::RolePolicy":
+            case "AWS::IAM::InstanceProfile":
+              break;
+            default:
+              return errorResponse({
+                message:
+                  "AWS::IAM schema not found. Use one of AWS::IAM::User, AWS::IAM::Role, AWS::IAM::RolePolicy, AWS::IAM::UserPolicy, AWS::IAM::ManagedPolicy, AWS::IAM::InstanceProfile, or AWS::IAM::Group.",
+              });
+          }
+        }
 
         const response = await siApi.findSchema(args);
         const responseData: NonNullable<FindSchemaOutput["data"]> = {
           schemaId: response.data.schemaId,
           schemaName: response.data.schemaName,
         };
+        if (responseData.schemaName == "AWS::IAM::User") {
+          responseData.description =
+            "Specifies an IAM User. For more information, see [IAM User](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html) in the *Amazon IAM User Guide*.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html";
+        } else if (responseData.schemaName == "AWS::IAM::Role") {
+          responseData.description =
+            "Specifies an IAM Role. For more information, see [IAM Roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) in the *Amazon IAM User Guide*. Always ensure the AssumeRolePolicyDocument is a prettified JSON string, not a raw object.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html";
+        } else if (responseData.schemaName == "AWS::IAM::Group") {
+          responseData.description =
+            "Specifies an IAM Group. For more information, see [IAM Groups](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html) in the *Amazon IAM User Guide*.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html";
+        } else if (responseData.schemaName == "AWS::IAM::ManagedPolicy") {
+          responseData.description =
+            "You use this operation to define a custom IAM policy. For more information, see [IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html) in the *Amazon IAM User Guide*. Always ensure the PolicyDocument is a prettified JSON string, not a raw object.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html";
+        } else if (responseData.schemaName == "AWS::IAM::UserPolicy") {
+          responseData.description =
+            "You use this operation to attach a managed policy to a user. For more information, see [IAM Policies and permissions in AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) in the *Amazon IAM User Guide*.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html";
+        } else if (responseData.schemaName == "AWS::IAM::RolePolicy") {
+          responseData.description =
+            "Use this operation to attach a managed policy to a role. For more information, see [IAM Policies and permissions in AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) in the *Amazon IAM User Guide*.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html";
+        } else if (responseData.schemaName == "AWS::IAM::InstanceProfile") {
+          responseData.description =
+            "You use this operation to manage an Instance Profile. For more information, see [IAM Instance Profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) in the *Amazon IAM User Guide*.";
+          responseData.link =
+            "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html";
+        } else if (responseData.schemaName == "String Template") {
+          responseData.description =
+            `Formats a string with dynamic JavaScript and data from your components.
 
-        const docs = getDocumentationForService(responseData.schemaName);
-        responseData.description = docs.description;
-        responseData.link = docs.link;
+This is typically used to format a complex string property in a component, including properties from *other* components via subscriptions. For example, the Role and ManagedPolicy components have text fields where you input a JSON policy document. Frequently, you want to insert ARNs and IDs from other components you want to give permission to, such as a User or Instance, into these documents.
 
+You can look at the rendered value in Code Gen. To use it, subscribe to \`/domain/Rendered/Value\` on the String Template component from the place you want to use it.
+
+## Example
+
+To use this component to fill in strings, you follow these steps:
+
+1. Create a String Template component for your string (e.g. an AWS JSON Policy Document).
+2. Set the Template property, inserting \`<%= VariableName %>\` where you want to pull in data:
+   \`\`json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Sid": "AllowBucketAccess",
+               "Effect": "Allow",
+               "Action": [ "s3:PutObject", "s3:GetObject", "s3:ListBucket", "s3:DeleteObject" ],
+               "Resource": [
+                   "<%= BucketArn %>/*",
+                   "<%= BucketArn %>"
+               ]
+           }
+       ]
+   }
+   \`\`\`
+3. Add the variables you referenced in step 1 to the Variables property, and  subscribe to the data you want!
+
+   e.g. add \`BucketArn\` to Variables and subscribe to \`/resource_value/Arn\` on \`MyBucket\`.
+4. In the *destination*, subscribe to \`/domain/Rendered/Value\` on your String Template:
+
+   e.g. go to \`PolicyDocument\` on your IAM ManagedPolicy, and subscribe to \`/domain/Rendered/Value\` on the String Template component.
+
+## Syntax
+
+Variables aren't the only thing you can do: String Template uses [eta](https://eta.js.org/docs/intro/template-syntax), a JavaScript-based templating engine that lets you use arbitrary JavaScript. A brief summary:
+
+* Variables: \`<%= VariableName %>\` is replaced with the variable name
+* JavaScript: you can use arbitrary JavaScript. For example, \`<%= JSON.stringify(VariableName) %>\` will take a value and put quotes around it for JSON, escaping anything inside it (such as newlines and embedded quotes) to ensure it's valid JSON.
+* Control (loops, if statements, variables): you can do more advanced JavaScript with \`<%\`:
+
+  \`\`\`
+  Roles:
+  <% const roles = ListOfRolesSeparatedByComma.split(','); %>
+  <% ListOfRolesSeparatedByComma.split(',').forEach((role) => { %>
+    - <%= role %>
+  <% }); %>
+  \`\`\`
+* More advanced syntax can be found in [eta's template syntax cheatsheet](https://eta.js.org/docs/intro/syntax-cheatsheet).
+`;
+        } else if (responseData.schemaName == "Region") {
+          responseData.description =
+            `The geography for an AWS Region is the specific physical location of its infrastructure. This can help you meet your regulatory, compliance, and operational requirements.
+
+When you are preparing to deploy a workload, consider which Region or Regions best meet your needs. For example, select a Region that has the AWS services and features that you need. Also, you can lower network latency when you select a Region that is close to the majority of your users.
+
+Your AWS account determines the Regions that are available to you.`;
+          responseData.link =
+            "https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html";
+        } else if (responseData.schemaName == "AWS Credential") {
+          responseData.description =
+            `AWS Credential must be configured *manually* in System Initiative. It cannot be configured by the MCP server.
+
+          You can authenticate with AWS using one of the following methods:
+
+Short-Term Credentials
+
+Set the following environment variables when using temporary AWS security credentials:
+	•	AWS_ACCESS_KEY_ID: Your AWS access key associated with an IAM account.
+	•	AWS_SECRET_ACCESS_KEY: The secret key for your access key (acts like a password).
+	•	AWS_SESSION_TOKEN: Required if you’re using temporary credentials obtained from AWS Security Token Service (STS). For details, refer to the assume-role command documentation: https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-short-term.html
+
+Long-Term Credentials
+
+Set these environment variables when using permanent AWS IAM credentials:
+	•	AWS_ACCESS_KEY_ID: Your AWS access key associated with an IAM account.
+	•	AWS_SECRET_ACCESS_KEY: The secret key for your access key (acts like a password).
+
+For more details, visit AWS CLI Authentication with Long-Term Credentials: https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-user.html
+
+Assume Role
+
+Alternatively, you can authenticate by assuming an IAM role, which provides longer-term, managed authentication. Follow the instructions in our guide: https://docs.systeminit.com/explanation/aws-authentication#assuming-a-role`;
+          responseData.link =
+            "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html";
+        } else {
+          const docs = getDocumentationForService(responseData.schemaName);
+          responseData.description = docs.description;
+          responseData.link = docs.link;
+        }
         return successResponse(
           responseData,
           "You can use a web search to find the cloudformation schema",


### PR DESCRIPTION
- Updates the schemaFind MCP server to hard-code the IAM assets, Region, AWS Credential and String Template.
- Confirmed working for IAM assets and String Template, if you are explicit.

## How does this PR change the system?

It hard codes the documentation for working with IAM, Region, Credential, and String Template, so the MCP server can work with them.

## How was it tested?

Adam, John and Aaron crushing it.

## In short: [:link:](https://giphy.com/)
<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdldmphY240enRkbXVmeXgzZ3NwYXM5cTd5a2RqMTF2NG02MDg2Y280NSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/I1nwVpCaB4k36/giphy.gif"/>