### PR TITLE
fix(web): Ensure default subs box is checkable, style the grouping

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -806,8 +806,10 @@ export const changeSetExists = async (
   changeSetId: ChangeSetId,
 ) => await db.changeSetExists(workspaceId, changeSetId);
 
-/// Make a reactive query key that includes the workspace, changeSet, EntityKind and entity ID
-/// (if any).
+/// Make a reactive query key that includes the workspace, changeSet, EntityKind
+/// and entity ID (if any). You can also add an extension, if you want to
+/// respond to invalidations of EntityKind + entity ID but for a different
+/// query.
 ///
 /// @returns A computed reactive key suitable for use with tanstack useQuery() or useQueryClient().
 ///
@@ -822,12 +824,14 @@ export const useMakeKey = () => {
   return <K = Gettable>(
     kind: MaybeRefOrGetter<K>,
     id?: MaybeRefOrGetter<string>,
+    extension?: MaybeRefOrGetter<string>,
   ) =>
-    computed<[string, string, ComputedRef<K> | K, string]>(() => [
+    computed<[string, string, ComputedRef<K> | K, string, string]>(() => [
       ctx.workspacePk.value,
       ctx.changeSetId.value,
       toValue(kind),
       toValue(id ?? ctx.workspacePk),
+      toValue(extension ?? ""),
     ]);
 };
 

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -105,6 +105,7 @@ import Scissors from "~icons/clarity/scissors-solid";
 import Frame from "~icons/iconamoon/frame-light";
 import MaterialSymbolsKeyboardDoubleArrowLeftRounded from "~icons/material-symbols/keyboard-double-arrow-left-rounded";
 import MaterialSymbolsStopCircleOutlineRounded from "~icons/material-symbols/stop-circle-outline-rounded";
+import MaterialSymbolsArrowOutward from "~icons/material-symbols/arrow-outward";
 import MaterialSymbolsLightTouchpadMouseRounded from "~icons/material-symbols-light/touchpad-mouse";
 import IcBaselinePlusMinusAlt from "~icons/ic/baseline-plus-minus-alt";
 import MaterialSymbolsKeyboardCommandKey from "~icons/material-symbols/keyboard-command-key";
@@ -246,6 +247,7 @@ export const ICONS = Object.freeze({
   "alert-triangle": AlertTriangle,
   "alert-triangle-filled": CarbonWarningAltFilled,
   "alert-triangle-outline": CarbonWarningAlt,
+  "arrow-outward": MaterialSymbolsArrowOutward,
   "arrows-out": PhArrowsOutCardinal,
   backspace: MaterialSymbolsBackspaceOutline,
   beaker: Beaker,


### PR DESCRIPTION
Ensure you can click the checkbox and don't scroll to focus the input if the blur event fires because of checking the box.

Matching as closely as I can the design of the default subscriptions grouping. Now shows the value of the source (as the design intends).

<img width="1063" height="973" alt="Screenshot 2025-08-20 at 3 06 36 PM" src="https://github.com/user-attachments/assets/cab026e5-e424-49be-af84-66ddb9dae838" />