### PR TITLE
fix(web): only use extension if defined

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -826,13 +826,25 @@ export const useMakeKey = () => {
     id?: MaybeRefOrGetter<string>,
     extension?: MaybeRefOrGetter<string>,
   ) =>
-    computed<[string, string, ComputedRef<K> | K, string, string]>(() => [
-      ctx.workspacePk.value,
-      ctx.changeSetId.value,
-      toValue(kind),
-      toValue(id ?? ctx.workspacePk),
-      toValue(extension ?? ""),
-    ]);
+    computed<
+      | [string, string, ComputedRef<K> | K, string, string]
+      | [string, string, ComputedRef<K> | K, string]
+    >(() =>
+      extension
+        ? [
+            ctx.workspacePk.value,
+            ctx.changeSetId.value,
+            toValue(kind),
+            toValue(id ?? ctx.workspacePk),
+            toValue(extension),
+          ]
+        : [
+            ctx.workspacePk.value,
+            ctx.changeSetId.value,
+            toValue(kind),
+            toValue(id ?? ctx.workspacePk),
+          ],
+    );
 };
 
 export const useMakeKeyForHead = () => {


### PR DESCRIPTION
We do not use `useMakeKey` for constructing all keys, so some invalidations or queries were failing due to the added blank string for `extension`.

