### PR TITLE
feat: hardcode AWS Account schema in the SI MCP server

### DIFF
--- a/bin/si-mcp-server/src/data/cfDb.ts
+++ b/bin/si-mcp-server/src/data/cfDb.ts
@@ -320,6 +320,20 @@ function getManualSchemaDocumentation(
           return null;
       }
 
+    case "AWS Account":
+      switch (schemaAttributePath) {
+        case "/domain/AccountData/Account":
+          return "The AWS account ID number of the account that owns or contains the calling entity.\n\nDocumentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html";
+        case "/domain/AccountData/Arn":
+          return "The AWS ARN associated with the calling entity.\n\nDocumentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html";
+        case "/domain/AccountData/UserId":
+          return "The unique identifier of the calling entity. The exact value depends on the type of entity that is making the call. The values returned are those listed in the aws:userid column in the [Principal table](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable) found on the Policy Variables reference page in the IAM User Guide.\n\nDocumentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html";
+        case "/domain/CanonicalUserId":
+          return " Canonical user ID associated with the AWS account.\n\nDocumentation: https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html";
+        default:
+          return null;
+      }
+
     default:
       return null;
   }

--- a/bin/si-mcp-server/src/tools/schemaAttributesList.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesList.ts
@@ -369,6 +369,32 @@ export function schemaAttributesListTool(server: McpServer) {
             },
           ],
         };
+      } else if (schemaName == "AWS Account") {
+        responseData = {
+          schemaName: "AWS Account",
+          "attributes": [
+            {
+              "name": "Account",
+              "path": "/domain/AccountData/Account",
+              "required": false,
+            },
+            {
+              "name": "Arn",
+              "path": "/domain/AccountData/Arn",
+              "required": false,
+            },
+            {
+              "name": "UserId",
+              "path": "/domain/AccountData/UserId",
+              "required": false,
+            },
+            {
+              "name": "CanonicalUserId",
+              "path": "/domain/CanonicalUserId",
+              "required": false,
+            },
+          ],
+        };
       } else {
         const attributes = getAttributesForService(schemaName);
         responseData = { schemaName, attributes };

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -266,6 +266,11 @@ Assume Role
 Alternatively, you can authenticate by assuming an IAM role, which provides longer-term, managed authentication. Follow the instructions in our guide: https://docs.systeminit.com/explanation/aws-authentication#assuming-a-role`;
           responseData.link =
             "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html";
+        } else if (responseData.schemaName == "AWS Account") {
+          responseData.description =
+            "You use this to get details about the AWS Account. For more information, see [AWS STS GetCallerIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html) in the *Amazon Security Token Service API Reference*.";
+          responseData.link =
+            "https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html";
         } else {
           const docs = getDocumentationForService(responseData.schemaName);
           responseData.description = docs.description;


### PR DESCRIPTION
- updates the SI MCP server to be able to find the AWS Account asset

## How does this PR change the system?

It hardcodes the AWS Account assets documentation and attributes so it can be used with the MCP server.

## How was it tested?

NEEDS TESTING

## In short: [:link:](https://giphy.com/)

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExY3RjbHplaHhpNWN3ZXh4d2V6cjcwMWpsd3E1eXZqazQ3M2JsZXdyaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/rOiEUyhRZzxcLP3leB/giphy.gif)
