### PR TITLE
feat: Create change set CIA (create_initialize_apply) endpoint for onboarding flow

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -219,6 +219,16 @@
                       href="https://docs.systeminit.com/reference/public-api"
                       target="_blank"
                     />
+                    <VButton
+                      v-if="
+                        featureFlagsStore.INITIALIZER_ONBOARD &&
+                        ctx.onHead.value
+                      "
+                      label="Initialize your Workspace"
+                      tone="action"
+                      size="sm"
+                      @click="openOnboardModal"
+                    />
                   </div>
                 </template>
               </EmptyState>
@@ -467,6 +477,7 @@
       @pin="(c) => (gridMode = { mode: 'pinned', label: '', componentId: c })"
       @bulk="startBulkEdit"
     />
+    <OnboardModal ref="onboardModalRef" />
   </section>
 </template>
 
@@ -522,6 +533,7 @@ import ExploreGridSkeleton from "@/newhotness/skeletons/ExploreGridSkeleton.vue"
 import ExploreRightColumnSkeleton from "@/newhotness/skeletons/ExploreRightColumnSkeleton.vue";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import OnboardModal from "@/newhotness/OnboardModal.vue";
 import MapComponent from "./Map.vue";
 import {
   collapsingGridStyles,
@@ -565,6 +577,7 @@ import { useDefaultSubscription } from "./logic_composables/default_subscription
 import { useContext } from "./logic_composables/context";
 
 const featureFlagsStore = useFeatureFlagsStore();
+
 const router = useRouter();
 const route = useRoute();
 const ctx = useContext();
@@ -2402,6 +2415,12 @@ const addViewModalRef = ref<InstanceType<typeof AddViewModal>>();
 
 const openAddViewModal = () => {
   addViewModalRef.value?.open();
+};
+
+const onboardModalRef = ref<InstanceType<typeof AddViewModal>>();
+
+const openOnboardModal = () => {
+  onboardModalRef.value?.open();
 };
 
 const editViewModalRef = ref<InstanceType<typeof EditViewModal>>();

--- a/app/web/src/newhotness/OnboardModal.vue
+++ b/app/web/src/newhotness/OnboardModal.vue
@@ -1,0 +1,227 @@
+<!--  This whole component is very verbose and unoptimized, since it's made for the demo only  -->
+<template>
+  <ConfirmModal
+    ref="modalRef"
+    title="Initialize Workspace"
+    confirmLabel="Initialize"
+    size="2xl"
+    @confirm="runOnboardRequest"
+    @keydown.enter="runOnboardRequest"
+  >
+    <ErrorMessage v-if="requestError">{{ requestError }}</ErrorMessage>
+    <div
+      v-for="(field, idx) in formStructure"
+      :key="idx"
+      :class="
+        clsx(
+          'flex flex-row justify-between text-sm',
+          field.ref === undefined && 'border-b border-neutral-400 pb-xs',
+        )
+      "
+    >
+      <template v-if="field.ref">
+        <span class="mt-xs">
+          {{ field.title }} {{ field.required ? "*" : "" }}
+        </span>
+        <div class="w-3/5 flex flex-col gap-2xs">
+          <input
+            v-model="field.ref.value"
+            :type="field.type ?? 'text'"
+            :class="
+              clsx(
+                'h-lg p-xs text-sm border font-mono cursor-text',
+                'focus:outline-none focus:ring-0 focus:z-10',
+                themeClasses(
+                  'text-shade-100 bg-white border-neutral-400 focus:border-action-500',
+                  'text-shade-0 bg-black border-neutral-600 focus:border-action-300',
+                ),
+              )
+            "
+            @paste="(ev: ClipboardEvent) => tryMatchOnPaste(ev, field)"
+          />
+          <span class="text-xs text-neutral-400">
+            {{ field.hint }}
+          </span>
+        </div>
+      </template>
+      <template v-else>
+        <span class="mt-xs font-bold text-md">
+          {{ field.title }}
+        </span>
+        <div class="text-xs text-neutral-400 w-3/5">
+          {{ field.hint }}
+        </div>
+      </template>
+    </div>
+  </ConfirmModal>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import {
+  Modal,
+  useModal,
+  ErrorMessage,
+  themeClasses,
+} from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import * as _ from "lodash-es";
+import { componentTypes, routes, useApi } from "@/newhotness/api_composables";
+import { encryptMessage } from "@/utils/messageEncryption";
+import ConfirmModal from "@/newhotness/layout_components/ConfirmModal.vue";
+
+const requestError = ref<string | undefined>();
+
+// FORM FIELDS
+const awsRegion = ref("us-east-1");
+const credentialName = ref("My AWS Credential");
+const credentialDescription = ref("");
+const sessionToken = ref("");
+const accessKeyId = ref("");
+const secretAccessKey = ref("");
+const assumeRole = ref("");
+const endpoint = ref("");
+
+const formStructure = [
+  {
+    title: "Region Data",
+  },
+  {
+    title: "Region Name",
+    ref: awsRegion,
+    required: true,
+  },
+  {
+    title: "Credential Metadata",
+  },
+  {
+    title: "Credential Name",
+    ref: credentialName,
+    required: true,
+  },
+  {
+    title: "Credential Description",
+    ref: credentialDescription,
+  },
+  {
+    title: "Credential Secret Data",
+    hint: "If you paste a bash environment variable block on any of the following fields, we'll match and fill them in.",
+  },
+  {
+    title: "Session Token",
+    ref: sessionToken,
+    type: "password",
+  },
+  {
+    title: "Access Key ID",
+    ref: accessKeyId,
+    type: "password",
+  },
+  {
+    title: "Secret Access Key",
+    ref: secretAccessKey,
+    type: "password",
+  },
+  {
+    title: "Assume Role",
+    ref: assumeRole,
+    type: "password",
+  },
+  {
+    title: "Endpoint",
+    ref: endpoint,
+    type: "password",
+  },
+];
+
+type FormField = (typeof formStructure)[number];
+
+const tryMatchOnPaste = (ev: ClipboardEvent, field: FormField) => {
+  if (field.type !== "password") return;
+
+  const text = ev.clipboardData?.getData("text/plain");
+
+  if (!text) return;
+
+  const valuesFromInput = _.compact(
+    text.split("\n").map((e) => {
+      const [_, key, value] = e.match(/export AWS_(.*)="(.*)"/) ?? [];
+      if (!key || !value) return;
+
+      return {
+        key,
+        value,
+      };
+    }),
+  );
+
+  if (!valuesFromInput.length) return;
+
+  let matchedAValue = false;
+  // Loop through form fields and try to match the values keys to the titles
+  for (const { key, value } of valuesFromInput) {
+    const matchedField = formStructure.find(
+      (e) => e.title.replaceAll(" ", "_").toUpperCase() === key,
+    );
+
+    if (!matchedField || !matchedField.ref) continue;
+    matchedAValue = true;
+    matchedField.ref.value = value;
+  }
+
+  if (!matchedAValue) return;
+
+  ev.preventDefault();
+};
+
+const initializeApi = useApi();
+const keyApi = useApi();
+const runOnboardRequest = async () => {
+  // Encrypt secret
+  const callApi = keyApi.endpoint<componentTypes.PublicKey>(
+    routes.GetPublicKey,
+    { id: "00000000000000000000000000" }, // TODO Remove component id from this endpoint's path, it's not needed
+  );
+  const resp = await callApi.get();
+  const publicKey = resp.data;
+
+  // Format cred values for encryption
+  const credValue = (
+    [
+      ["SessionToken", sessionToken.value],
+      ["AccessKeyId", accessKeyId.value],
+      ["SecretAccessKey", secretAccessKey.value],
+      ["AssumeRole", assumeRole.value],
+      ["Endpoint", endpoint.value],
+    ].filter(([_, value]) => value !== "") as [string, string][]
+  ) // Remove empty values
+    .reduce<{ [key: string]: string }>((acc, [key, value]) => {
+      // make the pairs array into an object
+      acc[key] = value;
+      return acc;
+    }, {});
+
+  const crypted = await encryptMessage(credValue, publicKey);
+
+  const call = initializeApi.endpoint(routes.ChangeSetInitializeAndApply);
+  const { req } = await call.post({
+    awsRegion: awsRegion.value,
+    credential: {
+      name: credentialName.value,
+      description: credentialDescription.value,
+      crypted,
+      keyPairPk: publicKey.pk,
+      version: componentTypes.SecretVersion.V1,
+      algorithm: componentTypes.SecretAlgorithm.Sealedbox,
+    },
+  });
+
+  if (initializeApi.ok(req)) {
+    modalRef.value?.close();
+  }
+};
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const { open, close } = useModal(modalRef);
+defineExpose({ open, close, isOpen: modalRef.value?.isOpen });
+</script>

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -28,6 +28,7 @@ export enum routes {
   ChangeSetApprovalStatus = "ChangeSetApprovalStatus",
   ChangeSetApprove = "ChangeSetApprove",
   ChangeSetCancelApprovalRequest = "ChangeSetCancelApprovalRequest",
+  ChangeSetInitializeAndApply = "ChangeSetInitializeAndApply",
   ChangeSetRename = "ChangeSetRename",
   ChangeSetReopen = "ChangeSetReopen",
   ChangeSetRequestApproval = "ChangeSetRequestApproval",
@@ -78,6 +79,7 @@ const CAN_MUTATE_ON_HEAD: readonly routes[] = [
   routes.AbandonChangeSet,
   routes.EnqueueAttributeValue,
   routes.RefreshAction,
+  routes.ChangeSetInitializeAndApply,
 ] as const;
 
 const COMPRESSED_ROUTES: readonly routes[] = [
@@ -126,11 +128,13 @@ const _routes: Record<routes, string> = {
   ViewEraseComponents: "/views/<viewId>/erase_components",
 
   // THESE ARE SPECIAL CASED & NOT V2
-  AbandonChangeSet: "/change_set/abandon_change_set",
-  ChangeSets: "CHANGESETS", // a short v2 url
   CreateChangeSet: "/change_set/create_change_set",
-  WorkspaceListUsers: "WORKSPACELISTUSERS", // a short v2 url
+  AbandonChangeSet: "/change_set/abandon_change_set",
   Workspaces: "/workspaces", // not a v2 url
+  // URLs without the default `change-set/:id` section
+  ChangeSets: "/change-sets",
+  ChangeSetInitializeAndApply: "/change-sets/create_initialize_apply",
+  WorkspaceListUsers: "/users",
 } as const;
 
 // the mechanics
@@ -222,12 +226,16 @@ export class APICall<Response, Args> {
     ) {
       return this.path;
     }
-    if ([_routes.ChangeSets].includes(this.path)) {
-      return `v2/workspaces/${this.workspaceId}/change-sets`;
+    if (
+      [
+        _routes.ChangeSets,
+        _routes.ChangeSetInitializeAndApply,
+        _routes.WorkspaceListUsers,
+      ].includes(this.path)
+    ) {
+      return `v2/workspaces/${this.workspaceId}${this.path}`;
     }
-    if ([_routes.WorkspaceListUsers].includes(this.path)) {
-      return `v2/workspaces/${this.workspaceId}/users`;
-    }
+
     const API_PREFIX = `v2/workspaces/${this.workspaceId}/change-sets/${this.changeSetId}`;
     return `${API_PREFIX}${this.path}`;
   }

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -24,6 +24,7 @@ const USER_FLAG_MAPPING = {
   ENABLE_NEW_EXPERIENCE: "enable-new-experience",
   REVIEW_PAGE: "review-page",
   DEFAULT_SUBS: "default-subs",
+  INITIALIZER_ONBOARD: "initializer-onboard",
 } as const;
 const WORKSPACE_FLAG_MAPPING = {
   FRONTEND_ARCH_VIEWS: "workspace-frontend-arch-views",

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -214,7 +214,7 @@ pub enum ComponentError {
     #[error("attribute prototype argument error: {0}")]
     AttributePrototypeArgument(#[from] Box<AttributePrototypeArgumentError>),
     #[error("attributes error: {0}")]
-    Attributes(#[from] Box<attributes::Error>),
+    Attributes(#[from] Box<attributes::AttributesError>),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error(
@@ -505,8 +505,8 @@ impl From<WsEventError> for ComponentError {
         Box::new(value).into()
     }
 }
-impl From<attributes::Error> for ComponentError {
-    fn from(value: attributes::Error) -> Self {
+impl From<attributes::AttributesError> for ComponentError {
+    fn from(value: attributes::AttributesError) -> Self {
         Box::new(value).into()
     }
 }

--- a/lib/dal/src/management/mod.rs
+++ b/lib/dal/src/management/mod.rs
@@ -118,7 +118,7 @@ pub enum ManagementError {
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error("attributes error: {0}")]
-    Attributes(#[from] Box<crate::attribute::attributes::Error>),
+    Attributes(#[from] Box<crate::attribute::attributes::AttributesError>),
     #[error("cannot create component with 'self' as a placeholder")]
     CannotCreateComponentWithSelfPlaceholder,
     #[error("component error: {0}")]
@@ -1998,8 +1998,8 @@ impl From<ActionPrototypeError> for ManagementError {
     }
 }
 
-impl From<crate::attribute::attributes::Error> for ManagementError {
-    fn from(value: crate::attribute::attributes::Error) -> Self {
+impl From<crate::attribute::attributes::AttributesError> for ManagementError {
+    fn from(value: crate::attribute::attributes::AttributesError) -> Self {
         Box::new(value).into()
     }
 }

--- a/lib/dal/src/property_editor/values.rs
+++ b/lib/dal/src/property_editor/values.rs
@@ -32,6 +32,7 @@ use crate::{
         value::AttributeValueError,
     },
     property_editor::{
+        PropertyEditorError,
         PropertyEditorPropId,
         PropertyEditorResult,
         PropertyEditorValueId,
@@ -256,6 +257,22 @@ impl PropertyEditorValues {
             .map(|(_, found_property_editor_value)| {
                 found_property_editor_value.attribute_value_id()
             })
+    }
+
+    /// Finds the [`AttributeValueId`](AttributeValue) for a given [`PropId`](Prop).
+    ///
+    /// This is useful for non-maps and non-array [`Props`](Prop).
+    pub fn find_by_prop_id_or_err(
+        &self,
+        prop_id: PropId,
+    ) -> PropertyEditorResult<AttributeValueId> {
+        self.values
+            .iter()
+            .find(|(_, property_editor_value)| property_editor_value.prop_id() == prop_id)
+            .map(|(_, found_property_editor_value)| {
+                found_property_editor_value.attribute_value_id()
+            })
+            .ok_or_else(|| PropertyEditorError::PropertyEditorValueNotFoundByPropId(prop_id))
     }
 
     /// Finds the [`AttributeValueId`](AttributeValue) and the [`Value`] corresponding to it for a

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -591,7 +591,6 @@ impl Schema {
         ctx: &DalContext,
         schema_id: SchemaId,
     ) -> SchemaResult<SchemaVariantId> {
-        // Install the schema, if it isn't already
         Self::ensure_installed(ctx, schema_id).await?;
         Self::default_variant_id(ctx, schema_id).await
     }

--- a/lib/dal/tests/integration_test/action.rs
+++ b/lib/dal/tests/integration_test/action.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use dal::{
     AttributeValue,
+    ChangeSet,
     Component,
     DalContext,
     SchemaVariant,
@@ -889,7 +890,7 @@ async fn resource_value_propagation_subscriptions_works(ctx: &mut DalContext) ->
     // wait for actions to run
     ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
     // also wait for dvu!
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
+    ChangeSet::wait_for_dvu(ctx, false).await?;
     // need to update snapshot to visibility again for some reason??
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 

--- a/lib/dal/tests/integration_test/attribute_value.rs
+++ b/lib/dal/tests/integration_test/attribute_value.rs
@@ -1,5 +1,6 @@
 use dal::{
     AttributeValue,
+    ChangeSet,
     Component,
     DalContext,
 };
@@ -193,8 +194,7 @@ async fn update_object_multiplayer(ctx: &mut DalContext) -> Result<()> {
     }
 
     // Check its effect on the merged changeset
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
-    ctx.update_snapshot_to_visibility().await?;
+    ChangeSet::wait_for_dvu(ctx, false).await?;
     for &attr in &attrs {
         // The object must have exactly 4 child AVs and the value should be the merged value
         let av_id = value::id(ctx, attr).await?;

--- a/lib/dal/tests/integration_test/attributes.rs
+++ b/lib/dal/tests/integration_test/attributes.rs
@@ -479,7 +479,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));
@@ -492,7 +492,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));
@@ -505,7 +505,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));
@@ -518,7 +518,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));
@@ -533,7 +533,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));
@@ -546,7 +546,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));
@@ -559,7 +559,7 @@ async fn update_attribute_child_of_subscription(ctx: &mut DalContext) -> Result<
             }))?,
         )
         .await,
