### PR TITLE
chore: buck2 update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752683762,
-        "narHash": "sha256-CVC4bpthYhKk4Qb4mt00SqfJ7CJ4vfTX06pLN2OHa1c=",
+        "lastModified": 1755736253,
+        "narHash": "sha256-jlIQRypNhB1PcB1BE+expE4xZeJxzoAGr1iUbHQta8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa64ec5c1ca6f17746f3defedb988b9248e97616",
+        "rev": "596312aae91421d6923f18cecce934a7d3bfd6b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Updates the flake to get the latest buck2, which silences all those awful crates.io warnings!

#### Screenshots:

Before:
<img width="939" height="532" alt="image" src="https://github.com/user-attachments/assets/a76142c3-1e3c-4cdf-ac92-36bdb65e9cc7" />

 After:
<img width="947" height="379" alt="image" src="https://github.com/user-attachments/assets/4c01d75d-3f18-4e32-8e9c-66bd9f57e49a" />

## How was it tested?

CI tests here will be sufficient

## In short: [:link:](https://giphy.com/)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYm1vcW0xMzRneXpmaTU5anBqOGF0bmc2a2luMnhucXJ1a3R1NWMxZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/EKDIMDsRX3ihy/giphy.gif"/>