### PR TITLE
Fix faded apply change set

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -4,12 +4,12 @@ export enum ChangeSetStatus {
   Open = "Open",
   Applied = "Applied",
   Failed = "Failed",
-  Closed = "Closed",
+  Closed = "Closed", // FIXME(nick): DEAD, LIKELY CAN BE DELETED
   Abandoned = "Abandoned",
   NeedsApproval = "NeedsApproval",
-  NeedsAbandonApproval = "NeedsAbandonApproval",
-  Rejected = "Rejected",
-  Approved = "Approved",
+  NeedsAbandonApproval = "NeedsAbandonApproval", // FIXME(nick): DEPRECATED, GET RID OF THIS, MAY NEED MIGRATION
+  Rejected = "Rejected", // FIXME(nick): DEPRECATED, GET RID OF THIS, MAY NEED MIGRATION
+  Approved = "Approved", // FIXME(nick): DEPRECATED, GET RID OF THIS, MAY NEED MIGRATION
 }
 
 export type ChangeSetId = string;

--- a/app/web/src/newhotness/ApplyChangeSetButton.vue
+++ b/app/web/src/newhotness/ApplyChangeSetButton.vue
@@ -15,7 +15,6 @@
       "
       loadingText="Applying Changes"
       :loading="applyInFlight"
-      :disabled="disallowApply"
       @click="openApplyChangeSetModal"
     >
       <template #iconRight>
@@ -80,7 +79,7 @@ watchEffect(() => {
   }
 });
 
-const { applyInFlight, disallowApply } = useApplyChangeSet(ctx);
+const { applyInFlight } = useApplyChangeSet(ctx);
 
 const key = useMakeKey();
 const args = useMakeArgs();

--- a/app/web/src/newhotness/StatusPanel.vue
+++ b/app/web/src/newhotness/StatusPanel.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="mt-xs ml-xs relative">
-    <StatusPanelIcon :status="status" @faded="() => (status = undefined)" />
+    <StatusPanelIcon
+      :status="status[changeSetId]"
+      @faded="() => delete status[changeSetId]"
+    />
   </div>
 </template>
 
@@ -8,12 +11,12 @@
 import {
   computed,
   ref,
-  reactive,
   watch,
   onMounted,
   onUnmounted,
   unref,
   onBeforeUnmount,
+  reactive,
 } from "vue";
 import { useQuery } from "@tanstack/vue-query";
 import StatusPanelIcon from "@/newhotness/StatusPanelIcon.vue";
@@ -24,15 +27,24 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { useRainbow } from "@/newhotness/logic_composables/rainbow_counter";
 import { useRealtimeStore } from "@/store/realtime/realtime.store";
