### PR TITLE
fix(web): Special case creating deleteComponents endpoint

### DIFF
--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -432,7 +432,9 @@ export const useApi = <SpecificArgs extends EndpointArgs = EndpointArgs>(
     const canMutateHead = CAN_MUTATE_ON_HEAD.includes(key);
     const mustCompress = COMPRESSED_ROUTES.includes(key);
     const argList = args ? Object.entries(args).flatMap((m) => m) : [];
-    const desc = `${key} ${argList.join(": ")} by ${
+    const desc = `${
+      key === routes.DeleteComponents ? "Remove Component" : key
+    } ${argList.join(": ")} by ${
       ctx.user?.name
     } on ${new Date().toLocaleDateString()}`;
     labeledObs = setLabel(obs, `${key}.${argList.join(".")}`);


### PR DESCRIPTION
Both erase and delete components endpoints are the same, we just pass a 
different parameter. 

This means that creating a delete and erase change set will generate the
same name. That was difficult to understand for users. So we are going 
to call it “remove components” as a middle ground