### PR TITLE
feat(dal): Add the internals to create si/tags prop

### DIFF
--- a/lib/dal/src/schema/variant/root_prop.rs
+++ b/lib/dal/src/schema/variant/root_prop.rs
@@ -300,6 +300,10 @@ impl RootProp {
         // useful for importing an existing resource from reality into the model
         Prop::new_without_ui_optionals(ctx, "resourceId", PropKind::String, si_prop.id()).await?;
 
+        let tags_prop =
+            Prop::new_without_ui_optionals(ctx, "tags", PropKind::Map, si_prop.id()).await?;
+        Prop::new_without_ui_optionals(ctx, "tag", PropKind::String, tags_prop.id()).await?;
+
         Ok(si_prop.id())
     }
 

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -498,6 +498,8 @@ async fn for_intrinsics(ctx: &mut DalContext) {
         PropPath::new(["root", "si"]),
         PropPath::new(["root", "si", "protected"]),
         PropPath::new(["root", "si", "resourceId"]),
+        PropPath::new(["root", "si", "tags"]),
+        PropPath::new(["root", "si", "tags", "tag"]),
         PropPath::new(["root", "secrets"]),
         PropPath::new(["root", "resource"]),
         PropPath::new(["root", "resource", "message"]),

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -183,6 +183,8 @@ async fn all_prop_ids(ctx: &DalContext) {
         "root/si/name",
         "root/si/protected",
         "root/si/resourceId",
+        "root/si/tags",
+        "root/si/tags/tag",
         "root/si/type",
     ];
     assert_eq!(


### PR DESCRIPTION
This enables us to build a tagging interface that sits agnostic of cloud
resource tagging and will work for any components

Putting this out there now so that as schema upgrades happen for users, they will be able to take advantage of this new prop that greats created on upgrade

enables us to do something like:

<img width="918" height="329" alt="Screenshot 2025-08-16 at 00 57 55" src="https://github.com/user-attachments/assets/3d8870d2-11c3-42a9-bde3-7e34b88e171a" />
