### PR TITLE
fix(web): Normalize search string to prevent filterered components from losing reactivity

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1390,8 +1390,12 @@ provide("EXPLORE_CONTEXT", exploreContext.value);
 
 // ================================================================================================
 // THE SEARCH BAR AND FILTERING
-const searchString = ref("");
-const filteredComponents = useComponentSearch(searchString, componentList);
+// searchString can be null because VormInput sets the value to null onBlur if it's an empty string
+const searchString = ref<string | null>("");
+const filteredComponents = useComponentSearch(
+  () => searchString.value ?? "",
+  componentList,
+);
 
 // Filtered components counter state
 const isScrolledToBottom = ref(false);
@@ -1401,7 +1405,7 @@ const shouldShowFilteredCounter = computed(() => {
     componentList.value.length > filteredComponents.value.length;
   return (
     hasFilteredComponents &&
-    (isScrolledToBottom.value || searchString.value.trim() !== "")
+    (isScrolledToBottom.value || (searchString.value ?? "").trim() !== "")
   );
 });
 
@@ -1421,6 +1425,7 @@ watch(searchString, () => {
   };
 
   if (!searchString.value) {
+    // if search string is empty, remove it from the URL
     delete query.searchQuery;
   } else {
     query.searchQuery = searchString.value;
@@ -1442,9 +1447,11 @@ watch(filteredComponents, () => {
   // which means the selected indexes could have moved in either direction
 });
 
+// this is so that when on the map view, if you have a component selected
+// and start searching, we clear the selected component
+// on grid view, this has no impact, because you can't focus on the search box if you've got component(s) selected
 watch(searchString, (newValue, oldValue) => {
   if (oldValue === "" && newValue === null) {
-    // this is not a real change in the search string!
     return;
   }
   if (mapRef.value && typeof mapRef.value.deselect === "function") {
@@ -2287,6 +2294,7 @@ section.grid.map {
 div.main {
   grid-area: "main";
 }
+
 div.right {
   grid-area: "right";
 }


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
This fixes a bug that can be reproduced as follows: 
- Create a change set
- Create a component
- Type something into the search bar
- backspace and delete the query
- click on the grid
- duplicate the component
- See that the count increases, but the component doesn't show up
- See this error in the console: 
``` 
main.ts:137 TypeError: Cannot read properties of null (reading '0')
    at SearchParser.consume (search.ts:380:26)
    at SearchParser.parseTerm (search.ts:296:14)
    at SearchParser.parseAndCondition (search.ts:281:30)
    at SearchParser.parseOrCondition (search.ts:265:30)
    at SearchParser.parseCondition (search.ts:254:17)
    at SearchParser.parse (search.ts:228:30)
    at parseSearchTerms (search.ts:189:35)
    at search.ts:59:25
    at async.ts:24:26
    at async.ts:48:13
mapStackTrace.cacheGlobally	@	main.ts:137
app.config.errorHandler	@	main.ts:130
Promise.then		
bustTanStackCache	@	heimdall.ts:220
``` 
- type something else in the search bar
- delete it
- see the component on the grid!

This happens because of the following chain of events:
1. Type in search
2. Delete all the text (making `searchString.value === ""`) 
3. Unfocus the search bar (which triggers `onBlur`)
4. `onBlur` calls `cleanValue("")`
5. `cleanValue("")` returns null 
6. This emits `update:modelValue` with `null`
7. The `searchString becomes `null` 
8. The search composable only expects `string | undefined ` 

By normalizing `searchString.value = ""` when `VormInput` sets it to `null` this fixes the bug!

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Out of Scope:
Any changes to `VormInput` :) 
<!-- Anything this PR explicitly leaves out? -->

## How was it tested?
Manually! 
Many permutations of searching, deleting search terms, duplicating/deleting components (things that will impact the grid), and seeing all of those changes flow in as expected, regardless of the search value! 


## In short: [:link:](https://giphy.com/)
<div><img src="https://media3.giphy.com/media/QX6tXumZ2Q4rpvWIJ2/200w.gif?cid=5a38a5a27xrqk7133zbxz1p6rxz66k2x71zm2ltc5ajvfjj0&amp;ep=v1_gifs_search&amp;rid=200w.gif&amp;ct=g&amp;epb=ad.kevel.da5484cc97f8" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/cbc/">CBC</a> on <a href="https://giphy.com/gifs/cbc-schitts-creek-QX6tXumZ2Q4rpvWIJ2">GIPHY</a></div>
