### PR TITLE
Add browser support and fix getting started warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ buck2 run dev:stop
 
 To log into SI locally, you need to create a new Workspace of type `Local Dev Instance` and select it at `https://auth.systeminit.com/workspaces`.
 
+> [!NOTE]
+> SI is developed in compliance with modern web standards, but the only officially supported browsers are Chrome and Firefox.
+> If you encounter issues while using another browser, we recommend switching to one of the supported options.
+
 ## Where Do I Learn More?
 
 For more information on how to use and develop the System Initiative software, talk to us on

--- a/app/docs/src/tutorials/getting-started.md
+++ b/app/docs/src/tutorials/getting-started.md
@@ -14,10 +14,12 @@ To follow along, you'll need three things:
 
 3. Your System Initiative workspace open in another window.
 
-::: warning Your AWS account must have a
-[Default VPC](https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html)
-to complete the quick start guide. Most accounts do!
+::: warning Your AWS account must have a [Default VPC](https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html) to complete the quick start guide.
+Most accounts do!
+:::
 
+::: info SI is developed in compliance with modern web standards, but the only officially supported browsers are Chrome and Firefox.
+If you encounter issues while using another browser, we recommend switching to one of the supported options.
 :::
 
 ## Keyboard Controls


### PR DESCRIPTION
## Description

This change adds browser support clarification to bo the repository README and the docs site "getting started" page. This change also fixes the broken "warning" panel text above it (split sentence).

## Testing

I ran the docs page locally to get the screenshot.

## Docs Site Screenshot

<img width="807" height="625" alt="Screenshot 2025-08-18 at 1 35 45 PM" src="https://github.com/user-attachments/assets/92aa8b34-83cb-426f-91eb-a68301d91da9" />