### PR TITLE
feat(web) - first draft of review page newhotness

### DIFF
--- a/app/web/src/newhotness/ComponentCard.vue
+++ b/app/web/src/newhotness/ComponentCard.vue
@@ -39,16 +39,19 @@ import {
   TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { ComponentInList } from "@/workers/types/entity_kind_types";
+import {
+  BifrostComponent,
+  ComponentInList,
+} from "@/workers/types/entity_kind_types";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon, getAssetColor } from "./util";
 import ComponentTileQualificationStatus from "./ComponentTileQualificationStatus.vue";
 
 defineProps<{
-  component: ComponentInList;
+  component: ComponentInList | BifrostComponent;
 }>();
 
-const borderStyle = (component: ComponentInList) => {
+const borderStyle = (component: ComponentInList | BifrostComponent) => {
   const color = getAssetColor(component.schemaCategory);
   return `border-color: ${color}`;
 };

--- a/app/web/src/newhotness/DiffPanel.vue
+++ b/app/web/src/newhotness/DiffPanel.vue
@@ -1,6 +1,11 @@
 <template>
   <ul class="p-xs flex flex-col gap-xs">
-    <CodeViewer v-if="diff" :code="diff" codeLanguage="diff" />
+    <CodeViewer
+      v-if="diff"
+      :code="diff"
+      codeLanguage="diff"
+      copyTooltip="Copy diff to clipboard"
+    />
     <EmptyState v-else icon="diff" text="No changes" />
   </ul>
 </template>

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -454,7 +454,6 @@
 import * as _ from "lodash-es";
 import {
   computed,
-  inject,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -488,7 +487,6 @@ import {
 import {
   BifrostActionViewList,
   ComponentInList,
-  ComponentDiffStatus,
   EntityKind,
   View,
 } from "@/workers/types/entity_kind_types";
@@ -511,12 +509,7 @@ import CollapsingGridItem from "./layout_components/CollapsingGridItem.vue";
 import InstructiveVormInput from "./layout_components/InstructiveVormInput.vue";
 import { getQualificationStatus } from "./ComponentTileQualificationStatus.vue";
 import FuncRunList from "./FuncRunList.vue";
-import {
-  assertIsDefined,
-  ComponentsHaveActionsWithState,
-  Context,
-  ExploreContext,
-} from "./types";
+import { ComponentsHaveActionsWithState, ExploreContext } from "./types";
 import {
   KeyDetails,
   keyEmitter,
@@ -541,12 +534,12 @@ import ActionQueueList from "./ActionQueueList.vue";
 import { useComponentSearch } from "./logic_composables/search";
 import { routes, useApi } from "./api_composables";
 import { ExploreGridRowData } from "./explore_grid/ExploreGridRow.vue";
+import { useContext } from "./logic_composables/context";
 
 const featureFlagsStore = useFeatureFlagsStore();
 const router = useRouter();
 const route = useRoute();
-const ctx = inject<Context>("CONTEXT");
-assertIsDefined(ctx);
+const ctx = useContext();
 
 const key = useMakeKey();
 const args = useMakeArgs();
@@ -1105,8 +1098,7 @@ const sortedAndGroupedComponents = computed(() => {
     };
     for (const component of components) {
       const title =
-        component.diffStatus &&
-        component.diffStatus !== ComponentDiffStatus.None
+        component.diffStatus && component.diffStatus !== "None"
           ? "With Diffs"
           : "No Diffs";
       groups[title]?.push(component);

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -1,3 +1,218 @@
 <template>
-  <div>test</div>
+  <section
+    v-if="ctx.onHead.value"
+    class="p-lg flex flex-col items-center gap-sm"
+  >
+    <EmptyState
+      icon="x"
+      text="You are on HEAD"
+      secondaryText="There are no changes to review"
+    />
+    <VButton
+      label="Exit"
+      tone="neutral"
+      icon="chevron--left"
+      @click="exitReview"
+    />
+  </section>
+  <section v-else class="grid review w-full h-full">
+    <div
+      :class="
+        clsx(
+          'left',
+          'flex flex-col border-r',
+          themeClasses('border-neutral-400', 'border-neutral-600'),
+        )
+      "
+    >
+      <div
+        :class="
+          clsx(
+            'h-xl flex-none w-full border-b flex flex-row items-center justify-center gap-xs [&>*]:font-bold',
+            themeClasses('border-neutral-400', 'border-neutral-600'),
+          )
+        "
+      >
+        <PillCounter :count="changedComponents.length" size="lg" hideIfZero />
+        <div class="text-xl text-center">Changed Components</div>
+      </div>
+      <div class="scrollable">
+        <div
+          v-for="component in changedComponents"
+          :key="component.id"
+          :class="
+            clsx(
+              'cursor-pointer border border-transparent',
+              themeClasses(
+                'hover:border-action-500',
+                'hover:border-action-300',
+              ),
+            )
+          "
+          @click="scrollToDiff(component.id)"
+        >
+          <ComponentCard :component="component" />
+        </div>
+      </div>
+    </div>
+    <div class="main flex flex-col">
+      <div
+        :class="
+          clsx(
+            'flex flex-row flex-none items-center w-full p-xs border-b h-xl',
+            themeClasses('border-neutral-400', 'border-neutral-600'),
+          )
+        "
+      >
+        <VButton
+          label="Exit"
+          tone="neutral"
+          icon="chevron--left"
+          class="flex-none"
+          @click="exitReview"
+        />
+        <div class="flex-1 flex flex-col gap-xs p-xs text-center items-center">
+          <div>
+            Summary of changes for change set
+            <span
+              v-if="changeSetName"
+              class="font-bold font-mono basis-0 flex-grow text-xs"
+              >"{{ changeSetName }}"</span
+            >
+          </div>
+          <div class="flex flex-row gap-xs">
+            <div>{{ addedCount }} added</div>
+            <div>{{ updatedCount }} updated</div>
+            <div>{{ removedCount }} removed</div>
+          </div>
+        </div>
+      </div>
+      <div ref="mainScrollDivRef" class="scrollable flex flex-col gap-xs px-xs">
+        <div
+          v-for="component in changedComponents"
+          :key="component.id"
+          ref="componentDiffRefs"
+          :data-component-id="component.id"
+        >
+          <CodeViewer
+            :title="`${component.name}: ${component.schemaName}`"
+            :code="changedComponentData[component.id]?.resourceDiff.diff"
+            showTitle
+            codeLanguage="diff"
+            copyTooltip="Copy diff to clipboard"
+          />
+        </div>
+      </div>
+    </div>
+  </section>
 </template>
+
+<script setup lang="ts">
+import { useQueries, useQuery } from "@tanstack/vue-query";
+import { computed, ref } from "vue";
+import clsx from "clsx";
+import { PillCounter, themeClasses, VButton } from "@si/vue-lib/design-system";
+import { useRouter } from "vue-router";
+import {
+  bifrost,
+  bifrostList,
+  useMakeArgs,
+  useMakeKey,
+} from "@/store/realtime/heimdall";
+import {
+  BifrostComponent,
+  ComponentInList,
+  EntityKind,
+} from "@/workers/types/entity_kind_types";
+import CodeViewer from "@/components/CodeViewer.vue";
+import { ComponentId } from "@/api/sdf/dal/component";
+import ComponentCard from "./ComponentCard.vue";
+import { useContext } from "./logic_composables/context";
+import EmptyState from "./EmptyState.vue";
+
+const router = useRouter();
+const ctx = useContext();
+
+const changeSetName = computed(() => ctx.changeSet.value?.name);
+
+const key = useMakeKey();
+const args = useMakeArgs();
+
+// All components on this change set
+const componentListQuery = useQuery({
+  queryKey: key(EntityKind.ComponentList),
+  enabled: ctx.queriesEnabled,
+  queryFn: async () =>
+    await bifrostList<ComponentInList[]>(args(EntityKind.ComponentList)),
+});
+const componentList = computed(() => componentListQuery.data.value ?? []);
+
+const changedComponents = computed(() =>
+  componentList.value.filter((component) => component.diffStatus !== "None"),
+);
+
+const changedComponentDataQueries = useQueries({
+  queries: computed(() =>
+    changedComponents.value.map((component) => ({
+      queryKey: key(EntityKind.Component, component.id),
+      queryFn: async () =>
+        await bifrost<BifrostComponent>(
+          args(EntityKind.Component, component.id),
+        ),
+    })),
+  ),
+});
+const changedComponentData = computed<Record<ComponentId, BifrostComponent>>(
+  () =>
+    Object.fromEntries(
+      changedComponentDataQueries.value.map((component) => [
+        component.data?.id,
+        component.data,
+      ]),
+    ),
+);
+const addedCount = computed(
+  () =>
+    changedComponents.value.filter(
+      (component) => component.diffStatus === "Added",
+    ).length,
+);
+const updatedCount = computed(
+  () =>
+    changedComponents.value.filter(
+      (component) => component.diffStatus === "Modified",
+    ).length,
+);
+const removedCount = computed(() => 0);
+
+const mainScrollDivRef = ref<HTMLDivElement>();
+const componentDiffRefs = ref<HTMLDivElement[]>();
+
+const scrollToDiff = (componentId: ComponentId) => {
+  const divEl = componentDiffRefs.value?.find(
+    (divEl) => divEl.dataset.componentId === componentId,
+  );
+  divEl?.scrollIntoView({ behavior: "smooth" });
+};
+
+const exitReview = () => {
+  router.push({
+    name: "new-hotness",
+  });
+};
+</script>
+
+<style lang="css" scoped>
+section.grid.review {
+  grid-template-columns: minmax(0, 20%) minmax(0, 80%);
+  grid-template-rows: 100%;
+  grid-template-areas: "left main";
+}
+
+div.main {
+  grid-area: "main";
+}
+div.left {
+  grid-area: "left";
+}
+</style>

--- a/app/web/src/newhotness/composables/useComponentDeletion.ts
+++ b/app/web/src/newhotness/composables/useComponentDeletion.ts
@@ -21,14 +21,14 @@ export function useComponentDeletion(viewId?: string, skipNavigation = false) {
     // Convert resourceDiff to diffStatus
     let diffStatus: ComponentDiffStatus;
     if (component.resourceDiff?.diff) {
-      diffStatus = ComponentDiffStatus.Modified;
+      diffStatus = "Modified";
     } else if (
       component.resourceDiff?.current &&
       !component.resourceDiff?.diff
     ) {
-      diffStatus = ComponentDiffStatus.Added;
+      diffStatus = "Added";
     } else {
-      diffStatus = ComponentDiffStatus.None;
+      diffStatus = "None";
     }
 
     return {

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -105,7 +105,7 @@
           <Icon name="tilde" class="text-warning-500" size="sm" />
           <div class="text-sm">Diff</div>
           <TextPill
-            v-if="component.diffStatus === ComponentDiffStatus.Added"
+            v-if="component.diffStatus === 'Added'"
             tighter
             :class="
               clsx(
@@ -120,7 +120,7 @@
             Added
           </TextPill>
           <TextPill
-            v-else-if="component.diffStatus === ComponentDiffStatus.Modified"
+            v-else-if="component.diffStatus === 'Modified'"
             tighter
             :class="
               clsx(
@@ -224,10 +224,7 @@ import {
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed, inject, ref, watch } from "vue";
-import {
-  ComponentInList,
-  ComponentDiffStatus,
-} from "@/workers/types/entity_kind_types";
+import { ComponentInList } from "@/workers/types/entity_kind_types";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "../util";
 import { assertIsDefined, Context, ExploreContext } from "../types";
@@ -267,8 +264,7 @@ const dynamicRows = computed(() => {
     props.pendingActionCounts &&
     Object.keys(props.pendingActionCounts).length > 0;
   const hasDiff =
-    props.component.diffStatus &&
-    props.component.diffStatus !== ComponentDiffStatus.None;
+    props.component.diffStatus && props.component.diffStatus !== "None";
 
   // Row 2: Resource if exists, otherwise diff if exists, otherwise empty
   if (props.component.hasResource) {

--- a/app/web/src/newhotness/logic_composables/context.ts
+++ b/app/web/src/newhotness/logic_composables/context.ts
@@ -1,6 +1,8 @@
 import { inject } from "vue";
 import { assertIsDefined, Context } from "../types";
 
+// This will only work in Vue components which are descendants of the newhotness Workspace!
+// DO NOT USE THIS IN WORKSPACE OR INSIDE OF OTHER LOGIC COMPOSABLES
 export function useContext(): Context {
   const ctx = inject<Context>("CONTEXT");
   assertIsDefined(ctx);

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -261,7 +261,7 @@ export interface BifrostComponent {
   color?: string;
   schemaName: string;
   schemaId: SchemaId;
-  // Needed for "BifrostComponentInList" usage where the "SchemaVariant" is dropped.
+  // Needed for "ComponentInList" usage where the "SchemaVariant" is dropped.
   schemaVariantId: WeakReference<EntityKind.SchemaVariant>;
   schemaVariant: SchemaVariant;
   schemaVariantName: string;
@@ -287,21 +287,17 @@ export interface BifrostComponent {
   toDelete: boolean;
 }
 
-export enum ComponentDiffStatus {
-  Added = "Added",
-  None = "None",
-  Modified = "Modified",
-}
+export type ComponentDiffStatus = "Added" | "None" | "Modified";
 
 // NOTE: when using `getMany` you don't end up with a BifrostComponent (b/c it doesnt have SchemaVariant)
-// You end up with a BifrostComponentInList
+// You end up with a ComponentInList
 export interface ComponentInList {
   id: ComponentId;
   name: string;
   color?: string;
   schemaName: string;
   schemaId: SchemaId;
-  // Needed for "BifrostComponentInList" usage where the "SchemaVariant" is dropped.
+  // Needed for "ComponentInList" usage where the "SchemaVariant" is dropped.
   schemaVariantId: SchemaVariantId;
   schemaVariantName: string;
   schemaCategory: string;


### PR DESCRIPTION
## How does this PR change the system?

A first draft of the new review page - if the feature flag is on, it can be accessed by pressing "R" on the Explore page.

This version of the review page only populates its data based on the current change set context. To get totally accurate data we will need to also pull info about Head and then eventually also check the audit log.

#### Screenshots:

<img width="1173" height="1033" alt="image" src="https://github.com/user-attachments/assets/ed43d01d-9e7a-4de8-ac95-b65791fc9d57" />