+import { ChangeSetId, ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import { useStatus } from "./logic_composables/status";
 import { useContext } from "./logic_composables/context";
 
 const realtimeStore = useRealtimeStore();
 
 const ctx = useContext();
+const changeSetId = computed(() => ctx.changeSetId.value);
+
+export type PerChangeSet = Record<string, number>;
+const superBucket = reactive<Record<ChangeSetId, PerChangeSet>>({});
 
 const status = useStatus();
-const bucket = reactive<Record<string, number>>({});
+const bucketIsEmpty = computed(() => {
+  const k = Object.keys(superBucket[changeSetId.value] ?? {});
+  return k.length < 1;
+});
+
 const trigger = ref<boolean>(false);
 
 const timeoutMs = 30000;
@@ -58,96 +70,127 @@ watch(
   (newComponentsInFlight) => {
     if (newComponentsInFlight.length > 0) {
       // BUCKET ITEM -- ADD -- COMPONENTS IN FLIGHT, DVU ROOTS, ETC.
+      let bucket = superBucket[changeSetId.value];
+      if (!bucket) {
+        bucket = {};
+        superBucket[changeSetId.value] = bucket;
+      }
       bucket.componentsInFlight = Date.now();
     } else if (
       newComponentsInFlight.length === 0 &&
-      bucket.componentsInFlight
+      superBucket[changeSetId.value]?.componentsInFlight
     ) {
       // BUCKET ITEM -- REMOVE -- COMPONENTS IN FLIGHT, DVU ROOTS, ETC.
-      delete bucket.componentsInFlight;
+      delete superBucket[changeSetId.value]?.componentsInFlight;
     }
   },
 );
 
-const rainbow = useRainbow();
+const rainbow = useRainbow(changeSetId);
 watch(
   () => rainbow.value,
   (newRainbow) => {
     const count = unref(newRainbow.count);
     if (count > 0) {
       // BUCKET ITEM -- ADD -- RAINBOW, MATERIALIZED VIEWS, ETC.
+      let bucket = superBucket[changeSetId.value];
+      if (!bucket) {
+        bucket = {};
+        superBucket[changeSetId.value] = bucket;
+      }
       bucket.rainbow = Date.now();
-    } else if (count === 0 && bucket.rainbow) {
+    } else if (count === 0 && superBucket[changeSetId.value]?.rainbow) {
       // BUCKET ITEM -- REMOVE -- RAINBOW, MATERIALIZED VIEWS, ETC.
-      delete bucket.rainbow;
+      delete superBucket[changeSetId.value]?.rainbow;
     }
   },
+  { deep: true },
 );
 
 const STATUS_PANEL_KEY = "statusPanel";
-const changeSetId = computed(() => ctx.changeSetId.value);
-watch(
-  () => changeSetId.value,
-  () => {
-    realtimeStore.unsubscribe(STATUS_PANEL_KEY);
-    realtimeStore.subscribe(
-      STATUS_PANEL_KEY,
-      `changeset/${changeSetId.value}`,
-      [
-        {
-          eventType: "ManagementOperationsComplete",
-          callback: async (payload) => {
-            if (!payload.requestUlid) return;
-            const key = `management-${payload.requestUlid}`;
-            if (bucket[key]) {
-              // BUCKET ITEM -- REMOVE -- MANAGEMENT FUNCS
-              delete bucket[key];
-            }
-          },
-        },
-        {
-          eventType: "ManagementOperationsFailed",
-          callback: async (payload) => {
-            // BUCKET ITEM -- ADD -- MANAGEMENT FUNCS
-            const key = `management-${payload.requestUlid}`;
-            bucket[key] = Date.now();
-          },
-        },
-        {
-          eventType: "ManagementOperationsInProgress",
-          callback: async (payload) => {
-            // BUCKET ITEM -- ADD -- MANAGEMENT FUNCS
-            const key = `management-${payload.requestUlid}`;
-            bucket[key] = Date.now();
-          },
-        },
-      ],
-    );
-  },
+realtimeStore.subscribe(
+  STATUS_PANEL_KEY,
+  `workspace/${ctx.workspacePk.value}`,
+  [
+    {
+      eventType: "ChangeSetStatusChanged",
+      callback: async (data) => {
+        if (
+          [
+            ChangeSetStatus.Abandoned,
+            ChangeSetStatus.Applied,
+            ChangeSetStatus.Closed,
+          ].includes(data.changeSet.status) &&
+          data.changeSet.id !== ctx.headChangeSetId.value
+        ) {
+          if (status[data.changeSet.id]) {
+            delete status[data.changeSet.id];
+          }
+          delete superBucket[data.changeSet.id];
+        }
+      },
+    },
+    {
+      eventType: "ManagementOperationsComplete",
+      callback: async (payload, meta) => {
+        if (!payload.requestUlid) return;
+        const key = `management-${payload.requestUlid}`;
+        if (superBucket[meta.change_set_id]?.[key]) {
+          // BUCKET ITEM -- REMOVE -- MANAGEMENT FUNCS
+          delete superBucket[meta.change_set_id]?.[key];
+        }
+      },
+    },
+    {
+      eventType: "ManagementOperationsFailed",
+      callback: async (payload, meta) => {
+        // BUCKET ITEM -- ADD -- MANAGEMENT FUNCS
+        const key = `management-${payload.requestUlid}`;
+        let bucket = superBucket[meta.change_set_id];
+        if (!bucket) {
+          bucket = {};
+          superBucket[meta.change_set_id] = bucket;
+        }
+        bucket[key] = Date.now();
+      },
+    },
+    {
+      eventType: "ManagementOperationsInProgress",
+      callback: async (payload, meta) => {
+        // BUCKET ITEM -- ADD -- MANAGEMENT FUNCS
+        const key = `management-${payload.requestUlid}`;
+        let bucket = superBucket[meta.change_set_id];
+        if (!bucket) {
+          bucket = {};
+          superBucket[meta.change_set_id] = bucket;
+        }
+        bucket[key] = Date.now();
+      },
+    },
+  ],
 );
 
 // This watcher ejects expired items.
-watch([trigger], () => {
+watch([trigger, changeSetId.value], () => {
   const now = Date.now();
 
-  for (const [key, value] of Object.entries(bucket)) {
+  for (const [key, value] of Object.entries(
+    superBucket[changeSetId.value] ?? {},
+  )) {
     if (now - value > timeoutMs) {
-      delete bucket[key];
+      delete superBucket[changeSetId.value]?.[key];
     }
   }
 });
 
 // This watcher updates the status based on the state of the bucket.
-watch(
-  () => ({ ...bucket }),
-  (newBucket) => {
-    if (Object.keys(newBucket).length < 1) {
-      status.value = "synced";
-    } else {
-      status.value = "syncing";
-    }
-  },
-);
+watch(bucketIsEmpty, (newBucketIsEmpty) => {
+  if (newBucketIsEmpty) {
+    status[changeSetId.value] = "synced";
+  } else {
+    status[changeSetId.value] = "syncing";
+  }
+});
 
 onMounted(() => {
   const interval = setInterval(() => {

--- a/app/web/src/newhotness/logic_composables/change_set.ts
+++ b/app/web/src/newhotness/logic_composables/change_set.ts
@@ -6,7 +6,6 @@ import { ChangeSetId, ChangeSetStatus } from "@/api/sdf/dal/change_set";
 import { WorkspaceMetadata } from "@/api/sdf/dal/workspace";
 import { ApprovalData, Context, UserId } from "../types";
 import { routes, useApi } from "../api_composables";
-import { useStatus } from "./status";
 import { reset } from "./navigation_stack";
 
 /**
@@ -71,23 +70,16 @@ export const useChangeSets = (
 
 export const useApplyChangeSet = (ctx: Context) => {
   const api = useApi(ctx);
-  const status = useStatus();
 
   const applyInFlight = computed(() => api.inFlight.value);
+
   const performApply = async () => {
     const call = api.endpoint(routes.ApplyChangeSet);
     const { req } = await call.post({});
     return { success: api.ok(req) };
   };
-  const disallowApply = computed(
-    () =>
-      (ctx.changeSet.value?.status !== ChangeSetStatus.Open &&
-        ctx.changeSet.value?.status !== ChangeSetStatus.NeedsApproval) ||
-      ctx.onHead.value ||
-      status.value === "syncing",
-  );
 
-  return { performApply, applyInFlight, disallowApply };
+  return { performApply, applyInFlight };
 };
 
 export const navigateToExistingChangeSet = async (

--- a/app/web/src/newhotness/logic_composables/rainbow_counter.ts
+++ b/app/web/src/newhotness/logic_composables/rainbow_counter.ts
@@ -1,6 +1,6 @@
-import { computed, inject, reactive } from "vue";
+import { computed, ComputedRef, reactive } from "vue";
 import { DefaultMap } from "@/utils/defaultmap";
-import { assertIsDefined, Context } from "../types";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
 
 const queueByChangeSet = new DefaultMap<string, Set<string>>(() => {
   return reactive(new Set<string>());
@@ -16,13 +16,10 @@ export const remove = (changeSetId: string, desc: string) => {
   if (queue) queue.delete(desc);
 };
 
-export const useRainbow = () => {
+export const useRainbow = (changeSetId: ComputedRef<ChangeSetId>) => {
   return computed(() => {
     try {
-      const ctx = inject<Context>("CONTEXT");
-      assertIsDefined(ctx);
-
-      const queue = queueByChangeSet.get(ctx.changeSetId.value);
+      const queue = queueByChangeSet.get(changeSetId.value);
 
       /**
        * This is a global "stuff is happening" counter

--- a/app/web/src/newhotness/logic_composables/status.ts
+++ b/app/web/src/newhotness/logic_composables/status.ts
@@ -1,6 +1,7 @@
-import { ref } from "vue";
+import { reactive } from "vue";
+import { ChangeSetId } from "@/api/sdf/dal/change_set";
 
-const status = ref<"syncing" | "synced" | undefined>(undefined);
+const status = reactive<Record<ChangeSetId, "syncing" | "synced">>({});
 
 export function useStatus() {
   return status;


### PR DESCRIPTION
## Introduction

This change fixes the faded apply change set bug hopefully once and for all. I could not reproduce the bug locally, but it is now easy to see how (structurally) the bug could happen. In every instance of the bug happening, the spinner was not moving. We believe that because the status panel was not scoped to change sets, it would be very easy to get into a de-synced state.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzhoMW1ibHA1MmZlZ3MzZjh1azF2OTkydG9qMHoxZnYwOTB6OXZpeiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3EAKxlmEhkEqRymYnK/giphy.gif"/>

## Primary Changes

- Make "status" a reactive record instead of a ref so that it can work for multiple change sets
- Make a super bucket that tracks the bucket of each change set
- Don't disable the button that brings up the modal pretty much ever (we already remove the button when on HEAD)
- Add deep=true for the rainbow watcher for increased UX

## Secondary Changes

- Split the request approval and apply buttons in the modal to reduce confusion (the original was flooded with conditionals)
- Add "useStatus" to the approval flow since it is in the standard apply flow
- Mark dead or deprecated change set statuses

## Bugs Fixed Along the Way

- #6947
- #6944 
- #6943

## Screenshots?

It looks exactly as it does today.

## Testing

- With two users in two browsers (owner and collaborator), apply change sets with each user involving a non-trivial number of components and actions
- See the faded button while the status indicator is on when the modal is open for each user (swap with each apply)
- Now, do the same test, but with approvals enabled
- The same functionality happens, but with the approval flow in the mix
- No faded change set apply button is observed when the status indicator isn't on