### PR TITLE
feat: pretty review screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8504,6 +8504,7 @@ dependencies = [
  "module-index-types",
  "remain",
  "serde",
+ "serde-tuple-vec-map",
  "serde_json",
  "si-events",
  "si-frontend-mv-types-macros",

--- a/app/web/src/api/sdf/dal/component.ts
+++ b/app/web/src/api/sdf/dal/component.ts
@@ -25,7 +25,7 @@ export interface ComponentIdentificationTimestamp {
   timestamp: string;
 }
 
-export interface ComponentDiff {
+export interface ComponentTextDiff {
   componentId: string;
   current: CodeView;
   diff?: CodeView;

--- a/app/web/src/newhotness/ComponentListItem.vue
+++ b/app/web/src/newhotness/ComponentListItem.vue
@@ -1,0 +1,52 @@
+<template>
+  <div
+    tabindex="0"
+    :data-list-item-component-id="component.id"
+    :class="
+      clsx(
+        'flex flex-row items-center gap-xs p-2xs text-sm',
+        'border border-transparent rounded-sm cursor-pointer outline-none',
+        '[&>span]:min-w-0',
+        themeClasses('hover:border-action-500', 'hover:border-action-300'),
+        selected && themeClasses('bg-action-200', 'bg-action-900'),
+      )
+    "
+  >
+    <StatusIndicatorIcon type="qualification" :status="qualificationStatus" />
+    <TextPill
+      tighter
+      variant="component"
+      :class="themeClasses('text-green-light-mode', 'text-green-dark-mode')"
+    >
+      <TruncateWithTooltip>{{ component.schemaName }}</TruncateWithTooltip>
+    </TextPill>
+    <TextPill tighter variant="component" class="text-purple">
+      <TruncateWithTooltip>{{ component.name }}</TruncateWithTooltip>
+    </TextPill>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  TextPill,
+  themeClasses,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { computed } from "vue";
+import {
+  BifrostComponent,
+  ComponentInList,
+} from "@/workers/types/entity_kind_types";
+import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
+import { getQualificationStatus } from "./ComponentTileQualificationStatus.vue";
+
+const props = defineProps<{
+  component: ComponentInList | BifrostComponent;
+  selected?: boolean;
+}>();
+
+const qualificationStatus = computed(() =>
+  getQualificationStatus(props.component),
+);
+</script>

--- a/app/web/src/newhotness/ReviewAttributeItem.vue
+++ b/app/web/src/newhotness/ReviewAttributeItem.vue
@@ -1,0 +1,79 @@
+<template>
+  <div
+    :class="
+      clsx(
+        'flex flex-col gap-xs p-xs border',
+        themeClasses(
+          'border-neutral-400 bg-white',
+          'border-neutral-600 bg-neutral-800',
+        ),
+        '[&>*]:h-10 [&>div]:p-xs [&>h1]:py-xs',
+      )
+    "
+  >
+    <h1>{{ path }}</h1>
+    <div
+      v-if="diff.new"
+      :class="
+        clsx(
+          'flex flex-row items-center gap-xs',
+          themeClasses('bg-success-200', 'bg-success-900'),
+        )
+      "
+    >
+      <div
+        :class="
+          clsx(
+            'text-xl flex-none',
+            themeClasses('text-success-600', 'text-success-500'),
+          )
+        "
+      >
+        +
+      </div>
+      <TruncateWithTooltip class="py-2xs"
+        >{{ diff.new.$value }} SOURCE:
+        {{ diff.new.$source }}</TruncateWithTooltip
+      >
+    </div>
+    <div
+      v-if="diff.old"
+      :class="
+        clsx(
+          'flex flex-row items-center gap-xs',
+          themeClasses('text-neutral-600', 'text-neutral-400'),
+        )
+      "
+    >
+      <div class="text-xl flex-none">-</div>
+      <TruncateWithTooltip class="line-through mr-auto py-2xs"
+        >{{ diff.old.$value }} SOURCE:
+        {{ diff.old.$source }}</TruncateWithTooltip
+      >
+      <IconButton
+        class="flex-none"
+        icon="undo"
+        iconTone="shade"
+        iconIdleTone="shade"
+        tooltip="Revert to old value"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  IconButton,
+  themeClasses,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
+import clsx from "clsx";
+import { PropType } from "vue";
+import { AttributeDiff } from "@/workers/types/entity_kind_types";
+import { AttributePath } from "@/api/sdf/dal/component";
+
+defineProps({
+  path: { type: String as PropType<AttributePath>, required: true },
+  diff: { type: Object as PropType<AttributeDiff>, required: true },
+});
+</script>

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -356,13 +356,6 @@ const emit = defineEmits<{
 <script lang="ts">
 // Grid tiles need to have a fixed height - make sure this number matches its total height!
 export const GRID_TILE_HEIGHT = 269;
-
-export function getQualificationStatus(component: ComponentInList) {
-  if (component.qualificationTotals.failed > 0) return "failure";
-  if (component.qualificationTotals.warned > 0) return "warning";
-  if (component.qualificationTotals.succeeded > 0) return "success";
-  return "unknown";
-}
 </script>
 
 <style scoped>

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -7,10 +7,10 @@
         'flex flex-col items-stretch',
         'border overflow-hidden basis-0 mb-[-1px]', // basis-0 makes items take equal size when multiple are open
         themeClasses(
-          'border-neutral-300 bg-white',
+          'border-neutral-400 bg-white',
           'border-neutral-600 bg-neutral-800',
         ),
-        openState.open.value ? 'grow' : 'shrink',
+        showOpen ? 'grow' : 'shrink',
       )
     "
     :style="`min-height: ${headerHeight}px`"
@@ -21,25 +21,31 @@
         clsx(
           h3class,
           'group/header',
-          'cursor-pointer text-lg flex-none h-lg flex items-center px-xs m-0',
-          openState.open.value && 'border-b',
+          'flex-none flex items-center px-xs m-0',
+          !disableCollapse && [
+            'cursor-pointer',
+            themeClasses('hover:bg-neutral-100', 'hover:bg-neutral-700'),
+          ],
+          `text-${headerTextSize}`,
+          showOpen && 'border-b',
           themeClasses(
-            'bg-white border-neutral-300 hover:bg-neutral-100',
-            'bg-neutral-800 border-neutral-600 hover:bg-neutral-700',
+            'bg-white border-neutral-400',
+            'bg-neutral-800 border-neutral-600',
           ),
         )
       "
       @click="toggleOpen"
     >
       <Icon
-        :name="openState.open.value ? 'chevron-down' : 'chevron-right'"
+        v-if="!disableCollapse"
+        :name="showOpen ? 'chevron-down' : 'chevron-right'"
         size="sm"
       />
       <slot name="header" />
       <div class="ml-auto" />
       <slot name="headerIcons" />
       <IconButton
-        v-if="expandable && openState.open.value"
+        v-if="expandable && showOpen && !disableCollapse"
         tooltip="Expand"
         tooltipPlacement="top"
         size="xs"
@@ -48,7 +54,7 @@
         @click.prevent.stop="expand"
       />
     </h3>
-    <div v-if="openState.open.value" :class="clsx('scrollable min-h-0 flex-1')">
+    <div v-if="showOpen" :class="clsx('scrollable min-h-0 flex-1')">
       <slot />
     </div>
     <Modal ref="modalRef" size="4xl">
@@ -70,6 +76,7 @@ import {
   IconButton,
   Modal,
   Icon,
+  SpacingSizes,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed, onMounted, ref } from "vue";
@@ -89,15 +96,21 @@ const props = withDefaults(
     open?: boolean;
     h3class?: string;
     expandable?: boolean;
+    headerTextSize?: SpacingSizes;
+    disableCollapse?: boolean;
   }>(),
   {
     h3class: tw`flex flex-row items-center gap-xs p-2xs z-30`,
     expandable: true,
+    disableCollapse: false,
+    headerTextSize: "lg",
   },
 );
 
 const headerRef = ref<HTMLDivElement>();
 const headerHeight = computed(() => headerRef.value?.offsetHeight ?? 0);
+
+const showOpen = computed(() => openState.open.value || props.disableCollapse);
 
 onMounted(() => {
   openState.open.value = props.open;

--- a/app/web/src/store/components.store.ts
+++ b/app/web/src/store/components.store.ts
@@ -31,7 +31,7 @@ import {
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import {
   AttributePath,
-  ComponentDiff,
+  ComponentTextDiff,
   ComponentId,
   Edge,
   EdgeId,
@@ -773,7 +773,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
 
           componentCodeViewsById: {} as Record<ComponentId, CodeView[]>,
           componentResourceById: {} as Record<ComponentId, Resource>,
-          componentDiffsById: {} as Record<ComponentId, ComponentDiff>,
+          componentDiffsById: {} as Record<ComponentId, ComponentTextDiff>,
 
           rawComponentsById: {} as Record<ComponentId, RawComponent>,
           nodesById: {} as Record<ComponentId, DiagramNodeData>,
@@ -1486,7 +1486,7 @@ export const useComponentsStore = (forceChangeSetId?: ChangeSetId) => {
           },
 
           async FETCH_COMPONENT_DIFF(componentId: ComponentId) {
-            return new ApiRequest<{ componentDiff: ComponentDiff }>({
+            return new ApiRequest<{ componentDiff: ComponentTextDiff }>({
               url: "component/get_diff",
               keyRequestStatusBy: componentId,
               params: {

--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -13,14 +13,15 @@ use dal::{
 };
 use si_frontend_mv_types::component::{
     Component as ComponentMv,
-    ComponentDiff,
     ComponentDiffStatus,
     ComponentInList as ComponentInListMv,
+    ComponentTextDiff,
     SchemaMembers,
 };
 use telemetry::prelude::*;
 
 pub mod attribute_tree;
+pub mod component_diff;
 
 #[instrument(
     name = "dal_materialized_views.component_in_list",
@@ -132,7 +133,7 @@ pub async fn assemble(ctx: DalContext, component_id: ComponentId) -> crate::Resu
             Some(code_view) => code_view.code,
             None => None,
         };
-        ComponentDiff {
+        ComponentTextDiff {
             current: dal_component_diff.current.code,
             diff,
         }

--- a/lib/dal-materialized-views/src/component/component_diff.rs
+++ b/lib/dal-materialized-views/src/component/component_diff.rs
@@ -1,0 +1,451 @@
+use dal::{
+    AttributePrototype,
+    AttributeValue,
+    Component,
+    DalContext,
+    Func,
+    attribute::{
+        prototype::argument::{
+            AttributePrototypeArgument,
+            static_value::StaticArgumentValue,
+            value_source::ValueSource,
+        },
+        value::subscription::ValueSubscription,
+    },
+    func::intrinsics::IntrinsicFunc,
+};
+use si_frontend_mv_types::component::{
+    ComponentDiffStatus,
+    component_diff::{
+        AttributeDiff,
+        AttributeSource,
+        AttributeSourceAndValue,
+        ComponentDiff,
+        SimplifiedAttributeSource,
+    },
+};
+use si_id::{
+    AttributePrototypeArgumentId,
+    AttributePrototypeId,
+    AttributeValueId,
+    ComponentId,
+};
+
+/// Generates a [`ComponentDiff`] MV.
+pub async fn assemble(new_ctx: DalContext, id: ComponentId) -> crate::Result<ComponentDiff> {
+    // If we are already on HEAD, it's unmodified; short circuit!
+    let new_ctx = &new_ctx;
+    let old_ctx = new_ctx.clone_with_head().await?;
+    let old_ctx = &old_ctx;
+    if new_ctx.change_set_id() == old_ctx.change_set_id() {
+        return Ok(ComponentDiff {
+            id,
+            diff_status: ComponentDiffStatus::None,
+            attribute_diffs: vec![],
+        });
+    }
+
+    // Diff attributes
+    let new_root_av_id = if Component::exists_by_id(new_ctx, id).await? {
+        Some(Component::root_attribute_value_id(new_ctx, id).await?)
+    } else {
+        None
+    };
+    let old_root_av_id = if Component::exists_by_id(old_ctx, id).await? {
+        Some(Component::root_attribute_value_id(old_ctx, id).await?)
+    } else {
+        None
+    };
+    let attribute_diffs = diff_attributes(old_ctx, old_root_av_id, new_ctx, new_root_av_id).await?;
+
+    // Figure out diff status
+    let diff_status = if new_root_av_id.is_some() {
+        if old_root_av_id.is_none() {
+            ComponentDiffStatus::Added
+        } else if !attribute_diffs.is_empty() {
+            ComponentDiffStatus::Modified
+        } else {
+            ComponentDiffStatus::None
+        }
+    } else {
+        ComponentDiffStatus::Removed
+    };
+
+    Ok(ComponentDiff {
+        id,
+        diff_status,
+        attribute_diffs,
+    })
+}
+
+// Walk two attributes, diffing them and their children and adding the results to
+async fn diff_attributes(
+    old_ctx: &DalContext,
+    old_av_id: Option<AttributeValueId>,
+    new_ctx: &DalContext,
+    new_av_id: Option<AttributeValueId>,
+) -> crate::Result<Vec<(String, AttributeDiff)>> {
+    let mut attribute_diffs = vec![];
+    let mut work_queue = Vec::from([(old_av_id, new_av_id)]);
+    while let Some((old_av_id, new_av_id)) = work_queue.pop() {
+        match (old_av_id, new_av_id) {
+            // Modified or Unchanged
+            (Some(old_av_id), Some(new_av_id)) => {
+                // If they are different, push up the Modified entry.
+                if !attributes_are_same(old_ctx, old_av_id, new_ctx, new_av_id).await? {
+                    // If they are different, diff them.
+                    let (_, new_path) = AttributeValue::path_from_root(new_ctx, new_av_id).await?;
+                    let old = assemble_source_and_value(old_ctx, old_av_id).await?;
+                    let new = assemble_source_and_value(new_ctx, new_av_id).await?;
+                    attribute_diffs.push((new_path, AttributeDiff::Modified { old, new }));
+                }
+
+                // Check if any children are different (whether this particular AV was different
+                // or not!)
+                for (old_av_id, new_av_id) in
+                    child_av_pairs(old_ctx, old_av_id, new_ctx, new_av_id).await?
+                {
+                    work_queue.push((old_av_id, new_av_id));
+                }
+            }
+
+            // Added
+            (None, Some(new_av_id)) => {
+                let (_, new_path) = AttributeValue::path_from_root(new_ctx, new_av_id).await?;
+                let new = assemble_source_and_value(new_ctx, new_av_id).await?;
+                attribute_diffs.push((new_path, AttributeDiff::Added { new }));
+
+                for new_av_id in AttributeValue::get_child_av_ids_in_order(new_ctx, new_av_id)
+                    .await?
+                    .into_iter()
+                    .rev()
+                {
+                    work_queue.push((None, Some(new_av_id)));
+                }
+            }
+
+            // Removed
+            (Some(old_av_id), None) => {
+                let (_, old_path) = AttributeValue::path_from_root(old_ctx, old_av_id).await?;
+                let old = assemble_source_and_value(old_ctx, old_av_id).await?;
+                attribute_diffs.push((old_path, AttributeDiff::Removed { old }));
+
+                for old_av_id in AttributeValue::get_child_av_ids_in_order(old_ctx, old_av_id)
+                    .await?
+                    .into_iter()
+                    .rev()
+                {
+                    work_queue.push((Some(old_av_id), None));
+                }
+            }
+
+            (None, None) => {}
+        }
+    }
+    Ok(attribute_diffs)
+}
+
+async fn attributes_are_same(
+    old_ctx: &DalContext,
+    old_av_id: AttributeValueId,
+    new_ctx: &DalContext,
+    new_av_id: AttributeValueId,
+) -> crate::Result<bool> {
+    // If the JS values are different, they are different
+    //
+    // (We only check the content address; it's technically possible for two JS values to be
+    // the same even if content is different, but only when there is extra whitespace in the
+    // JSON)
+    let old_av = AttributeValue::node_weight(old_ctx, old_av_id).await?;
+    let new_av = AttributeValue::node_weight(new_ctx, new_av_id).await?;
+    if old_av.value() != new_av.value() {
+        return Ok(false);
+    }
+
+    // If the prototypes are different, they are different
+    let old_prototype_id = AttributeValue::component_prototype_id(old_ctx, old_av_id).await?;
+    let new_prototype_id = AttributeValue::component_prototype_id(new_ctx, new_av_id).await?;
+    match (old_prototype_id, new_prototype_id) {
+        (Some(old_prototype_id), Some(new_prototype_id)) => {
+            if !prototypes_are_same(old_ctx, old_prototype_id, new_ctx, new_prototype_id).await? {
+                return Ok(false);
+            }
+        }
+        (None, None) => {
+            let old_prototype_id =
+                AttributeValue::schema_variant_prototype_id(old_ctx, old_av_id).await?;
+            let new_prototype_id =
+                AttributeValue::schema_variant_prototype_id(new_ctx, new_av_id).await?;
+            if !prototypes_are_same(old_ctx, old_prototype_id, new_ctx, new_prototype_id).await? {
+                return Ok(false);
+            }
+        }
+        // If one is the default prototype and the other is the schema variant prototype,
+        // they are different *even if the values / prototypes are the same*. This means the
+        // user has explicitly overridden, or unset the value.
+        (Some(_), None) | (None, Some(_)) => {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+async fn prototypes_are_same(
+    old_ctx: &DalContext,
+    old_prototype_id: AttributePrototypeId,
+    new_ctx: &DalContext,
+    new_prototype_id: AttributePrototypeId,
+) -> crate::Result<bool> {
+    // If the functions are different, they are different.
+    if AttributePrototype::func_id(old_ctx, old_prototype_id).await?
+        != AttributePrototype::func_id(new_ctx, new_prototype_id).await?
+    {
+        return Ok(false);
+    }
+
+    // If the arguments are different, they are different.
+    let old_apa_ids = AttributePrototype::list_arguments(old_ctx, old_prototype_id).await?;
+    let new_apa_ids = AttributePrototype::list_arguments(new_ctx, new_prototype_id).await?;
+    if old_apa_ids.len() != new_apa_ids.len() {
+        return Ok(false);
+    }
+    for (old_apa_id, new_apa_id) in old_apa_ids.into_iter().zip(new_apa_ids) {
+        if !arguments_are_same(old_ctx, old_apa_id, new_ctx, new_apa_id).await? {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+async fn arguments_are_same(
+    old_ctx: &DalContext,
+    old_apa_id: AttributePrototypeArgumentId,
+    new_ctx: &DalContext,
+    new_apa_id: AttributePrototypeArgumentId,
+) -> crate::Result<bool> {
+    // If they are for different arguments, they are different.
+    if AttributePrototypeArgument::func_argument_id(old_ctx, old_apa_id).await?
+        != AttributePrototypeArgument::func_argument_id(new_ctx, new_apa_id).await?
+    {
+        return Ok(false);
+    }
+
+    // If they are for different targets, they are different.
+    let old_arg = AttributePrototypeArgument::get_by_id(old_ctx, old_apa_id).await?;
+    let new_arg = AttributePrototypeArgument::get_by_id(new_ctx, new_apa_id).await?;
+    if old_arg.targets() != new_arg.targets() {
+        return Ok(false);
+    }
+
+    // If they have different value sources, they are different.
+    let old_value = AttributePrototypeArgument::value_source(old_ctx, old_apa_id).await?;
+    let new_value = AttributePrototypeArgument::value_source(new_ctx, new_apa_id).await?;
+    if !value_sources_are_same(old_ctx, old_value, new_ctx, new_value).await? {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+async fn value_sources_are_same(
+    old_ctx: &DalContext,
+    old_value: ValueSource,
+    new_ctx: &DalContext,
+    new_value: ValueSource,
+) -> crate::Result<bool> {
+    Ok(match (old_value, new_value) {
+        (ValueSource::InputSocket(old_id), ValueSource::InputSocket(new_id)) => old_id == new_id,
+        (ValueSource::OutputSocket(old_id), ValueSource::OutputSocket(new_id)) => old_id == new_id,
+        (ValueSource::Prop(old_id), ValueSource::Prop(new_id)) => old_id == new_id,
+        (ValueSource::Secret(old_id), ValueSource::Secret(new_id)) => old_id == new_id,
+        // Static values must have the same value
+        (ValueSource::StaticArgumentValue(old_id), ValueSource::StaticArgumentValue(new_id)) => {
+            StaticArgumentValue::value_content_hash(old_ctx, old_id).await?
+                == StaticArgumentValue::value_content_hash(new_ctx, new_id).await?
+        }
+        // Subscriptions must go to the same component and path
+        (ValueSource::ValueSubscription(old_sub), ValueSource::ValueSubscription(new_sub)) => {
+            subscriptions_are_same(old_ctx, old_sub, new_ctx, new_sub).await?
+        }
+
+        // Different types are different!
+        // NOTE: Writing out all the possibilities so if a new source is added, it will have to be
+        // added here as well due to exhaustive matching
+        (
+            ValueSource::InputSocket(_)
+            | ValueSource::OutputSocket(_)
+            | ValueSource::Prop(_)
+            | ValueSource::Secret(_)
+            | ValueSource::StaticArgumentValue(_)
+            | ValueSource::ValueSubscription(_),
+            _,
+        ) => false,
+    })
+}
+
+async fn subscriptions_are_same(
+    old_ctx: &DalContext,
+    old_sub: ValueSubscription,
+    new_ctx: &DalContext,
+    new_sub: ValueSubscription,
+) -> crate::Result<bool> {
+    // If they go to different paths, they are different.
+    if old_sub.path != new_sub.path {
+        return Ok(false);
+    }
+
+    // Short circuit if attribute value IDs are the same--they definitely go to the same root then.
+    // This saves us a bunch of traversal work for a very common case.
+    if old_sub.attribute_value_id == new_sub.attribute_value_id {
+        return Ok(true);
+    }
+
+    // Also have to check the attribute value paths (in case a sub goes to a non-root av)
+    let (old_root_id, old_av_path) =
+        AttributeValue::path_from_root(old_ctx, old_sub.attribute_value_id).await?;
+    let (new_root_id, new_av_path) =
+        AttributeValue::path_from_root(new_ctx, new_sub.attribute_value_id).await?;
+    if old_av_path != new_av_path {
+        return Ok(false);
+    }
+
+    // If they go to different components, they are different.
+    let old_component_id = AttributeValue::component_id(old_ctx, old_root_id).await?;
+    let new_component_id = AttributeValue::component_id(new_ctx, new_root_id).await?;
+    if old_component_id != new_component_id {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+async fn assemble_source_and_value(
+    ctx: &DalContext,
+    av_id: AttributeValueId,
+) -> crate::Result<AttributeSourceAndValue> {
+    let value = AttributeValue::view(ctx, av_id).await?;
+    let source = assemble_source(ctx, av_id).await?;
+    Ok(AttributeSourceAndValue { value, source })
+}
+
+async fn assemble_source(
+    ctx: &DalContext,
+    av_id: AttributeValueId,
+) -> crate::Result<AttributeSource> {
+    // Get the controlling prototype and where it's from (from_schema / from_ancestor)
+    let (from_ancestor, av_id) = match AttributeValue::controlling_av_id(ctx, av_id).await? {
+        Some(controlling_av_id) if controlling_av_id != av_id => {
+            let (_, path) = AttributeValue::path_from_root(ctx, controlling_av_id).await?;
+            (Some(path), controlling_av_id)
+        }
+        _ => (None, av_id),
+    };
+    let (from_schema, prototype_id) =
+        match AttributeValue::component_prototype_id(ctx, av_id).await? {
+            Some(prototype_id) => (None, prototype_id),
+            None => (
+                Some(true),
+                AttributeValue::schema_variant_prototype_id(ctx, av_id).await?,
+            ),
+        };
+
+    // Assemble the result
+    let simplified_source = assemble_simplified_source(ctx, av_id, prototype_id).await?;
+    Ok(AttributeSource {
+        simplified_source,
+        from_schema,
+        from_ancestor,
+    })
+}
+
+async fn assemble_simplified_source(
+    ctx: &DalContext,
+    av_id: AttributeValueId,
+    prototype_id: AttributePrototypeId,
+) -> crate::Result<SimplifiedAttributeSource> {
+    // Handle special-case subscription or value
+    let args = AttributePrototype::list_arguments(ctx, prototype_id).await?;
+    if let Some(&arg_id) = args.first()
+        && args.len() == 1
+    {
+        let func_id = AttributePrototype::func_id(ctx, prototype_id).await?;
+        if let Some(intrinsic) = Func::intrinsic_kind(ctx, func_id).await? {
+            // Static value (si:setString(), si:setObject(), etc.)
+            if let Some(static_value) =
+                AttributePrototypeArgument::static_value_by_id(ctx, arg_id).await?
+                && intrinsic.set_func().is_some()
+            {
+                return Ok(SimplifiedAttributeSource::Value {
+                    value: static_value.value,
+                });
+            }
+
+            // Subscription (si:identity(subscription to /component /path))
+            if let ValueSource::ValueSubscription(subscription) =
+                AttributePrototypeArgument::value_source(ctx, arg_id).await?
+                && IntrinsicFunc::Identity == intrinsic
+            {
+                // Don't bother if the path isn't /; if it's a subscription whose root is
+                // deeply nested, we'll call it a complex prototype and let fmt_title handle it.
+                let (root_id, root_path) =
+                    AttributeValue::path_from_root(ctx, subscription.attribute_value_id).await?;
+                if root_path == "/" {
+                    let component = AttributeValue::component_id(ctx, root_id).await?;
+                    return Ok(SimplifiedAttributeSource::Subscription {
+                        component,
+                        path: subscription.path.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    // If it isn't a special simplified case, show the prototype instead.
+    let component_id = AttributeValue::component_id(ctx, av_id).await?;
+    Ok(SimplifiedAttributeSource::Prototype {
+        prototype: AttributePrototype::fmt_title(ctx, prototype_id, Some(component_id)).await,
+    })
+}
+
+async fn child_av_pairs(
+    old_ctx: &DalContext,
+    old_parent_av_id: AttributeValueId,
+    new_ctx: &DalContext,
+    new_parent_av_id: AttributeValueId,
+) -> crate::Result<Vec<(Option<AttributeValueId>, Option<AttributeValueId>)>> {
+    let new_children = AttributeValue::get_child_av_ids_in_order(new_ctx, new_parent_av_id).await?;
+    let old_children = AttributeValue::get_child_av_ids_in_order(old_ctx, old_parent_av_id).await?;
+
+    let mut result = Vec::with_capacity(new_children.len().max(old_children.len()));
+    let new_children = new_children.into_iter().rev();
+    let mut old_children = old_children.into_iter().rev().peekable();
+    for new_av_id in new_children {
+        // Check if the old attribute value had this field.
+        //
+        // TODO match field name for objects and maps. If old and new maps are in a different
+        // order, or if the type or field order changes during a schema upgrade, then this may
+        // not detect whether two fields are the same.
+        let old_av_id = match old_children.peek() {
+            Some(&old_av_id) => {
+                let old_key = AttributeValue::key_for_id(new_ctx, old_av_id).await?;
+                let new_key = AttributeValue::key_for_id(new_ctx, new_av_id).await?;
+                match (old_key, new_key) {
+                    (Some(old_key), Some(new_key)) if old_key == new_key => old_children.next(),
+                    (None, None) => old_children.next(),
+                    _ => None,
+                }
+            }
+            None => None,
+        };
+        result.push((old_av_id, Some(new_av_id)));
+    }
+
+    // Go through any remaining old children we haven't consumed, and add them at the end
+    for old_av_id in old_children {
+        result.push((Some(old_av_id), None));
+    }
+
+    Ok(result)
+}

--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -54,9 +54,10 @@ pub async fn apply_and_refork(ctx: &mut DalContext) -> Result<()> {
 }
 
 /// Applies a forked context to head, consuming it.
-pub async fn apply(mut ctx: DalContext) -> Result<()> {
+/// Returns a new changeset representing head.
+pub async fn apply(mut ctx: DalContext) -> Result<DalContext> {
     ChangeSetTestHelpers::apply_change_set_to_base(&mut ctx).await?;
-    Ok(())
+    Ok(ctx)
 }
 
 /// This unit struct provides helper functions for working with [`ChangeSets`](ChangeSet). It is

--- a/lib/dal-test/src/helpers/component.rs
+++ b/lib/dal-test/src/helpers/component.rs
@@ -7,6 +7,7 @@ use dal::{
     DalContext,
     InputSocket,
     OutputSocket,
+    attribute::attributes,
     diagram::{
         geometry::Geometry,
         view::View,
@@ -53,6 +54,37 @@ pub async fn create(
             .await?
             .id(),
     )
+}
+
+/// Create a component with the given name and schema variant, and set some attributes
+pub async fn create_and_set(
+    ctx: &DalContext,
+    variant: impl SchemaVariantKey,
+    name: impl AsRef<str>,
+    values: serde_json::Value,
+) -> Result<ComponentId> {
+    let component_id = create(ctx, variant, name).await?;
+    update(ctx, component_id, values).await?;
+    Ok(component_id)
+}
+
+/// Create a component with the given name and schema variant
+pub async fn update(
+    ctx: &DalContext,
+    component: impl ComponentKey,
+    values: serde_json::Value,
+) -> Result<()> {
+    let component_id = self::id(ctx, component).await?;
+    let values = serde_json::from_value(values)?;
+    attributes::update_attributes(ctx, component_id, values).await?;
+    Ok(())
+}
+
+/// Remove a component from the graph (even if it has connections/sockets/children)
+pub async fn remove(ctx: &DalContext, component: impl ComponentKey) -> Result<()> {
+    let component_id = id(ctx, component).await?;
+    Component::remove(ctx, component_id).await?;
+    Ok(())
 }
 
 /// Find a management prototype by the prototype name (NOT THE FUNC NAME)

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -396,11 +396,11 @@ impl AttributePrototypeArgument {
         &self,
         ctx: &DalContext,
     ) -> AttributePrototypeArgumentResult<FuncArgument> {
-        let func_arg_id = Self::func_argument_id_by_id(ctx, self.id).await?;
+        let func_arg_id = Self::func_argument_id(ctx, self.id).await?;
         Ok(FuncArgument::get_by_id(ctx, func_arg_id).await?)
     }
 
-    pub async fn func_argument_id_by_id(
+    pub async fn func_argument_id(
         ctx: &DalContext,
         apa_id: AttributePrototypeArgumentId,
     ) -> AttributePrototypeArgumentResult<FuncArgumentId> {
@@ -434,7 +434,7 @@ impl AttributePrototypeArgument {
         // AP --> APA --> Func Arg
 
         for apa_id in AttributePrototype::list_arguments(ctx, ap_id).await? {
-            let this_func_arg_id = Self::func_argument_id_by_id(ctx, apa_id).await?;
+            let this_func_arg_id = Self::func_argument_id(ctx, apa_id).await?;
 
             if this_func_arg_id == func_argument_id {
                 return Ok(Some(apa_id));

--- a/lib/dal/src/attribute/prototype/debug.rs
+++ b/lib/dal/src/attribute/prototype/debug.rs
@@ -154,11 +154,9 @@ impl AttributePrototypeDebugView {
                 )
                 .await?;
 
-                let func_arg_id = AttributePrototypeArgument::func_argument_id_by_id(
-                    ctx,
-                    attribute_prototype_arg_id,
-                )
-                .await?;
+                let func_arg_id =
+                    AttributePrototypeArgument::func_argument_id(ctx, attribute_prototype_arg_id)
+                        .await?;
 
                 let func_arg_name = FuncArgument::get_name_by_id(ctx, func_arg_id).await?;
                 let value_source =

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -983,8 +983,7 @@ impl Component {
         let mut new_value_sources = vec![];
 
         for &apa_id in &apa_ids {
-            let func_arg_id =
-                AttributePrototypeArgument::func_argument_id_by_id(ctx, apa_id).await?;
+            let func_arg_id = AttributePrototypeArgument::func_argument_id(ctx, apa_id).await?;
 
             if let Some(source) = AttributePrototypeArgument::value_source_opt(ctx, apa_id).await? {
                 match source {
@@ -2379,7 +2378,7 @@ impl Component {
             .workspace_snapshot()?
             .get_node_weight(base_change_set_connection.attribute_prototype_argument_id)
             .await?;
-        let base_func_arg_id = AttributePrototypeArgument::func_argument_id_by_id(
+        let base_func_arg_id = AttributePrototypeArgument::func_argument_id(
             base_change_set_ctx,
             base_change_set_connection.attribute_prototype_argument_id,
         )

--- a/lib/dal/src/context.rs
+++ b/lib/dal/src/context.rs
@@ -1013,6 +1013,10 @@ impl DalContext {
         new
     }
 
+    pub async fn is_head(&self) -> TransactionsResult<bool> {
+        Ok(self.get_workspace_default_change_set_id().await? == self.change_set_id())
+    }
+
     pub async fn parent_is_head(&self) -> TransactionsResult<bool> {
         let change_set = self.change_set()?;
         let base_change_set_id = change_set

--- a/lib/dal/src/func/binding/attribute_argument.rs
+++ b/lib/dal/src/func/binding/attribute_argument.rs
@@ -115,8 +115,7 @@ impl AttributeArgumentBinding {
                 }
             };
 
-        let func_argument_id =
-            AttributePrototypeArgument::func_argument_id_by_id(ctx, apa_id).await?;
+        let func_argument_id = AttributePrototypeArgument::func_argument_id(ctx, apa_id).await?;
 
         Ok(Self {
             func_argument_id,

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -881,8 +881,7 @@ impl PkgExporter {
         let mut inputs = vec![];
 
         for &apa_id in &apas {
-            let func_arg_id =
-                AttributePrototypeArgument::func_argument_id_by_id(ctx, apa_id).await?;
+            let func_arg_id = AttributePrototypeArgument::func_argument_id(ctx, apa_id).await?;
             let func_arg = FuncArgument::get_by_id(ctx, func_arg_id).await?;
             let arg_name = func_arg.name;
 

--- a/lib/dal/src/pkg/import.rs
+++ b/lib/dal/src/pkg/import.rs
@@ -2022,9 +2022,7 @@ pub async fn attach_resource_payload_to_value(
 
     let mut rv_input_apa_id = None;
     for apa_id in AttributePrototypeArgument::list_ids_for_prototype(ctx, target_id).await? {
-        if func_argument_id
-            == AttributePrototypeArgument::func_argument_id_by_id(ctx, apa_id).await?
-        {
+        if func_argument_id == AttributePrototypeArgument::func_argument_id(ctx, apa_id).await? {
             rv_input_apa_id = Some(apa_id);
             break;
         }

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -1710,7 +1710,7 @@ impl SchemaVariant {
             let mut exisiting_func_arg = None;
             for apa_id in &apas {
                 let func_arg_id =
-                    AttributePrototypeArgument::func_argument_id_by_id(ctx, *apa_id).await?;
+                    AttributePrototypeArgument::func_argument_id(ctx, *apa_id).await?;
                 apa_func_arg_ids.insert(apa_id, func_arg_id);
 
                 if func_arg_id == input.func_argument_id {

--- a/lib/edda-server/src/materialized_view.rs
+++ b/lib/edda-server/src/materialized_view.rs
@@ -45,6 +45,7 @@ use si_frontend_mv_types::{
         ComponentList as ComponentListMv,
         SchemaMembers,
         attribute_tree::AttributeTree as AttributeTreeMv,
+        component_diff::ComponentDiff as ComponentDiffMv,
     },
     dependent_values::DependentValueComponentList as DependentValueComponentListMv,
     incoming_connections::{
@@ -1335,6 +1336,22 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 entity_mv_id,
                 ComponentMv,
                 dal_materialized_views::component::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into(),
+                ),
+            );
+        }
+        ReferenceKind::ComponentDiff => {
+            let entity_mv_id = change.entity_id.to_string();
+
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                ComponentDiffMv,
+                dal_materialized_views::component::component_diff::assemble(
                     ctx.clone(),
                     si_events::ulid::Ulid::from(change.entity_id).into(),
                 ),

--- a/lib/si-frontend-mv-types-rs/BUCK
+++ b/lib/si-frontend-mv-types-rs/BUCK
@@ -19,6 +19,7 @@ rust_library(
         "//third-party/rust:lazy_static",
         "//third-party/rust:remain",
         "//third-party/rust:serde",
+        "//third-party/rust:serde-tuple-vec-map",
         "//third-party/rust:serde_json",
         "//third-party/rust:strum",
     ],

--- a/lib/si-frontend-mv-types-rs/Cargo.toml
+++ b/lib/si-frontend-mv-types-rs/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = { workspace = true }
 module-index-types = { path = "../../lib/module-index-types" }
 remain = { workspace = true }
 serde = { workspace = true }
+serde-tuple-vec-map = { workspace = true }
 serde_json = { workspace = true }
 si-events = { path = "../../lib/si-events-rs" }
 si-frontend-mv-types-macros = { path = "../../lib/si-frontend-mv-types-macros" }

--- a/lib/si-frontend-mv-types-rs/src/checksum.rs
+++ b/lib/si-frontend-mv-types-rs/src/checksum.rs
@@ -288,6 +288,15 @@ where
     }
 }
 
+impl<T1: FrontendChecksum, T2: FrontendChecksum> FrontendChecksum for (T1, T2) {
+    fn checksum(&self) -> Checksum {
+        let mut hasher = ChecksumHasher::new();
+        hasher.update(self.0.checksum().as_bytes());
+        hasher.update(self.1.checksum().as_bytes());
+        hasher.finalize()
+    }
+}
+
 impl FrontendChecksum for DateTime<Utc> {
     fn checksum(&self) -> Checksum {
         FrontendChecksum::checksum(&self.to_rfc3339())

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -3,13 +3,13 @@ use serde::{
     Serialize,
 };
 use serde_json::Value;
-use si_events::{
+use si_events::workspace_snapshot::EntityKind;
+use si_id::{
     ComponentId,
     SchemaId,
     SchemaVariantId,
-    workspace_snapshot::EntityKind,
+    WorkspacePk,
 };
-use si_id::WorkspacePk;
 use strum::{
     AsRefStr,
     Display,
@@ -23,6 +23,7 @@ use crate::reference::{
 };
 
 pub mod attribute_tree;
+pub mod component_diff;
 
 #[derive(
     Debug,
@@ -51,7 +52,7 @@ pub struct ComponentQualificationStats {
     si_frontend_mv_types_macros::FrontendChecksum,
 )]
 #[serde(rename_all = "camelCase")]
-pub struct ComponentDiff {
+pub struct ComponentTextDiff {
     pub current: Option<String>,
     pub diff: Option<String>,
 }
@@ -88,7 +89,7 @@ pub struct Component {
     pub has_resource: bool,
     pub qualification_totals: ComponentQualificationStats,
     pub input_count: usize,
-    pub resource_diff: ComponentDiff,
+    pub resource_diff: ComponentTextDiff,
     pub is_secret_defining: bool,
     pub to_delete: bool,
 }
@@ -111,6 +112,7 @@ pub enum ComponentDiffStatus {
     Added,
     Modified,
     None,
+    Removed,
 }
 
 #[derive(

--- a/lib/si-frontend-mv-types-rs/src/component/component_diff.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/component_diff.rs
@@ -1,0 +1,379 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ComponentId,
+    workspace_snapshot::EntityKind,
+};
+use tuple_vec_map;
+
+use crate::{
+    component::ComponentDiffStatus,
+    reference::ReferenceKind,
+};
+
+/// Differences between a component in a changeset vs. head
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+    si_frontend_mv_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[mv(
+  trigger_entity = EntityKind::Component,
+  reference_kind = ReferenceKind::ComponentDiff,
+)]
+pub struct ComponentDiff {
+    /// The component ID
+    pub id: ComponentId,
+    /// The status of the component (added or modified)
+    pub diff_status: ComponentDiffStatus,
+    /// Attributes that have changed.
+    ///
+    /// Only one entry per spot in the tree: if an attribute is here, neither its parents nor
+    /// its children will have their own entries.
+    // tuple_vec_map preserves order while allowing the JSON representation to be an object
+    // (for more ergonomic APIs)
+    #[serde(with = "tuple_vec_map")]
+    pub attribute_diffs: Vec<(String, AttributeDiff)>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
+pub enum AttributeDiff {
+    /// This value was added in the current changeset.
+    Added { new: AttributeSourceAndValue },
+    /// This attribute was removed entirely from the current changeset.
+    Removed { old: AttributeSourceAndValue },
+    /// Either the source or value has changed (or both).
+    Modified {
+        new: AttributeSourceAndValue,
+        old: AttributeSourceAndValue,
+    },
+}
+
+/// An attribute's source, as well as its current value.
+///
+/// - Subscription:
+///
+///       {
+///            $value: "us-east-1",
+///            $source: {
+///                component: "My Region",
+///                path: "/domain/region"
+///            }
+///       }
+///
+/// - Value:
+///
+///       {
+///           $value: "us-east-1",
+///           $source: {
+///              value: "us-east-1"
+///           }
+///       }
+///
+/// - Set by a parent subscription:
+///
+///       {
+///          $value: "127.0.0.1"
+///          $source: {
+///              fromAncestor: "/domain/SecurityGroupIngress/3",
+///              component: "My Security Group Ingress Rule",
+///              path: "/domain",
+///          }
+///       }
+///
+/// - Set by schema (e.g. attribute function):
+///
+///       {
+///           $value: "ami-1234567890EXAMPLE",
+///           $source: {
+///               fromSchema: true,
+///               prototype: "AWS_EC2_AMI:getImageIdFromAws()"
+///           }
+///       }
+///
+///       {
+///           $value: "Region is us-east-2",
+///           $source: {
+///               fromSchema: true,
+///               fromAncestor: "/domain/Rendered",
+///               prototype: "String_Template:renderValue()"
+///           }
+///       }
+///
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AttributeSourceAndValue {
+    /// The source of this attribute.
+    #[serde(rename = "$source")]
+    pub source: AttributeSource,
+
+    /// The computed value of this attribute, *including child values*.
+    ///
+    /// - If an object field is None (i.e. currentValue is not in the JSON), the field will not
+    ///   show up (i.e. None == undefined).
+    /// - If an object field is null, the field will show up and have a null value.
+    /// - Object, maps and array values will include the child value.
+    #[serde(rename = "$value", skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+// TODO add deny_unknown_fields
+#[serde(rename_all = "camelCase")]
+pub struct AttributeSource {
+    // The actual source (value, subscription or prototype).
+    #[serde(flatten)]
+    pub simplified_source: SimplifiedAttributeSource,
+
+    /// Whether this value came from the schema prototype. Missing or false means it came from
+    /// a component prototype.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_schema: Option<bool>,
+
+    /// If this value came from a dynamic prototype or subscription on a parent/ancestor
+    /// attribute, this will be set to the path of that parent/ancestor. If this is unspecified,
+    /// the value came from a prototype on this attribute.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_ancestor: Option<String>,
+}
+
+/// The source of a value (but not whether it came from the schema, or from a parent)
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
+pub enum SimplifiedAttributeSource {
+    /// This attribute was set to a value by the user.
+    ///
+    ///     { value: "us-east-1"}
+    ///
+    /// If this is an object, map or array, the value will always be {} or [].
+    ///
+    /// This represents values set by component prototypes:
+    /// - si:setString("string"), etc.
+    /// - si:setMap({})
+    /// - si:setObject({})
+    /// - si:setObject([])
+    ///
+    Value { value: serde_json::Value },
+
+    /// This attribute is set to a subscription.
+    ///
+    ///     { component: "My Region", path: "/domain/region" }
+    ///
+    /// This represents values set by si:identity subscription:
+    /// - si:identity(arg = /domain/SubnetId on Subnet)
+    ///
+    Subscription {
+        component: ComponentId,
+        path: String,
+    },
+
+    /// This attribute is set to a complex function, possibly with multiple arguments.
+    ///
+    ///     { complexPrototype: "si:normalizeToArray(arg = /domain/SubnetId on Subnet)" }
+    ///
+    /// NOTE: we serialize it so you can read it, but you should not rely on the value or parse
+    /// it.
+    ///
+    Prototype { prototype: String },
+}
+
+#[allow(clippy::panic_in_result_fn)]
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_component_diff() -> serde_json::Result<()> {
+        let id = ComponentId::new();
+        assert_eq!(
+            ComponentDiff {
+                id,
+                diff_status: ComponentDiffStatus::Added,
+                attribute_diffs: vec![
+                    (
+                        "/domain/Foo".to_string(),
+                        AttributeDiff::Removed {
+                            old: AttributeSourceAndValue {
+                                source: AttributeSource {
+                                    simplified_source: SimplifiedAttributeSource::Value {
+                                        value: json!("foo")
+                                    },
+                                    from_schema: None,
+                                    from_ancestor: None,
+                                },
+                                value: Some(json!("foo")),
+                            }
+                        }
+                    ),
+                    (
+                        "/domain/Bar".to_string(),
+                        AttributeDiff::Added {
+                            new: AttributeSourceAndValue {
+                                source: AttributeSource {
+                                    simplified_source: SimplifiedAttributeSource::Value {
+                                        value: json!("bar")
+                                    },
+                                    from_schema: None,
+                                    from_ancestor: None,
+                                },
+                                value: Some(json!("bar")),
+                            }
+                        }
+                    ),
+                    (
+                        "/domain/Baz".to_string(),
+                        AttributeDiff::Modified {
+                            new: AttributeSourceAndValue {
+                                source: AttributeSource {
+                                    simplified_source: SimplifiedAttributeSource::Value {
+                                        value: json!("new_baz")
+                                    },
+                                    from_schema: None,
+                                    from_ancestor: None,
+                                },
+                                value: Some(json!("new_baz")),
+                            },
+                            old: AttributeSourceAndValue {
+                                source: AttributeSource {
+                                    simplified_source: SimplifiedAttributeSource::Value {
+                                        value: json!("baz")
+                                    },
+                                    from_schema: None,
+                                    from_ancestor: None,
+                                },
+                                value: Some(json!("baz")),
+                            }
+                        }
+                    ),
+                ]
+            },
+            serde_json::from_str(&format!(
+                r#"{{ "id": {}, "diffStatus": "Added", "attributeDiffs": {} }}"#,
+                serde_json::to_string(&id)?,
+                r#"{
+                        "/domain/Foo": {
+                            "old": {
+                                "$source": { "value": "foo" },
+                                "$value": "foo"
+                            }
+                        },
+                        "/domain/Bar": {
+                            "new": {
+                                "$source": { "value": "bar" },
+                                "$value": "bar"
+                            }
+                        },
+                        "/domain/Baz": {
+                            "new": {
+                                "$source": { "value": "new_baz" },
+                                "$value": "new_baz"
+                            },
+                            "old": {
+                                "$source": { "value": "baz" },
+                                "$value": "baz"
+                            }
+                        }
+                    }"#
+            ))?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_attribute_source_and_value() -> Result<(), serde_json::Error> {
+        assert_eq!(
+            AttributeSourceAndValue {
+                source: AttributeSource {
+                    simplified_source: SimplifiedAttributeSource::Value {
+                        value: json!("foo")
+                    },
+                    from_schema: None,
+                    from_ancestor: None,
+                },
+                value: Some(json!("foo")),
+            },
+            serde_json::from_str(
+                r#"{
+                    "$source": { "value": "foo" },
+                    "$value": "foo"
+                }"#,
+            )?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_attribute_source() -> Result<(), serde_json::Error> {
+        assert_eq!(
+            AttributeSource {
+                simplified_source: SimplifiedAttributeSource::Value {
+                    value: json!("foo")
+                },
+                from_schema: None,
+                from_ancestor: None,
+            },
+            serde_json::from_str(r#"{ "value": "foo" }"#)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_simplified_attribute_source() -> Result<(), serde_json::Error> {
+        assert_eq!(
+            SimplifiedAttributeSource::Value {
+                value: json!("foo")
+            },
+            serde_json::from_str(r#"{ "value": "foo" }"#)?
+        );
+
+        Ok(())
+    }
+}

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -46,6 +46,7 @@ pub enum ReferenceKind {
     ChangeSetMvIndex,
     ChangeSetRecord,
     Component,
+    ComponentDiff,
     ComponentInList,
     ComponentList,
     DependentValueComponentList,

--- a/lib/vue-lib/src/design-system/general/SiSearch.vue
+++ b/lib/vue-lib/src/design-system/general/SiSearch.vue
@@ -52,6 +52,7 @@
         :tabindex="tabIndex"
         @input="onChange"
         @keydown="onKeyDown"
+        @focus="onFocus"
         @blur="onBlur"
       />
       <Icon
@@ -169,6 +170,7 @@ const emit = defineEmits<{
   (e: "update:modelValue", newValue: string): void;
   (e: "enterPressed"): void;
   (e: "blur", event: FocusEvent): void;
+  (e: "focus", event: FocusEvent): void;
   (e: "input", event: Event): void;
 }>();
 
@@ -268,6 +270,10 @@ const blurSearch = () => {
 
 const onBlur = (e: FocusEvent) => {
   emit("blur", e);
+};
+
+const onFocus = (e: FocusEvent) => {
+  emit("focus", e);
 };
 
 const onChange = (e: Event) => {

--- a/lib/vue-lib/src/design-system/general/TextPill.vue
+++ b/lib/vue-lib/src/design-system/general/TextPill.vue
@@ -16,6 +16,11 @@
             'border-neutral-600 bg-neutral-100',
             'border-neutral-400 bg-neutral-800',
           ),
+        variant === 'component' &&
+          themeClasses(
+            'border-neutral-400 bg-neutral-100',
+            'border-neutral-600 bg-neutral-900',
+          ),
       )
     "
   >
@@ -28,7 +33,7 @@ import { PropType } from "vue";
 import clsx from "clsx";
 import { themeClasses } from "../utils/theme_tools";
 
-export type TextPillVariant = "simple" | "key" | "key2";
+export type TextPillVariant = "simple" | "key" | "key2" | "component";
 
 defineProps({
   tighter: { type: Boolean },

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -177,6 +177,7 @@ import CarbonCheckmarkOutline from "~icons/carbon/checkmark-outline";
 import CarbonChevronDown from "~icons/carbon/chevron-down";
 import CarbonChevronRight from "~icons/carbon/chevron-right";
 import CarbonRepeat from "~icons/carbon/repeat";
+import CarbonUndo from "~icons/carbon/undo";
 
 // streamline
 import StreamlineBracesCircleSolid from "~icons/streamline/braces-circle-solid";
@@ -415,6 +416,7 @@ export const ICONS = Object.freeze({
   "trash-restore": TrashRestore,
   "tree-parents": TreeParents,
   triangle: MdiTriangle,
+  undo: CarbonUndo,
   unlink: TdesignLinkUnlink,
   "user-circle": UserCircle,
   x: X,


### PR DESCRIPTION
This PR presents @VictoriaMolgado's slick attribute-by-attribute review screen, driven by a new ComponentDiff MV in the backend.

#### Screenshots:

<img width="1624" height="911" alt="image" src="https://github.com/user-attachments/assets/2816b602-885a-4a78-be58-1350f33afbeb" />

#### Out of Scope:

* Modified components sometimes show more fields than you'd expect. We'll bring that number down case by case.
* New components show too many fields! We'd like them to show fewer down the road.
* Removed components don't show up, because you can't generate an MV for something that doesn't exist. (We plan to solve this a different way.)

## How was it tested?

- [X] New integration tests for MVs
- [X] Integration tests pass
- [X] Manual test: review screen shows modified and added components
- [X] Manual test: review screen is reactive to changes

## In short:

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYno2Nmxjcm0yNWlrNGsyNGpuZjN2aHg0OGNzem81MHowdzQzMXFvdyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/nqc6rhyQv69w8QnDUU/giphy-downsized-medium.gif"/>