### PR TITLE
Fix: checksum collision in mv data, need to add kind

### DIFF
--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -63,9 +63,9 @@ export type LobbyExitFn = (
 ) => void;
 
 export type MjolnirBulk = Array<{
-  kind: string;
+  kind: EntityKind;
   id: Id;
-  checksum?: Checksum;
+  checksum: Checksum;
 }>;
 
 export const SHARED_BROADCAST_CHANNEL_NAME = "SHAREDWORKER_BROADCAST";


### PR DESCRIPTION
## How does this PR change the system?
ID and Checksum are not sufficient keys to keep track of data, need to add the kind. For a given Component A with no connections, it will have at least 2 MVs with the same checksum (`ManagementConnections`, `IncomingConnections`) because the data shape is: the component ID (same between the two MVs) and an empty array/vec.

We were getting into a state where:
1. because old indexes were not being deleted
2. and we we're using `kind` in a "key" to keep track of things, MTM links were not getting populated for a given MV.

#### Screenshots:

<img width="482" height="382" alt="image" src="https://github.com/user-attachments/assets/a5712b50-7ca7-4ae4-9113-59f9ef507be5" />

#### Out of Scope:

One day we will start deleting indexes again.

## How was it tested?

1. Create a cred
3. Create a region (note: two things are important, you need to have an "old" index checksum
4. Load the map, see 2 components
5. Rune > Ragnarok
6. Refresh the page
7. Map shows 1 component

Watson found himself in this state initially without the Ragnorak.
He could get out of the state by going to the cred component, which would mjolnir and repair the missing link, fixing the map.
But deleting the current index was the best way to repro the state for others.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOXowaXUyMnFwN2VveGd5NXo0Ymx0MzcxMGM0YjZ0b2dvaXFkcTdqNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/B1fLJQIb4G4P6/giphy.gif"/>