### PR TITLE
fix: macos flake woes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
           # breakpointHook
         ]
         ++ lib.optionals pkgs.stdenv.isDarwin [
-          darwin.sigtool
+          pkgs.darwin.sigtool
         ];
 
       buck2BuildInputs = with pkgs;
@@ -96,9 +96,6 @@
         ]
         ++ lib.optionals pkgs.stdenv.isDarwin [
           libiconv
-          darwin.apple_sdk.frameworks.Security
-          darwin.apple_sdk.frameworks.SystemConfiguration
-          darwin.apple_sdk.frameworks.CoreFoundation
         ];
 
       # The file name of the program interpreter/dynamic linker. We're primarily


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Some macos flake bits have been deprecated and are (apparently) no longer needed.

## How was it tested?

`buck2 run dev:up` on the ole macbook and everything builds correctly

## In short: [:link:](https://giphy.com/)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZWR4dnQwZWhoZ2I0bjA4cDJlc2JvNDlyaG83OTl5OHZrcGxiNG54NSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/4n0ptv9XAt1pS/giphy.gif"/>