### PR TITLE
fix(sdf-api-tests):let's bump the timeout to 60 seconds here for now

### DIFF
--- a/bin/si-sdf-api-test/test_helpers.ts
+++ b/bin/si-sdf-api-test/test_helpers.ts
@@ -431,7 +431,7 @@ export async function eventualMVAssert(
   id: string,
   assertFn: (mv: any) => boolean,
   message: string,
-  timeoutMs: number = 45000, // 45 seconds
+  timeoutMs: number = 60000, // 60 seconds
 
 ): Promise<void> {
   // update this to use sdf.mjolnir and retryUntil 

--- a/bin/si-sdf-api-test/tests/4-create_two_components_connect_and_propagate.ts
+++ b/bin/si-sdf-api-test/tests/4-create_two_components_connect_and_propagate.ts
@@ -120,6 +120,7 @@ async function create_two_components_connect_and_propagate_inner(
       )
     ,
     "Expected propagated region value on EC2 Instance to match source",
+    90000, // give it 90 seconds to make it's way through dvu
   );
 
   // Now remove the subscription and verify the value is no longer propagated


### PR DESCRIPTION
We're getting sporadic timeouts across a few tests, seemingly more in Tools Prod than Prod. I'm increasing the timeout for now and can get more granular after more evidence. 

Also bumping some of the checks that need to wait for dvu to be 90 seconds

<div><img src="https://media0.giphy.com/media/2kWV5Xny049YX6kqts/200.gif?cid=5a38a5a2lnj5i5yhrf2zz2f6misz4527s1hy04lefts44h6b&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g&amp;epb=ad.kevel.f7d8c18e9bba" style="border:0;height:149px;width:300px"/><br/>via <a href="https://giphy.com/teamcoco/">Team Coco</a> on <a href="https://giphy.com/gifs/teamcoco-conan-italy-2kWV5Xny049YX6kqts">GIPHY</a></div>