### PR TITLE
Display any errors from the component update attributes endpoint

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -170,6 +170,7 @@ import {
   onMounted,
   provide,
   reactive,
+  Ref,
   ref,
   watch,
 } from "vue";
@@ -309,6 +310,18 @@ const route = useRoute();
 
 const saveApi = useApi();
 
+const saveErrors = ref<Record<string, string>>({});
+
+export interface AttributeErrors {
+  saveErrors: Ref<Record<string, string>>;
+}
+const errorContext = computed<AttributeErrors>(() => {
+  return {
+    saveErrors,
+  };
+});
+provide("ATTRIBUTE_ERRORS", errorContext);
+
 const save = async (
   path: AttributePath,
   value: string,
@@ -324,6 +337,13 @@ const save = async (
 
   const { req, newChangeSetId } =
     await call.put<componentTypes.UpdateComponentAttributesArgs>(payload);
+
+  if (!saveApi.ok(req)) {
+    saveErrors.value[path] = value;
+  } else {
+    delete saveErrors.value[path];
+  }
+
   if (saveApi.ok(req) && newChangeSetId) {
     saveApi.navigateToNewChangeSet(
       {


### PR DESCRIPTION
These errors are actually pretty rare!

## How does this PR change the system?

`<AttributePanel>` provides a context with API failures against the `routes.UpdateComponentAttributes` endpoint

#### Screenshots:

The right end "bump" is there for a failing validation, so I'm leaving it there for this error case as well. Can of course adjust it, but it seems we made a decision that errors display this way?

<img width="919" height="214" alt="image" src="https://github.com/user-attachments/assets/0d7bac70-6cf8-4d51-8730-533ce7180400" />
<img width="911" height="283" alt="image" src="https://github.com/user-attachments/assets/e3045e79-c830-489d-b65a-88d4fadaf965" />


## How was it tested?

It's actually really hard to generate one of these errors, now that @jkeiser has closed the one error he had with the string template.

1. Mock error data with a hardcoded value (see screenshot)
2. See it display correctly
3. Submit a new value
4. Watch the error disappear on API success