### PR TITLE
Ensure Actions that are dispatched show as running 

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1082,7 +1082,7 @@ const componentsHaveActionsWithState = computed(() => {
     if (!action.componentId) continue;
     if (action.state === ActionState.Failed) {
       results.failed.add(action.componentId);
-    } else if (action.state === ActionState.Running) {
+    } else if (action.state === ActionState.Dispatched) {
       results.running.add(action.componentId);
     }
   }

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -299,7 +299,8 @@ async fn rebase_split(
         &original_workspace_snapshot,
         &to_rebase_workspace_snapshot,
         edda,
-        request,
+        request.change_set_id,
+        request.workspace_id,
         span,
     )
     .await?;
@@ -410,7 +411,8 @@ async fn rebase_legacy(
         &original_workspace_snapshot,
         &to_rebase_workspace_snapshot,
         edda,
-        request,
+        request.change_set_id,
+        request.workspace_id,
         span,
     )
     .await?;
@@ -418,12 +420,13 @@ async fn rebase_legacy(
     Ok(())
 }
 
-async fn send_updates_to_edda_split_snapshot(
+pub(crate) async fn send_updates_to_edda_split_snapshot(
     ctx: &DalContext,
     original_workspace_snapshot: &SplitSnapshot,
     to_rebase_workspace_snapshot: &SplitSnapshot,
     edda: &edda_client::Client,
-    request: &EnqueueUpdatesRequest,
+    change_set_id: ChangeSetId,
+    workspace_id: WorkspacePk,
     span: Span,
 ) -> Result<(), RebaseError> {
     let changes = original_workspace_snapshot
@@ -435,8 +438,8 @@ async fn send_updates_to_edda_split_snapshot(
     let change_batch_address = ctx.write_change_batch(changes).await?;
     let edda_update_request_id = edda
         .update_from_workspace_snapshot(
-            request.workspace_id,
-            request.change_set_id,
+            workspace_id,
+            change_set_id,
             original_workspace_snapshot.id().await,
             to_rebase_workspace_snapshot.id().await,
             change_batch_address,
@@ -446,12 +449,13 @@ async fn send_updates_to_edda_split_snapshot(
     Ok(())
 }
 
-async fn send_updates_to_edda_legacy_snapshot(
+pub(crate) async fn send_updates_to_edda_legacy_snapshot(
     ctx: &mut DalContext,
     original_workspace_snapshot: &WorkspaceSnapshot,
     to_rebase_workspace_snapshot: &WorkspaceSnapshot,
     edda: &edda_client::Client,
-    request: &EnqueueUpdatesRequest,
+    change_set_id: ChangeSetId,
+    workspace_id: WorkspacePk,
     span: Span,
 ) -> Result<(), RebaseError> {
     let changes = original_workspace_snapshot
@@ -463,8 +467,8 @@ async fn send_updates_to_edda_legacy_snapshot(
     let change_batch_address = ctx.write_change_batch(changes).await?;
     let edda_update_request_id = edda
         .update_from_workspace_snapshot(
-            request.workspace_id,
-            request.change_set_id,
+            workspace_id,
+            change_set_id,
             original_workspace_snapshot.id().await,
             to_rebase_workspace_snapshot.id().await,
             change_batch_address,


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
2 Changes: 
1. We missed one of the places where the front end was looking for actions in the `Running` state which is no longer in use
2. We recently modified the Actions Job to no longer modify the graph to capture the action’s now-running state. We planned on exposing `Dispatched` as the user indicator that the action is in flight, however because the dispatch happens after the rebase request has been processed (and Edda has been informed), we need to again, tell Edda about the 
change to the graph that the Rebaser does directly in post processing.


<!-- Why: briefly what problem this solves and what the aim is as an overview -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->


- [X] Manual test: Enqueue an action and see that it shows as running when it is dispatched!
- Also see that it successfully is removed on completion, and shows as failed when it fails


## In short: [:link:](https://giphy.com/)

<div><img src="https://media0.giphy.com/media/h2OLfcSKKthRK/giphy.gif?cid=5a38a5a2y3ivgw9ly6mhlilq21jk03fy0supzcjendt2muw6&amp;ep=v1_gifs_trending&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/gifs/reactiongifs-h2OLfcSKKthRK">GIPHY</a></div>