-        Err(attributes::Error::AttributeValue(
+        Err(attributes::AttributesError::AttributeValue(
             AttributeValueError::CannotSetChildOfDynamicValue(..)
         )),
     ));

--- a/lib/dal/tests/integration_test/component/upgrade.rs
+++ b/lib/dal/tests/integration_test/component/upgrade.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use dal::{
     AttributeValue,
+    ChangeSet,
     Component,
     ComponentId,
     ComponentType,
@@ -886,8 +887,7 @@ async fn upgrade_component_multiplayer(ctx: &mut DalContext) -> Result<()> {
     }
 
     // Find out how the changeset ended up
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
-    ctx.update_snapshot_to_visibility().await?;
+    ChangeSet::wait_for_dvu(ctx, false).await?;
     assert_eq!(expect_conns, connections(ctx, component.id).await?);
     assert_eq!(expect_domain, component.domain(ctx).await?);
 
@@ -1017,8 +1017,7 @@ async fn upgrade_component_multiplayer_new_and_removed_sockets(ctx: &mut DalCont
     }
 
     // Find out how the changeset ended up
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
-    ctx.update_snapshot_to_visibility().await?;
+    ChangeSet::wait_for_dvu(ctx, false).await?;
     // Make absolutely sure the socket AVs were not duplicated
     assert_eq!(
         3,

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -220,8 +220,6 @@ async fn import_and_refresh(ctx: &mut DalContext) -> Result<()> {
     )
     .await?;
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-    // wait for dvu
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
     // check actions, there should be one refresh enqueued but not dispatched since this component now exists on head
     let actions = Action::all_ids(ctx).await?;
     assert!(actions.len() == 1);

--- a/lib/dal/tests/integration_test/validations.rs
+++ b/lib/dal/tests/integration_test/validations.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use dal::{
     AttributeValue,
+    ChangeSet,
     Component,
     DalContext,
     workspace_snapshot::{
@@ -162,7 +163,7 @@ async fn validation_pre_post_mgmt_func(ctx: &mut DalContext) -> Result<()> {
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
     // Wait for dvu
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
+    ChangeSet::wait_for_dvu(ctx, false).await?;
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
     // Check that the validation is now passing as the mgmt func wrote a valid value
@@ -201,7 +202,7 @@ async fn validation_pre_post_mgmt_func(ctx: &mut DalContext) -> Result<()> {
     .await?;
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
     // Wait for dvu
-    ChangeSetTestHelpers::wait_for_dvu(ctx).await?;
+    ChangeSet::wait_for_dvu(ctx, false).await?;
 
     // now check that the validation is failing again
     // loop to wait for the validation job to finish

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -96,7 +96,7 @@ pub enum ComponentsError {
     #[error("component error: {0}")]
     ActionPrototype(#[from] ActionPrototypeError),
     #[error("attribute error: {0}")]
-    Attribute(#[from] dal::attribute::attributes::Error),
+    Attribute(#[from] dal::attribute::attributes::AttributesError),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] dal::attribute::value::AttributeValueError),
     #[error("attribute value {0} not from component {1}")]

--- a/lib/sdf-server/src/service/v2/change_set/create.rs
+++ b/lib/sdf-server/src/service/v2/change_set/create.rs
@@ -1,21 +1,17 @@
 use axum::{
     Json,
-    extract::{
-        Host,
-        OriginalUri,
-        Path,
-    },
     http::StatusCode,
     response::IntoResponse,
 };
 use dal::{
     ChangeSet,
-    WorkspacePk,
     WsEvent,
 };
 use sdf_extract::{
     EddaClient,
     FriggStore,
+    PosthogEventTracker,
+    workspace::WorkspaceDalContext,
 };
 use serde::{
     Deserialize,
@@ -24,17 +20,7 @@ use serde::{
 use si_events::audit_log::AuditLogKind;
 
 use super::Result;
-use crate::{
-    extract::{
-        HandlerContext,
-        PosthogClient,
-    },
-    service::v2::{
-        AccessBuilder,
-        change_set::create_index_for_new_change_set_and_watch,
-    },
-    track,
-};
+use crate::service::v2::change_set::create_index_for_new_change_set_and_watch;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -44,28 +30,19 @@ pub struct Request {
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_change_set(
-    HandlerContext(builder): HandlerContext,
-    AccessBuilder(request_ctx): AccessBuilder,
-    PosthogClient(posthog_client): PosthogClient,
-    OriginalUri(original_uri): OriginalUri,
-    Host(host_name): Host,
+    WorkspaceDalContext(ref ctx): WorkspaceDalContext,
+    tracker: PosthogEventTracker,
     FriggStore(frigg): FriggStore,
     EddaClient(edda_client): EddaClient,
-    Path(workspace_pk): Path<WorkspacePk>,
     Json(Request { name }): Json<Request>,
 ) -> Result<impl IntoResponse> {
-    let ctx = builder.build_head(request_ctx).await?;
-
     let change_set_name = name.to_owned();
 
-    let change_set = ChangeSet::fork_head(&ctx, change_set_name.clone()).await?;
+    let change_set = ChangeSet::fork_head(ctx, change_set_name.clone()).await?;
     let change_set_id = change_set.id;
 
-    track(
-        &posthog_client,
-        &ctx,
-        &original_uri,
-        &host_name,
+    tracker.track(
+        ctx,
         "create_change_set",
         serde_json::json!({
                     "change_set_name": change_set_name.clone(),
@@ -75,17 +52,17 @@ pub async fn create_change_set(
     ctx.write_audit_log(AuditLogKind::CreateChangeSet, change_set_name.to_string())
         .await?;
 
-    WsEvent::change_set_created(&ctx, change_set.id, change_set.workspace_snapshot_address)
+    WsEvent::change_set_created(ctx, change_set.id, change_set.workspace_snapshot_address)
         .await?
-        .publish_on_commit(&ctx)
+        .publish_on_commit(ctx)
         .await?;
 
-    let change_set = change_set.into_frontend_type(&ctx).await?;
+    let change_set = change_set.into_frontend_type(ctx).await?;
     ctx.commit_no_rebase().await?;
     if create_index_for_new_change_set_and_watch(
         &frigg,
         &edda_client,
-        workspace_pk,
+        ctx.workspace_pk()?,
         change_set_id,
         ctx.change_set_id(), // note DalCtx is built for Head here to create a change set!
         ctx.workspace_snapshot()?.address().await,

--- a/lib/sdf-server/src/service/v2/change_set/create_initialize_apply.rs
+++ b/lib/sdf-server/src/service/v2/change_set/create_initialize_apply.rs
@@ -1,0 +1,226 @@
+use axum::{
+    Json,
+    response::IntoResponse,
+};
+use dal::{
+    ChangeSet,
+    Component,
+    DalContext,
+    Prop,
+    Schema,
+    SchemaVariant,
+    Secret,
+    SecretAlgorithm,
+    SecretVersion,
+    diagram::view::View,
+    prop::PropPath,
+    property_editor::values::PropertyEditorValues,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    workspace::WorkspaceDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use si_id::KeyPairPk;
+
+use super::Result;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AwsCredentialData {
+    pub name: String,
+    pub description: Option<String>,
+    pub crypted: Vec<u8>,
+    pub key_pair_pk: KeyPairPk,
+    pub version: SecretVersion,
+    pub algorithm: SecretAlgorithm,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Request {
+    pub aws_region: String,
+    pub credential: AwsCredentialData,
+}
+
+const INITIALIZATION_CHANGE_SET_NAME: &str = "Initialization";
+
+pub async fn create_initialize_apply(
+    WorkspaceDalContext(ref mut ctx): WorkspaceDalContext,
+    tracker: PosthogEventTracker,
+    Json(request): Json<Request>,
+) -> Result<impl IntoResponse> {
+    let mut initialization_change_set =
+        ChangeSet::fork_head(ctx, INITIALIZATION_CHANGE_SET_NAME).await?;
+    ctx.write_audit_log(
+        AuditLogKind::CreateChangeSet,
+        INITIALIZATION_CHANGE_SET_NAME.to_string(),
+    )
+    .await?;
+
+    let mut initialization_changeset_ctx =
+        ctx.clone_with_new_visibility(initialization_change_set.id.into());
+    let initialization_result =
+        initialize_and_apply(&mut initialization_changeset_ctx, request).await;
+
+    // Ensure that if something went wrong on initialization, we abandon the change set
+    if initialization_result.is_err() {
+        let old_status = initialization_change_set.status;
+        initialization_change_set.abandon(ctx).await?;
+        ctx.write_audit_log(
+            AuditLogKind::AbandonChangeSet {
+                from_status: old_status.into(),
+            },
+            initialization_change_set.name,
+        )
+        .await?;
+
+        return initialization_result;
+    }
+
+    // TODO set fields on this new event
+    tracker.track(
+        ctx,
+        "onboarded",
+        serde_json::json!({
+                    "change_set_name": INITIALIZATION_CHANGE_SET_NAME,
+        }),
+    );
+
+    Ok(())
+}
+
+async fn initialize_and_apply(ctx: &mut DalContext, request: Request) -> Result<()> {
+    // TODO: there's still some audit logs missing on this function
+    let view_id = View::get_id_for_default(ctx).await?;
+    let credential_name = request.credential.name;
+
+    // Create the credential component
+    let credential_component = {
+        let schema = Schema::get_or_install_by_name(ctx, "AWS Credential").await?;
+        let sv_id = SchemaVariant::default_id_for_schema(ctx, schema.id()).await?;
+        let component = Component::new(ctx, &credential_name, sv_id, view_id).await?;
+
+        // Create the secret and set it to the credential
+        let secret = Secret::new(
+            ctx,
+            &credential_name,
+            "AWS Credential".to_owned(),
+            request.credential.description,
+            &request.credential.crypted,
+            request.credential.key_pair_pk,
+            request.credential.version,
+            request.credential.algorithm,
+        )
+        .await?;
+
+        ctx.write_audit_log(
+            AuditLogKind::CreateSecret {
+                name: secret.name().to_string(),
+                secret_id: secret.id(),
+            },
+            secret.name().to_string(),
+        )
+        .await?;
+
+        // Find the AWS Credential prop and attach the secret
+        {
+            let aws_credential_prop = Prop::find_prop_by_path(
+                ctx,
+                sv_id,
+                &PropPath::new(["root", "secrets", "AWS Credential"]),
+            )
+            .await?;
+
+            let property_values = PropertyEditorValues::assemble(ctx, component.id()).await?;
+            let aws_credential_attribute_value_id =
+                property_values.find_by_prop_id_or_err(aws_credential_prop.id())?;
+
+            Secret::attach_for_attribute_value(
+                ctx,
+                aws_credential_attribute_value_id,
+                Some(secret.id()),
+            )
+            .await?;
+        }
+
+        let variant = SchemaVariant::get_by_id(ctx, sv_id).await?;
+
+        ctx.write_audit_log(
+            AuditLogKind::CreateComponent {
+                name: credential_name.clone(),
+                component_id: component.id(),
+                schema_variant_id: sv_id,
+                schema_variant_name: variant.display_name().to_owned(),
+            },
+            credential_name.clone(),
+        )
+        .await?;
+
+        component
+    };
+
+    // Create the region component
+    let region = request.aws_region;
+    let region_component = {
+        let schema = Schema::get_or_install_by_name(ctx, "Region").await?;
+        let sv_id = SchemaVariant::default_id_for_schema(ctx, schema.id()).await?;
+        let component = Component::new(ctx, &region, sv_id, view_id).await?;
+
+        let variant = SchemaVariant::get_by_id(ctx, sv_id).await?;
+
+        ctx.write_audit_log(
+            AuditLogKind::CreateComponent {
+                name: region.clone(),
+                component_id: component.id(),
+                schema_variant_id: sv_id,
+                schema_variant_name: variant.display_name().to_owned(),
+            },
+            region.clone(),
+        )
+        .await?;
+
+        component
+    };
+
+    // Set the region value and subscribe the region's credential to the cred component
+    {
+        let sources = serde_json::from_value(serde_json::json!({
+            "/domain/region" : region,
+            "/secrets/credential": {
+              "$source": { "component": credential_component.id().to_string(), "path": "/secrets/AWS Credential" }
+            },
+        }))?;
+
+        dal::update_attributes(ctx, region_component.id(), sources).await?;
+    }
+
+    // Commit so the components are created and the DVU is triggered
+    ctx.commit().await?;
+
+    // Await the DVU before applying the changeset
+    ChangeSet::wait_for_dvu(ctx, true).await?;
+
+    let change_set = ctx.change_set()?.clone();
+    let old_status = change_set.status;
+
+    ChangeSet::prepare_for_force_apply(ctx).await?;
+    ctx.write_audit_log(
+        AuditLogKind::ApproveChangeSetApply {
+            from_status: old_status.into(),
+        },
+        change_set.name.clone(),
+    )
+    .await?;
+
+    ChangeSet::apply_to_base_change_set(ctx).await?;
+
+    ctx.write_audit_log(AuditLogKind::ApplyChangeSet, change_set.name.clone())
+        .await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/component.rs
+++ b/lib/sdf-server/src/service/v2/component.rs
@@ -37,7 +37,7 @@ pub enum Error {
     #[error("action error: {0}")]
     Action(#[from] dal::action::ActionError),
     #[error("attributes error: {0}")]
-    Attributes(#[from] dal::attribute::attributes::Error),
+    Attributes(#[from] dal::attribute::attributes::AttributesError),
     #[error("attribute value error: {0}")]
     AttributeValue(#[from] dal::attribute::value::AttributeValueError),
     #[error("attribute value '{0}' not found for component {1}")]


### PR DESCRIPTION
Add the new endpoint so the onboarding flow can initialize the workspace with a region and a credential component, filled out and connected. Also adds a feature flagged modal for testing it out.

Extras: 
- move wait_for_dvu into dal code
- ignore empty secrets when redacting

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

For testing only:

<img width="766" height="788" alt="image" src="https://github.com/user-attachments/assets/f9d2afe0-87ae-4bd1-9473-b9099c10ece0" />
#### Out of Scope:

- The real onboarding UI will be implemented on a further PR.
- The existing modal does not have polish. This is fine because this is only for testing. It only works for a happy path test.
- The CIA endpoint does not publish all the audit logs it needs to, this will be left for another PR.

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [ ] Integration tests pass
- [X] Manual test: Enable the feature flag, copy a real credential, use the "Initialize workspace" button on an empty HEAD changeset, fill out the form fields and press Initialize. It should NOT leave an open changeset, and the credential and region components should be on HEAD
- [X] Reran the changed SensitiveString unit tests

## In short: [:link:](https://giphy.com/)

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWVyN3h5MDA0eTA0Z29sZmxhZXZnb2Ztb2diMms0Nmkwbjc3dnowZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/I7u0AHaGFTeeYJaBMw/giphy.gif)
