### PR TITLE
Use an AWS account for the public API "how-to"

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -17,7 +17,6 @@ Above all, for any and all questions related to either using or developing the s
 - [Development Environment](#development-environment)
 - [Troubleshooting](#troubleshooting)
 - [Running the Stack Locally](#running-the-stack-locally)
-- [Using LocalStack for Secrets and Credentials](#using-localstack-for-secrets-and-credentials)
 - [Using buck2](#using-buck2)
 - [Reading and Writing Rust-based Code Documentation](#reading-and-writing-rust-based-code-documentation)
 - [Learning About SI Concepts](#learning-about-si-concepts)
@@ -280,26 +279,6 @@ TILT_HOST=0.0.0.0 DEV_HOST=0.0.0.0 buck2 run dev:up
 > [!NOTE]
 > Unless you are using "localhost", your remote workspace must be accessible using SSL.
 > For example, if you are using [Tailscale](https://tailscale.com/) and running SI on a remote instance without SSL, you may want to port foward over SSH and use a local development workspace instead.
-
-# Using LocalStack for Secrets and Credentials
-
-This section contains information related to using [LocalStack](https://github.com/localstack/localstack) when working on the System Initiative software.
-
-## How to Use with the "AWS Credential" Builtin `SchemaVariant`
-
-You can use the "AWS Credential" builtin `SchemaVariant` with LocalStack when running the System Initiative software with the following command:
-
-```shell
-buck2 run //dev:up
-```
-
-To use LocalStack with "AWS Credential", do the following:
-
-1. Create a `Component` using the `SchemaVariant`.
-1. Create a `Secret` and use it in the property editor.
-1. Populate `http://localhost:4566` (or `http://0.0.0.0:4566`, depending on your system) in the "Endpoint" field for the `Secret`.
-
-Now, you can use LocalStack in your development setup.
 
 # Using buck2
 

--- a/app/docs/src/how-tos/use-public-api.md
+++ b/app/docs/src/how-tos/use-public-api.md
@@ -10,6 +10,7 @@ This how-to assumes:
 - Basic [familiarity with System Initiative](../tutorials/getting-started)
 - Have generated a
   [workspace scoped API token](../explanation/generate-a-workspace-api-token)
+- Access to an AWS account
 
 It will teach you how to use the
 [System Initiative Public API](../reference/public-api) to manage your
@@ -231,20 +232,19 @@ def main():
         credential_component_id = credential_component_data["component"]["id"]
         print(f'AWS Credential created with ID: {credential_component_id}')
 
-        print('3. Creating Localstack secret')
+        print('3. Creating secret using AWS account')
         create_secret(change_set_id,
                 "demo-credential", # SecretName
                 "AWS Credential",  # SecretDefinitionName
                 {
-                    # If you are setting real credentials
-                    # please read these from environment variables to ensure
-                    # that we don't hard code credentials in our application
-                    "AccessKeyId": "test",
-                    "SecretAccessKey": "test",
-                    "Endpoint": "http://localstack.dev"
+                    # FIXME: set environment variables and read from them here to
+                    # ensure that we don't hard code credentials in our application
+                    "AccessKeyId": "<your-access-key-id-via-environment-variable>",
+                    "SecretAccessKey": "<your-secret-access-key-via-environment-variable>",
+                    "SessionToken": "<your-session-token-via-environment-variable>"
                 })
 
-        print('4. Setting Localstack secret to AWS Credential component')
+        print('4. Setting secret to AWS Credential component')
         update_component(change_set_id, credential_component_id, {
             'secrets': {
                 'AWS Credential': 'demo-credential'
@@ -268,8 +268,8 @@ Getting started with the System Initiative Public API
 Change set ID: 01JWATWKKQZQEN7KGWAXNZRSEA
 2. Creating AWS Credential
 AWS Credential created with ID: 01JWATWM7NR32CK2ATRDYRXM63
-3. Creating Localstack secret
-4. Setting Localstack secret to AWS Credential component
+3. Creating secret using AWS account
+4. Setting secret to AWS Credential component
 (venv)
 ```
 
@@ -390,8 +390,8 @@ Getting started with the System Initiative Public API
 Change set ID: 01JWAVDGMEDYK1TRJJVQMQ6ACN
 2. Creating AWS Credential
 AWS Credential created with ID: 01JWAVDH83NJWJ1K2X5DXWEQ8M
-3. Creating Localstack secret
-4. Setting Localstack secret to AWS Credential component
+3. Creating secret using AWS account
+4. Setting secret to AWS Credential component
 5. Creating Region
 Region created with ID: 01JWAVDK6T7TP47H33PJZFXA90
 6. Creating AWS Standard VPC Template
@@ -509,17 +509,19 @@ def main():
         credential_component_id = credential_component_data["component"]["id"]
         print(f'AWS Credential created with ID: {credential_component_id}')
 
-        print('3. Creating Localstack secret')
+        print('3. Creating secret using AWS account')
         create_secret(change_set_id,
                 "demo-credential",
                 "AWS Credential",
                 {
-                    "AccessKeyId": "test",
-                    "SecretAccessKey": "test",
-                    "Endpoint": "http://localstack.keeb.dev"
+                    # FIXME: set environment variables and read from them here to
+                    # ensure that we don't hard code credentials in our application
+                    "AccessKeyId": "<your-access-key-id-via-environment-variable>",
+                    "SecretAccessKey": "<your-secret-access-key-via-environment-variable>",
+                    "SessionToken": "<your-session-token-via-environment-variable>"
                 })
 
-        print('4. Setting Localstack secret to AWS Credential component')
+        print('4. Setting secret to AWS Credential component')
         update_component(change_set_id, credential_component_id, {
             'secrets': {
                 'AWS Credential': 'demo-credential'
@@ -775,14 +777,16 @@ async function main(): Promise<void> {
     const credentialComponentId = credentialComponentData.component.id;
     console.log(`AWS Credential created with ID: ${credentialComponentId}`);
 
-    console.log("Creating Localstack secret");
+    console.log("Creating secret using AWS account");
     await createSecret(changeSetId, "demo-credential", "AWS Credential", {
-      AccessKeyId: "test",
-      SecretAccessKey: "test",
-      Endpoint: "http://localstack.dev",
+      // FIXME: set environment variables and read from them here to
+      // ensure that we don't hard code credentials in our application
+      "AccessKeyId": "<your-access-key-id-via-environment-variable>",
+      "SecretAccessKey": "<your-secret-access-key-via-environment-variable>",
+      "SessionToken": "<your-session-token-via-environment-variable>"
     });
 
-    console.log("4. Setting Localstack secret to AWS Credential component");
+    console.log("4. Setting secret to AWS Credential component");
     await updateComponent(changeSetId, credentialComponentId, {
       secrets: {
         "AWS Credential": "demo-credential",


### PR DESCRIPTION
This change makes the public API "how-to" use a real API test. In addition, the "DOCS" have been updated to reflect this change.