### PR TITLE
fix(web): Changing the simulation wording

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -321,7 +321,7 @@
                   )
                 "
               >
-                You are in a simulated change set:
+                You are in a simulated environment:
                 {{ ctx.changeSet.value.name }}
               </div>
               <!-- <VButton


### PR DESCRIPTION
Simulation and Change Set were the same words. Trying the following:

<img width="1443" height="60" alt="Screenshot 2025-08-18 at 23 14 21" src="https://github.com/user-attachments/assets/6fb53649-30c6-410b-a253-52a4c8e68e93" />
