### PR TITLE
chore(dal, rebaser): add instrumentation to capture post rebase activities

### DIFF
--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -369,7 +369,10 @@ async fn rebase_legacy(
         .await?;
 
     debug!("updates complete: {:?}", start.elapsed());
-
+    span.record(
+        "si.rebase.perform_updates_time",
+        start.elapsed().as_millis(),
+    );
     if !corrected_updates.is_empty() {
         // Once all updates have been performed, we can write out, and update the pointer.
         to_rebase_workspace_snapshot.write(ctx).await?;


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
Adds instrumentation so we can see what's going on after `perform_rebase` is done. Also adds some metrics to try and correlate timings a bit more easily. 
<!-- Why: briefly what problem this solves and what the aim is as an overview -->


## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

Manually! 

I can see all of the new fields when I apply a change set, (for postprocessing the rebase request, which we currently have no visibility into) and the other ones I added, I validated I can see them without applying a change set.  

<div><img src="https://media2.giphy.com/media/gDcYqye9fh3QH3sGSl/giphy.gif?cid=5a38a5a23lmzgw45hhe52jsqz40fnqql143lefh4z9d9mkfn&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g&amp;epb=ad.kevel.7e1cfc803d7a" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/hbo/">HBO</a> on <a href="https://giphy.com/gifs/hbo-hbo-max-the-last-of-us-tlou-gDcYqye9fh3QH3sGSl">GIPHY</a></div>
