### PR TITLE
Fix: if the index already exists but isnt on the change set, and its a valid move forward, push the change set forward to the existing index

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -2009,16 +2009,13 @@ const niflheim = async (
     // Use index checksum for validation - this is more reliable than snapshot addresses
     const indexChecksum = req.data.indexChecksum;
     const atoms = req.data.frontEndObject.data.mvList;
-    initIndexAndChangeSet(
-      db,
-      {
-        changeSetId,
-        workspaceId,
-        toIndexChecksum: indexChecksum,
-        fromIndexChecksum: indexChecksum,
-      },
-      frigg,
-    );
+    const meta = {
+      changeSetId,
+      workspaceId,
+      toIndexChecksum: indexChecksum,
+      fromIndexChecksum: indexChecksum,
+    };
+    initIndexAndChangeSet(db, meta, frigg);
     debug("niflheim atom count", atoms.length);
     frigg.setAttribute("numEntries", atoms.length);
     frigg.setAttribute("indexChecksum", indexChecksum);
@@ -2101,6 +2098,9 @@ const niflheim = async (
       // need to see the result
       bulkRemoveAtoms(db, atomsToUnlink, indexChecksum);
     }
+
+    // link the checksum to the change set (just in case its not done in init)
+    updateChangeSetWithNewIndex(db, meta);
 
     // Now to deal with all the atoms we don't have present. Throw the big hammer.
     if (hammerObjs.length > 0) {


### PR DESCRIPTION
Nick & Brit got into a state where:
1. browser made the new index checksum
1. browser wrote patch data for a new index
2. browser did not update the change set record to have the new index checksum

Because of the last bit, when they refreshed the page, or did a cold start, the change set wasn't getting set to the new index value. So the data that was being read was stale.

## How does this PR change the system?

During a cold start, add the call to update the change set record to the new index checksum, even though in 99% of cases it will be a no-op.

## How was it tested?

1. browser A, make a new change set, make a change
2. open browser B (literally a different browser) load the change set.
3. see the change.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaXJmaHU5aDhmYTB5Zm13bDJ1cjNka3gzMzhpOHJvazJhZml6a3FwbyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/YrEWeQHbbSmrItPF23/giphy.gif"/>