### PR TITLE
feat(web,sdf): default subscriptions UI

### DIFF
--- a/app/web/src/newhotness/DefaultSubscriptionsButton.vue
+++ b/app/web/src/newhotness/DefaultSubscriptionsButton.vue
@@ -1,0 +1,30 @@
+<template>
+  <button
+    :class="
+      clsx(
+        'flex flex-row gap-xs items-center border rounded-sm',
+        'p-2xs mb-[-1px] h-7',
+        'font-mono text-[13px] text-left truncate relative',
+        themeClasses(
+          'border-neutral-400 hover:border-action-500',
+          'border-neutral-600 hover:border-action-300',
+        ),
+        selected
+          ? themeClasses('bg-action-200', 'bg-action-900')
+          : themeClasses('bg-neutral-100', 'bg-neutral-900'),
+      )
+    "
+  >
+    <Icon name="repeat" size="xs" />
+    <span>See default subscriptions</span>
+  </button>
+</template>
+
+<script lang="ts" setup>
+import { Icon, themeClasses } from "@si/vue-lib/design-system";
+import clsx from "clsx";
+
+defineProps<{
+  selected?: boolean;
+}>();
+</script>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -396,6 +396,7 @@ export type SelectionsInQueryString = Partial<{
   groupBy: GroupByUrlQuery;
   sortBy: SortByUrlQuery;
   pinned: string;
+  defaultSubscriptions: string;
   viewId: string;
   searchQuery: string;
   retainSessionState: string; // If set, the component should load up with the last state it had on this tab. Used by Explore.vue

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -36,6 +36,7 @@ export enum routes {
   CreateTemplate = "CreateTemplate",
   CreateView = "CreateView",
   DeleteComponents = "DeleteComponents",
+  DeleteDefaultSubscriptionSource = "DeleteDefaultSubscriptionSource",
   DeleteView = "DeleteView",
   DuplicateComponents = "DuplicateComponents",
   EnqueueAttributeValue = "EnqueueAttributeValue",
@@ -46,6 +47,7 @@ export enum routes {
   GetPublicKey = "GetPublicKey",
   RefreshAction = "RefreshAction",
   RestoreComponents = "RestoreComponents",
+  SetDefaultSubscriptionSource = "SetDefaultSubscriptionSource",
   MgmtFuncRun = "MgmtFuncRun",
   MgmtFuncGetJobState = "MgmtFuncGetJobState",
   MgmtFuncGetLatest = "MgmtFuncGetLatest",
@@ -85,12 +87,12 @@ const COMPRESSED_ROUTES: readonly routes[] = [
 const _routes: Record<routes, string> = {
   ActionAdd: "/action/add",
   ActionCancel: "/action/<id>/cancel",
+  ActionFuncRunId: "/action/<id>/func_run_id",
   ActionHold: "/action/<id>/put_on_hold",
   ActionRetry: "/action/<id>/retry",
-  ActionFuncRunId: "/action/<id>/func_run_id",
   ApplyChangeSet: "/apply",
-  ChangeSetApprove: "/approve",
   ChangeSetApprovalStatus: "/approval_status",
+  ChangeSetApprove: "/approve",
   ChangeSetCancelApprovalRequest: "/cancel_approval_request",
   ChangeSetRename: "/rename",
   ChangeSetReopen: "/reopen",
@@ -100,6 +102,7 @@ const _routes: Record<routes, string> = {
   CreateTemplate: "/management/generate_template/<viewId>",
   CreateView: "/views",
   DeleteComponents: "/components/delete",
+  DeleteDefaultSubscriptionSource: "/components/<id>/attributes/default_source",
   DeleteView: "/views/<viewId>",
   DuplicateComponents: "/views/<viewId>/duplicate_components",
   EnqueueAttributeValue: "/components/<id>/attributes/enqueue",
@@ -108,11 +111,12 @@ const _routes: Record<routes, string> = {
   FuncRunLogs: "/funcs/runs/<id>/logs",
   GetFuncRunsPaginated: "/funcs/runs/paginated",
   GetPublicKey: "/components/<id>/secret/public_key",
-  RefreshAction: "/action/refresh/<componentId>",
-  RestoreComponents: "/components/restore",
-  MgmtFuncRun: "/management/prototype/<prototypeId>/<componentId>/<viewId>",
   MgmtFuncGetJobState: "/management/state/<funcRunId>",
   MgmtFuncGetLatest: "/management/component/<componentId>/latest",
+  MgmtFuncRun: "/management/prototype/<prototypeId>/<componentId>/<viewId>",
+  RefreshAction: "/action/refresh/<componentId>",
+  RestoreComponents: "/components/restore",
+  SetDefaultSubscriptionSource: "/components/<id>/attributes/default_source",
   UpdateComponentAttributes: "/components/<id>/attributes",
   UpdateComponentManage: "/components/<id>/manage",
   UpdateComponentName: "/components/<id>/name",
@@ -120,12 +124,13 @@ const _routes: Record<routes, string> = {
   UpgradeComponents: "/components/upgrade",
   ViewAddComponents: "/views/<viewId>/add_components",
   ViewEraseComponents: "/views/<viewId>/erase_components",
+
   // THESE ARE SPECIAL CASED & NOT V2
-  CreateChangeSet: "/change_set/create_change_set",
   AbandonChangeSet: "/change_set/abandon_change_set",
-  Workspaces: "/workspaces", // not a v2 url
   ChangeSets: "CHANGESETS", // a short v2 url
+  CreateChangeSet: "/change_set/create_change_set",
   WorkspaceListUsers: "WORKSPACELISTUSERS", // a short v2 url
+  Workspaces: "/workspaces", // not a v2 url
 } as const;
 
 // the mechanics

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -30,6 +30,9 @@
       @childHover="(componentId) => $emit('childHover', componentId)"
       @childUnhover="(componentId) => $emit('childUnhover', componentId)"
       @clickCollapse="clickCollapse"
+      @componentNavigate="
+        (componentId) => $emit('componentNavigate', componentId)
+      "
       @unpin="(componentId) => $emit('unpin', componentId)"
       @resetFilter="$emit('resetFilter')"
     />
@@ -56,6 +59,12 @@ const props = defineProps<{
   scrollRef: HTMLDivElement | undefined;
 }>();
 
+const treatAsMultipleSections = computed(
+  () =>
+    exploreContext.hasMultipleSections.value ||
+    exploreContext.gridMode.value.mode === "defaultSubscriptions",
+);
+
 const GRID_TILE_GAP = 16; // this is being used for both the X and Y gap
 
 const clickCollapse = (title: string, collapsed: boolean) => {
@@ -74,9 +83,11 @@ const getItemKey = (rowIndex: number) => {
   switch (row.type) {
     case "header":
       return `header-${row.title}`;
+    case "defaultSubHeader":
+      return `defaultSubHeader-${row.subKey}`;
     case "contentRow":
       if (
-        !exploreContext.hasMultipleSections.value &&
+        !treatAsMultipleSections.value &&
         rowIndex === props.gridRows.length - 1
       )
         return `contentRow-final-${rowIndex}`;
@@ -99,10 +110,11 @@ const rowHeights = computed(() => {
   return props.gridRows.map((row, index) => {
     switch (row.type) {
       case "header":
+      case "defaultSubHeader":
         return GROUP_HEADER_HEIGHT;
       case "contentRow":
         if (
-          !exploreContext.hasMultipleSections.value &&
+          !treatAsMultipleSections.value &&
           index === props.gridRows.length - 1
         ) {
           return GRID_TILE_HEIGHT;
@@ -192,6 +204,7 @@ const emit = defineEmits<{
   (e: "childHover", componentId: ComponentId): void;
   (e: "childUnhover", componentId: ComponentId): void;
   (e: "collapse", title: string, collapsed: boolean): void;
+  (e: "componentNavigate", componentId: ComponentId): void;
   (e: "resetFilter"): void;
   (
     e: "childClicked",
@@ -218,6 +231,7 @@ section.grid.map {
 div.main {
   grid-area: "main";
 }
+
 div.right {
   grid-area: "right";
 }

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -14,6 +14,7 @@
     :externalSources="attributeTree.attributeValue.externalSources"
     :isArray="false"
     :isMap="false"
+    :isDefaultSource="false"
     :forceReadOnly="false"
     :hasSocketConnection="hasSocketConnections"
     @close="closeSubscriptionInput"
@@ -156,6 +157,9 @@
             "
             @delete="(path) => emit('delete', path)"
             @remove-subscription="(path) => emit('removeSubscription', path)"
+            @set-default-subscription-source="
+              (path, setTo) => emit('setDefaultSubscriptionSource', path, setTo)
+            "
             @add="(...args) => emit('add', ...args)"
             @set-key="(...args) => emit('setKey', ...args)"
           />
@@ -243,8 +247,12 @@
         :isMap="attributeTree.prop?.kind === 'map'"
         :forceReadOnly="props.forceReadOnly || parentHasExternalSources"
         :hasSocketConnection="hasSocketConnections"
+        :isDefaultSource="attributeTree.attributeValue.isDefaultSource"
         @save="(...args) => emit('save', ...args)"
         @delete="(...args) => emit('delete', ...args)"
+        @set-default-subscription-source="
+          (path, setTo) => emit('setDefaultSubscriptionSource', path, setTo)
+        "
         @remove-subscription="(...args) => emit('removeSubscription', ...args)"
         @add="(...args) => add(...args)"
       />
@@ -482,6 +490,11 @@ const emit = defineEmits<{
     connectingComponentId?: ComponentId,
   ): void;
   (e: "delete", path: AttributePath): void;
+  (
+    e: "setDefaultSubscriptionSource",
+    path: AttributePath,
+    setTo: boolean,
+  ): void;
   (e: "removeSubscription", path: AttributePath): void;
   (e: "add", api: UseApi, attributeTree: AttrTree, value: NewChildValue): void;
   (

--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -73,6 +73,28 @@
             @click="submitSecretForm"
           />
         </ul>
+        <div
+          v-if="featureFlagsStore.DEFAULT_SUBS"
+          :class="
+            clsx(
+              'border w-full',
+              themeClasses('border-neutral-300', 'border-neutral-600'),
+            )
+          "
+        >
+          <input
+            :id="`default-subs-checkbox-${attributeTree.prop?.id}`"
+            type="checkbox"
+            :checked="attributeTree.attributeValue.isDefaultSource"
+            @input="
+              (ev) =>
+                toggleIsDefaultSource(ev, attributeTree.attributeValue.path)
+            "
+          />
+          <label :for="`default-subs-checkbox-${attributeTree.prop?.id}`">
+            Make this the default subscription for new components
+          </label>
+        </div>
       </div>
     </AttributeChildLayout>
   </div>
@@ -111,6 +133,7 @@ import {
 } from "@/workers/types/entity_kind_types";
 import { encryptMessage } from "@/utils/messageEncryption";
 import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
+import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import AttributeChildLayout from "./AttributeChildLayout.vue";
 import AttributeInput from "./AttributeInput.vue";
 import AttributeInputRequiredProperty from "./AttributeInputRequiredProperty.vue";
@@ -120,9 +143,19 @@ import { useWatchedForm } from "../logic_composables/watched_form";
 import SecretInput from "./SecretInput.vue";
 import { MouseDetails, mouseEmitter } from "../logic_composables/emitters";
 
+const featureFlagsStore = useFeatureFlagsStore();
+
 const props = defineProps<{
   component: BifrostComponent | ComponentInList;
   attributeTree: AttrTree;
+}>();
+
+const emit = defineEmits<{
+  (
+    e: "setDefaultSubscriptionSource",
+    path: AttributePath,
+    setTo: boolean,
+  ): void;
 }>();
 
 const displayName = computed(() => {
@@ -348,5 +381,10 @@ const removeListeners = () => {
 const submitSecretForm = async () => {
   await secretForm.handleSubmit();
   closeSecretForm();
+};
+
+const toggleIsDefaultSource = (event: Event, path: AttributePath) => {
+  const checked = (event.target as HTMLInputElement).checked;
+  emit("setDefaultSubscriptionSource", path, checked);
 };
 </script>

--- a/app/web/src/newhotness/logic_composables/default_subscriptions.ts
+++ b/app/web/src/newhotness/logic_composables/default_subscriptions.ts
@@ -1,0 +1,25 @@
+import { computed } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import { getDefaultSubscriptions, useMakeKey } from "@/store/realtime/heimdall";
+import {
+  emptyDefaultSubs,
+  EntityKind,
+} from "@/workers/types/entity_kind_types";
+import { useContext } from "./context";
+
+export const useDefaultSubscription = () => {
+  const ctx = useContext();
+  const key = useMakeKey();
+  const args = computed(() => ({
+    workspaceId: ctx.workspacePk.value,
+    changeSetId: ctx.changeSetId.value,
+  }));
+
+  const query = useQuery({
+    queryKey: key(EntityKind.DefaultSubscriptions),
+    enabled: ctx.queriesEnabled,
+    queryFn: async () => await getDefaultSubscriptions(args.value),
+  });
+
+  return computed(() => query.data.value ?? emptyDefaultSubs);
+};

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -70,6 +70,25 @@ export interface ComponentsHaveActionsWithState {
   running: Set<ComponentId>;
 }
 
+export type GridMode =
+  | { mode: "default"; label: "" }
+  | { mode: "pinned"; componentId: ComponentId; label: "" }
+  | { mode: "defaultSubscriptions"; label: "" }
+  | { mode: "groupBy"; criteria: "diff"; label: "Diff Status" }
+  | {
+      mode: "groupBy";
+      criteria: "qualification";
+      label: "Qualification Status";
+    }
+  | { mode: "groupBy"; criteria: "upgrade"; label: "Upgradeable" }
+  | { mode: "groupBy"; criteria: "schemaName"; label: "Schema Name" }
+  | { mode: "groupBy"; criteria: "resource"; label: "Resource" }
+  | {
+      mode: "groupBy";
+      criteria: "incompatibleComponents";
+      label: "Incompatible Components";
+    };
+
 export interface ExploreContext {
   viewId: ComputedRef<string>;
   upgradeableComponents: ComputedRef<Set<string>>;
@@ -86,6 +105,7 @@ export interface ExploreContext {
   allVisibleComponents: ComputedRef<ComponentInList[]>;
   hasMultipleSections: ComputedRef<boolean>;
   focusedComponentRef: Ref<HTMLElement | undefined>;
+  gridMode: Ref<GridMode>;
 }
 
 // Define an enum for function kinds

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -23,6 +23,7 @@ const USER_FLAG_MAPPING = {
   PROPS_TO_PROPS_CONNECTIONS: "props-to-props-connections",
   ENABLE_NEW_EXPERIENCE: "enable-new-experience",
   REVIEW_PAGE: "review-page",
+  DEFAULT_SUBS: "default-subs",
 } as const;
 const WORKSPACE_FLAG_MAPPING = {
   FRONTEND_ARCH_VIEWS: "workspace-frontend-arch-views",

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -559,6 +559,24 @@ export const getSchemaMembers = async (args: {
   else return [];
 };
 
+export const getDefaultSubscriptions = async (args: {
+  workspaceId: WorkspacePk;
+  changeSetId: ChangeSetId;
+}) => {
+  if (!initCompleted.value) throw new Error("You must wait for initialization");
+
+  const start = performance.now();
+  const defaultSubscriptions = await db.getDefaultSubscriptions(
+    args.workspaceId,
+    args.changeSetId,
+  );
+  const end = performance.now();
+  // eslint-disable-next-line no-console
+  console.log("🌈 bifrost query defaultSubscriptions", end - start, "ms");
+
+  return defaultSubscriptions;
+};
+
 export const getOutgoingConnections = async (args: {
   workspaceId: WorkspacePk;
   changeSetId: ChangeSetId;

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -355,6 +355,13 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
+  async getDefaultSubscriptions(workspaceId: string, changeSetId: string) {
+    return await withLeader(
+      async (remote) =>
+        await remote.getDefaultSubscriptions(workspaceId, changeSetId),
+    );
+  },
+
   async mjolnir(
     workspaceId: string,
     changeSetId: string,

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -16,6 +16,7 @@ import { WorkspacePk } from "@/api/sdf/dal/workspace";
 import { ViewId } from "@/api/sdf/dal/views";
 import {
   Connection,
+  DefaultSubscriptions,
   EntityKind,
   PossibleConnection,
 } from "./entity_kind_types";
@@ -175,6 +176,10 @@ export interface SharedDBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): Promise<string>;
+  getDefaultSubscriptions(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+  ): Promise<DefaultSubscriptions>;
   get(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -278,6 +283,10 @@ export interface TabDBInterface {
     changeSetId: ChangeSetId,
   ): Record<ComponentId, ViewId>;
   getSchemaMembers(workspaceId: string, changeSetId: ChangeSetId): string;
+  getDefaultSubscriptions(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+  ): DefaultSubscriptions;
   get(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -25,6 +25,7 @@ export enum EntityKind {
   ComponentList = "ComponentList",
   ComponentsInOnlyOneView = "ComponentsInOnlyOneView",
   ComponentsInViews = "ComponentsInViews",
+  DefaultSubscriptions = "DefaultSubscriptions",
   DependentValueComponentList = "DependentValueComponentList",
   IncomingConnections = "IncomingConnections",
   IncomingConnectionsList = "IncomingConnectionsList",
@@ -377,10 +378,12 @@ export interface AttributeValue {
   validation?: ValidationOutput;
   secret: Secret | null;
   hasSocketConnection: boolean;
+  isDefaultSource: boolean;
 }
 
 export interface ExternalSource {
   path: string;
+  componentId: ComponentId;
   componentName: string;
   isSecret: boolean;
 }
@@ -470,3 +473,20 @@ export interface DependentValueComponentList {
   id: string;
   componentIds: ComponentId[];
 }
+
+export interface DefaultSubscription {
+  componentId: ComponentId;
+  path: string;
+}
+
+export interface DefaultSubscriptions {
+  defaultSubscriptions: Map<string, DefaultSubscription>;
+  componentsForSubs: DefaultMap<string, Set<ComponentId>>;
+  subsForComponents: DefaultMap<ComponentId, Set<string>>;
+}
+
+export const emptyDefaultSubs: DefaultSubscriptions = {
+  defaultSubscriptions: new Map(),
+  componentsForSubs: new DefaultMap(() => new Set()),
+  subsForComponents: new DefaultMap(() => new Set()),
+};

--- a/lib/dal-materialized-views/src/component/attribute_tree.rs
+++ b/lib/dal-materialized-views/src/component/attribute_tree.rs
@@ -141,6 +141,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
                 let comp_id = AttributeValue::component_id(ctx, sub.attribute_value_id).await?;
                 let comp_name = Component::name_by_id(ctx, comp_id).await?;
                 let source = ExternalSource {
+                    component_id: comp_id,
                     path: sub.path.to_string(),
                     component_name: comp_name,
                     is_secret: sub.path.to_string().starts_with("/secrets/"),

--- a/lib/sdf-server/src/service/v2/component/attributes.rs
+++ b/lib/sdf-server/src/service/v2/component/attributes.rs
@@ -88,6 +88,8 @@ async fn set_as_default_source(
             ))?;
     AttributeValue::set_as_default_subscription_source(ctx, attribute_value_id).await?;
 
+    ctx.commit().await?;
+
     tracker.track(
         ctx,
         "set_default_source",
@@ -121,7 +123,9 @@ async fn delete_default_source(
                 component_id,
             ))?;
 
-    AttributeValue::set_as_default_subscription_source(ctx, attribute_value_id).await?;
+    AttributeValue::remove_default_subscription_source(ctx, attribute_value_id).await?;
+
+    ctx.commit().await?;
 
     tracker.track(
         ctx,

--- a/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/attribute_tree.rs
@@ -52,6 +52,7 @@ pub struct ValidationOutput {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ExternalSource {
+    pub component_id: ComponentId,
     pub component_name: String,
     pub path: String,
     pub is_secret: bool,

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -176,6 +176,7 @@ import CarbonCloseOutline from "~icons/carbon/close-outline";
 import CarbonCheckmarkOutline from "~icons/carbon/checkmark-outline";
 import CarbonChevronDown from "~icons/carbon/chevron-down";
 import CarbonChevronRight from "~icons/carbon/chevron-right";
+import CarbonRepeat from "~icons/carbon/repeat";
 
 // streamline
 import StreamlineBracesCircleSolid from "~icons/streamline/braces-circle-solid";
@@ -383,6 +384,7 @@ export const ICONS = Object.freeze({
   "refresh-active": Refresh,
   "refresh-carbon-active": Renew,
   "refresh-hex-outline": RefreshHexOutline,
+  repeat: CarbonRepeat,
   resize: Resize,
   save: Save,
   scissors: Scissors,

--- a/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
+++ b/lib/vue-lib/src/design-system/menus/DropdownMenuButton.vue
@@ -10,6 +10,8 @@
           modelValueLabel &&
           themeClasses('bg-action-200', 'bg-action-900'),
         variant === 'navbar' && 'flex-1 font-bold min-w-[80px] max-w-fit',
+        hoverBorder &&
+          themeClasses('hover:border-action-500', 'hover:border-action-300'),
         disabled
           ? [
               'cursor-not-allowed',
@@ -134,6 +136,7 @@ const props = defineProps({
   },
   minWidthToAnchor: { type: Boolean },
   noBorder: { type: Boolean },
+  hoverBorder: { type: Boolean },
   alignRightOnAnchor: { type: Boolean },
   enableSecondaryAction: { type: Function },
   secondaryActionIcon: { type: String as PropType<IconNames> },


### PR DESCRIPTION
Adds the ability to mark attributes as default subscription sources, and to display components grouped by whether they are subscribed to those attributes.

Hidden behind the `default-subs` feature flag. Enable it to see the checkboxes and ability to group components by default subscription.

NOTE: Two parts of this are unfinished: it is not fully styled. And there is a bug in the interaction with the default subscription where the attribute subscription list will intercept the checkbox click and trigger blur, focusing the attribute input. But I would like to merge this behind the flag and follow up on finishing up the rest of it.

To test: mark a region and credential as a default subscription. Add AWS components, remove them, Ensure the grouping updates. 