### PR TITLE
Fix map button by ignorig grid mode watcher in map

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -918,6 +918,9 @@ const clearGroupBy = () => {
 watch(
   [hasSocketConnections, gridMode],
   ([newHasSocketConnections, newGridMode]) => {
+    // Only new socket connections with incompatible components group by when in grid view.
+    if (!showGrid.value) return;
+
     // If groupBy is set to IncompatibleComponents but there are no socket connections, clear it
     if (
       !newHasSocketConnections &&
@@ -930,6 +933,9 @@ watch(
 );
 
 watch(gridMode, (newMode, oldMode) => {
+  // Ignore the grid mode in map view.
+  if (!showGrid.value) return;
+
   // If we are moving in or out of pinning mode, we need to clear the selection.
   if (newMode.mode === "pinned" || oldMode.mode === "pinned") {
     clearSelection();


### PR DESCRIPTION
## Description

When switching to map view, we need to ignore the new grid mode watcher introduced by the default subs UI. If not, the URL will be cleared out and set to the grid view.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdldG9zbDBoOWR4Z3FyNzJ1bm5rNXc1Zmx2enVpdHJ4aXg5Z3V0YWMzNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Kx7HO28xRu1cG8S3GB/giphy.gif"/>

## Testing

- Switch between views
- Create some components
- Switch between HEAD, the change set, and the component details