### PR TITLE
feat(luminork): Exposing Erase component in Luminork

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -67,6 +67,7 @@ pub use components::{
         DuplicateComponentsV1Request,
         DuplicateComponentsV1Response,
     },
+    erase_component::EraseComponentV1Response,
     execute_management_function::{
         ExecuteManagementFunctionV1Request,
         ExecuteManagementFunctionV1Response,
@@ -166,6 +167,7 @@ pub use crate::api_types::func_run::v1::{
         components::duplicate_components::duplicate_components,
         components::upgrade_component::upgrade_component,
         components::generate_template::generate_template,
+        components::erase_component::erase_component,
         schemas::list_schemas::list_schemas,
         schemas::find_schema::find_schema,
         schemas::get_schema::get_schema,
@@ -216,6 +218,7 @@ pub use crate::api_types::func_run::v1::{
             UpdateComponentV1Request,
             UpdateComponentV1Response,
             DeleteComponentV1Response,
+            EraseComponentV1Response,
             DuplicateComponentsV1Request,
             DuplicateComponentsV1Response,
             GenerateTemplateV1Request,

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -73,6 +73,7 @@ pub mod connections;
 pub mod create_component;
 pub mod delete_component;
 pub mod duplicate_components;
+pub mod erase_component;
 pub mod execute_management_function;
 pub mod find_component;
 pub mod generate_template;
@@ -804,6 +805,7 @@ pub fn routes() -> Router<AppState> {
                 )
                 .route("/action", post(add_action::add_action))
                 .route("/manage", post(manage_component::manage_component))
-                .route("/upgrade", post(upgrade_component::upgrade_component)),
+                .route("/upgrade", post(upgrade_component::upgrade_component))
+                .route("/erase", post(erase_component::erase_component)),
         )
 }

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -230,6 +230,12 @@ pub enum AuditLogKindV1 {
         component_id: Option<ComponentId>,
         subject_name: String,
     },
+    EraseComponent {
+        name: String,
+        component_id: ComponentId,
+        schema_variant_id: SchemaVariantId,
+        schema_variant_name: String,
+    },
     ExecuteFunc {
         func_id: FuncId,
         func_display_name: Option<String>,
@@ -679,6 +685,13 @@ pub enum AuditLogMetadataV1 {
         subject_name: String,
     },
     #[serde(rename_all = "camelCase")]
+    EraseComponent {
+        name: String,
+        component_id: ComponentId,
+        schema_variant_id: SchemaVariantId,
+        schema_variant_name: String,
+    },
+    #[serde(rename_all = "camelCase")]
     ExecuteFunc {
         func_id: FuncId,
         func_display_name: Option<String>,
@@ -986,6 +999,7 @@ impl AuditLogMetadataV1 {
             MetadataDiscrim::DeleteSecret => ("Deleted", Some("Secret")),
             MetadataDiscrim::DeleteView => ("Deleted", Some("View")),
             MetadataDiscrim::DetachFunc => ("Detached", Some("Function")),
+            MetadataDiscrim::EraseComponent => ("Erased", Some("Component")),
             MetadataDiscrim::ExecuteFunc => ("Executed", Some("Function")),
             MetadataDiscrim::ExportWorkspace => ("Exported", Some("Workspace")),
             MetadataDiscrim::InstallWorkspace => ("Installed", Some("Workspace")),
@@ -1334,6 +1348,17 @@ impl From<Kind> for Metadata {
                 schema_variant_id,
                 component_id,
                 subject_name,
+            },
+            Kind::EraseComponent {
+                name,
+                component_id,
+                schema_variant_id,
+                schema_variant_name,
+            } => Self::EraseComponent {
+                name,
+                component_id,
+                schema_variant_id,
+                schema_variant_name,
             },
             Kind::ExecuteFunc {
                 func_id,


### PR DESCRIPTION
We need to be able to expose erase as a specific operation on component so that we can use it in our MCP server.

<img width="1910" height="252" alt="Screenshot 2025-08-20 at 15 30 00" src="https://github.com/user-attachments/assets/01937b80-2fda-4b0d-ab7a-536c4d54c36e" />
