### PR TITLE
fix: Allow json -> string subscriptions (relax type mismatch error)

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2137,7 +2137,7 @@ impl AttributeValue {
         let subscription_prop_id = subscription.validate(ctx).await?;
         let subscription_prop_kind = Prop::kind(ctx, subscription_prop_id).await?;
         let subscriber_prop_kind = AttributeValue::prop_kind(ctx, subscriber_av_id).await?;
-        if subscription_prop_kind != subscriber_prop_kind {
+        if !subscription_prop_kind.js_compatible_with(subscriber_prop_kind) {
             return Err(AttributeValueError::SubscriptionTypeMismatch {
                 subscriber_av_id,
                 subscriber_prop_kind,

--- a/lib/dal/src/prop.rs
+++ b/lib/dal/src/prop.rs
@@ -423,6 +423,19 @@ impl PropKind {
             PropKind::String => IntrinsicFunc::SetString,
         }
     }
+
+    /// Check if the two PropKinds are both the same JavaScript type ({}, [], string, number, boolean)
+    pub fn js_compatible_with(&self, other: PropKind) -> bool {
+        match self {
+            PropKind::Array => matches!(other, PropKind::Array),
+            PropKind::Boolean => matches!(other, PropKind::Boolean),
+            PropKind::Integer | PropKind::Float => {
+                matches!(other, PropKind::Integer | PropKind::Float)
+            }
+            PropKind::Json | PropKind::String => matches!(other, PropKind::Json | PropKind::String),
+            PropKind::Map | PropKind::Object => matches!(other, PropKind::Map | PropKind::Object),
+        }
+    }
 }
 
 impl From<PropKind> for PropSpecKind {


### PR DESCRIPTION
Right now, if you try to subscribe from ManagedPolicy's `PolicyDocument` to String Template `Value`, you get a "type mismatch" error. JSON is basically a specific kind of string; we don't want to disallow these subscriptions because they will in fact work.

## How does this PR change the system?

Type mismatch rules now check that the *javascript* type is equivalent. This allows String Template to work with JSON, while still preventing the bad secret subscriptions that prompted us to check this in the first place.

## How was it tested?

- [X] Integration tests pass

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExd3pxYTF5cW40dmxqdnZpcGxjdTI3cjltbmlkcXBxNDgzY2k4ODd6ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/yx400dIdkwWdsCgWYp/giphy.gif)
