### PR TITLE
Fix apply button going off screen for approvals

### DIFF
--- a/app/web/src/newhotness/ApplyChangeSetModal.vue
+++ b/app/web/src/newhotness/ApplyChangeSetModal.vue
@@ -16,7 +16,12 @@
           in the cloud. These actions will be applied to the real world:
         </div>
         <div
-          class="flex-grow overflow-y-auto mb-sm border border-neutral-100 dark:border-neutral-700"
+          :class="
+            clsx(
+              'flex-grow overflow-y-auto mb-sm border border-neutral-100 dark:border-neutral-700',
+              approvalsEnabled && 'max-h-[36vh]',
+            )
+          "
         >
           <div class="flex flex-row py-xs">
             <span class="ml-xs text-md">{{ actionsTitle }}</span>

--- a/app/web/src/newhotness/ApprovalFlow.vue
+++ b/app/web/src/newhotness/ApprovalFlow.vue
@@ -3,8 +3,8 @@
     v-if="status !== 'unexpected'"
     :class="
       clsx(
-        'flex flex-col gap-sm p-sm',
-        'rounded shadow-2xl overflow-hidden',
+        'flex flex-col gap-sm p-sm overflow-y-auto',
+        'rounded shadow-2xl',
         themeClasses('bg-shade-0 border', 'bg-neutral-900'),
       )
     "
@@ -45,16 +45,8 @@
       </ErrorMessage>
     </div>
 
-    <div
-      :class="
-        clsx('flex flex-row gap-xs flex-1 overflow-hidden place-content-evenly')
-      "
-    >
-      <div
-        :class="
-          clsx('flex flex-col gap-xs overflow-hidden text-center basis-1/2')
-        "
-      >
+    <div :class="clsx('flex flex-row gap-xs flex-1 place-content-evenly')">
+      <div :class="clsx('flex flex-col gap-xs text-center basis-1/2')">
         <RouterLink
           :to="{
             name: 'workspace-audit',
@@ -73,11 +65,7 @@
     </div>
 
     <!-- MAIN SECTION -->
-    <div
-      :class="
-        clsx('flex flex-row gap-xs flex-1 overflow-hidden place-content-evenly')
-      "
-    >
+    <div :class="clsx('flex flex-row gap-xs flex-1 place-content-evenly')">
       <div class="flex flex-col basis-1/2 text-sm gap-xs overflow-y-auto">
         <div
           v-for="group in requirementGroups"


### PR DESCRIPTION
## Description

When the actions list is too long, the apply button goes off screen for approvals. This wasn't caught because the list has to be ~20 actions long and the original PR restoring approvals tested this with ~10 actions.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbTBldTh1d3QyZXdjaXFoZnB3MXR0eWV0eHJkczl5YWRlamhzZDQyYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/13zeE9qQNC5IKk/giphy.gif"/>

## Screenshots

Request with one action:

<img width="460" height="343" alt="Screenshot 2025-08-15 at 11 57 07 AM" src="https://github.com/user-attachments/assets/06e546b3-6653-4c30-916f-22da137cbede" />

Awaiting approval with one action:

<img width="815" height="444" alt="Screenshot 2025-08-15 at 11 57 03 AM" src="https://github.com/user-attachments/assets/1205ec3a-3fe2-4225-9cff-5a98b4f0afa6" />

Awaiting approval with 72 actions:

<img width="757" height="733" alt="Screenshot 2025-08-15 at 11 54 49 AM" src="https://github.com/user-attachments/assets/6fe55c32-e8de-452f-a490-f414f6b6cca8" />


