### PR TITLE
fix(dal): if conn state is invalid, error instead of panicking

### DIFF
--- a/lib/si-db/src/transactions.rs
+++ b/lib/si-db/src/transactions.rs
@@ -14,6 +14,8 @@ pub trait SiDbTransactions {
 #[remain::sorted]
 #[derive(Debug, Error, strum::EnumDiscriminants)]
 pub enum SiDbTransactionsError {
+    #[error("cannot use transactions when connection state invalid")]
+    ConnStateInvalid,
     #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("cannot start transactions without connections; state={0}")]


### PR DESCRIPTION
We're seeing panics in production in `txns`, which could only happen if the connection state is "invalid". We're investigating why the state is invalid after we try to run a transaction, but panicking is the wrong thing to do here, no matter what. So let's produce an error instead of panicking.
