### PR TITLE
Fix `onHead`, watch immediately

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -281,7 +281,9 @@ const ctx = computed<Context>(() => {
     changeSet,
     approvers,
     user: authStore.user,
-    onHead: computed(() => changeSetId.value === _headChangeSetId.value),
+    onHead: computed(() => {
+      return changeSetId.value === _headChangeSetId.value;
+    }),
     headChangeSetId: _headChangeSetId,
     outgoingCounts,
     componentDetails,
@@ -329,15 +331,30 @@ const changeSetsNeedingApproval = computed(() =>
   ),
 );
 
-watch(defaultApprovers, () => {
-  approvers.value = defaultApprovers.value;
-});
-watch(activeChangeSet, () => {
-  changeSet.value = activeChangeSet.value;
-});
-watch(headChangeSetId, () => {
-  _headChangeSetId.value = headChangeSetId.value;
-});
+watch(
+  defaultApprovers,
+  () => {
+    approvers.value = defaultApprovers.value;
+  },
+  { immediate: true },
+);
+watch(
+  activeChangeSet,
+  () => {
+    changeSet.value = activeChangeSet.value;
+  },
+  { immediate: true },
+);
+watch(
+  headChangeSetId,
+  () => {
+    // never assign a blank value over a truth-y value
+    if (_headChangeSetId.value && !headChangeSetId.value) return;
+
+    _headChangeSetId.value = headChangeSetId.value;
+  },
+  { immediate: true },
+);
 watch(
   () => openChangeSets,
   () => {

--- a/app/web/src/newhotness/logic_composables/change_set.ts
+++ b/app/web/src/newhotness/logic_composables/change_set.ts
@@ -33,9 +33,9 @@ export const useChangeSets = (
     },
   });
 
-  const headChangeSetId = computed(
-    () => changeSetQuery.data.value?.defaultChangeSetId ?? "",
-  );
+  const headChangeSetId = computed(() => {
+    return changeSetQuery.data.value?.defaultChangeSetId ?? "";
+  });
   const defaultApprovers = computed(
     () => changeSetQuery.data.value?.approvers || [],
   );


### PR DESCRIPTION
## How does this PR change the system?

Fix: ensure the watcher has `immediate: true` on it. My B.

## How was it tested?

About 1 in 10 times the `_headChangeSetId.value` field would be "empty string". Which tells me other things updated "fast enough" / within the mount loop that the watcher never fired in the first place, and thus was comparing a string value against an empty string for "am i on head?" which would always be `true`...

Changing the watcher to be immediate fixes this problem.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaDFub3l1cWthMTY0ZXd2M2FpcXp4cWU4eDVsZ2h6OHlxdXNiNzh4dSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1SzIPkhn8EOK99F0vj/giphy.gif"/>