### PR TITLE
Fix: don't mutate data potentially returned from tan stack cache

### DIFF
--- a/app/web/src/api/sdf/dal/change_set.ts
+++ b/app/web/src/api/sdf/dal/change_set.ts
@@ -29,7 +29,6 @@ export interface ChangeSet {
   updatedAt?: IsoDateString;
   abandonRequestedAt?: IsoDateString;
   abandonRequestedByUserId?: UserId;
-  isHead?: boolean;
 }
 
 export type ChangeStatus = "added" | "deleted" | "modified" | "unmodified";

--- a/app/web/src/newhotness/logic_composables/change_set.ts
+++ b/app/web/src/newhotness/logic_composables/change_set.ts
@@ -42,21 +42,15 @@ export const useChangeSets = (
 
   const openChangeSets = computed(() => {
     const changeSets = _.keyBy(changeSetQuery.data.value?.changeSets, "id");
-    return Object.values(changeSets)
-      .filter((cs) =>
-        [
-          ChangeSetStatus.Open,
-          ChangeSetStatus.NeedsApproval,
-          ChangeSetStatus.NeedsAbandonApproval,
-          ChangeSetStatus.Rejected,
-          ChangeSetStatus.Approved,
-        ].includes(cs.status),
-      )
-      .map((cs) => {
-        if (cs.id === changeSetQuery.data.value?.defaultChangeSetId)
-          cs.isHead = true;
-        return cs;
-      });
+    return Object.values(changeSets).filter((cs) =>
+      [
+        ChangeSetStatus.Open,
+        ChangeSetStatus.NeedsApproval,
+        ChangeSetStatus.NeedsAbandonApproval,
+        ChangeSetStatus.Rejected,
+        ChangeSetStatus.Approved,
+      ].includes(cs.status),
+    );
   });
 
   const changeSet = computed(() => {

--- a/app/web/src/newhotness/nav/AbandonChangeSetModal.vue
+++ b/app/web/src/newhotness/nav/AbandonChangeSetModal.vue
@@ -19,7 +19,7 @@
         icon="x"
         @click="closeModalHandler"
       />
-      <template v-if="!props.changeSet.isHead">
+      <template v-if="notHead">
         <VButton
           data-testid="abandon-change-set-modal-confirm-button"
           label="Abandon Change Set"
@@ -37,19 +37,28 @@
 <script lang="ts" setup>
 import * as _ from "lodash-es";
 import { VButton, Modal } from "@si/vue-lib/design-system";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
 import { routes, useApi } from "@/newhotness/api_composables";
+import { useContext } from "../logic_composables/context";
 
 const props = defineProps<{
   changeSet: ChangeSet;
 }>();
 
+const ctx = useContext();
+
+const notHead = computed(
+  () =>
+    ctx.headChangeSetId.value &&
+    props.changeSet.id !== ctx.headChangeSetId.value,
+);
+
 const modalRef = ref<InstanceType<typeof Modal> | null>(null);
 
 async function openModalHandler() {
-  if (props.changeSet.name === "HEAD" || props.changeSet.isHead) return;
+  if (props.changeSet.name === "HEAD" || !notHead.value) return;
   modalRef.value?.open();
 }
 

--- a/app/web/src/newhotness/nav/ChangeSetPanel.vue
+++ b/app/web/src/newhotness/nav/ChangeSetPanel.vue
@@ -62,7 +62,8 @@
       data-testid="abandon-change-set-button"
       :disabled="
         !changeSet ||
-        changeSet.isHead ||
+        (ctx.headChangeSetId.value &&
+          changeSet.id === ctx.headChangeSetId.value) ||
         createApi.inFlight.value ||
         changeSet.status === ChangeSetStatus.NeedsApproval
       "


### PR DESCRIPTION
## How does this PR change the system?

We were getting a warning about setting the `cs.isHead` value. That `cs` object can be returned from the readonly tan stack cache

#### Screenshots:

## How was it tested?

You can still abandon a change set

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzMzbWdxdTN1aWpjMmJxNWJlYW44ejl2MHlpbDIxdzJwYW96czd4aCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/kEK66eKT7FhPrlDsk6/giphy.gif"/>