### PR TITLE
fix(web): ensure default subs checkbox shows

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -666,10 +666,7 @@
             />
           </div>
           <label
-            v-if="
-              featureFlagsStore.DEFAULT_SUBS &&
-              filteredConnections.length - 1 > 0
-            "
+            v-if="featureFlagsStore.DEFAULT_SUBS"
             :for="`checkbox-${prop?.id}`"
             :class="
               clsx(


### PR DESCRIPTION
A miscommunication led to accidentally hiding the default sub checkbox even with the flag on. This restores it.

