### PR TITLE
feat(si-mcp-server): Add initial posthog tracking to si-mcp-server and a Readme

### DIFF
--- a/bin/si-mcp-server/README.md
+++ b/bin/si-mcp-server/README.md
@@ -1,0 +1,70 @@
+# System Initiative MCP Server
+
+A Model Context Protocol (MCP) server that provides Claude Code with direct access to System Initiative's API for managing infrastructure components, change sets, schemas, and actions.
+
+## Development Setup
+
+### Environment Variables
+
+Required:
+
+```bash
+export SI_API_TOKEN="your-token-here"
+export SI_BASE_URL="http://localhost:5380"  # Defaults to production if not overridden
+```
+
+Optional analytics configuration:
+
+```bash
+export POSTHOG_API_KEY="dev-posthog-key"  # Override if you want to use the Dev Project to test tracking changes
+```
+
+### Testing with MCP Inspector
+
+The MCP Inspector provides a web interface for testing tools and debugging:
+
+```bash
+# Start the inspector
+deno task inspector
+```
+
+This opens a browser interface where you can:
+
+- Test individual tools with parameters
+- Inspect tool schemas and validate responses  
+- Debug authentication and connection issues
+- View real-time tool execution
+
+### Testing with Claude Code
+
+Configure Claude Code to use your local server (without running in a container):
+
+```bash
+# From the repository root
+claude mcp add si-mcp-server-dev -- deno run --allow-env --allow-net bin/si-mcp-server/main.ts stdio
+
+# Or from within si-mcp-server directory  
+claude mcp add si-mcp-server-dev -- deno run --allow-env --allow-net main.ts stdio
+
+# Verify it's working
+claude mcp list
+```
+
+## Available Tasks
+
+| Task | Command | Description |
+|------|---------|-------------|
+| `dev` | `deno task dev` | Run with auto-reload for development |
+| `inspector` | `deno task inspector` | Start MCP Inspector for testing |
+| `build` | `deno task build` | Compile to standalone binary |
+| `docker:build` | `deno task docker:build` | Build Docker image |
+| `docker:run` | `deno task docker:run` | Run Docker container |
+
+## Adding New Tools
+
+1. Create tool file in `src/tools/`
+2. Import required dependencies and `withAnalytics` from `commonBehavior.ts`
+3. Define Zod schemas for input/output validation
+4. Wrap handler with `withAnalytics(toolName, async () => { ... })`
+5. Export tool registration function
+6. Register in `src/server.ts`

--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "dev": "deno run -A --watch main.ts stdio",
     "inspector": "npx @modelcontextprotocol/inspector deno run -A ./main.ts stdio",
+    "build": "deno compile --allow-env --allow-net main.ts",
     "docker:build": "docker build -t si-mcp-server .",
     "docker:run": "docker run --rm -i si-mcp-server"
   },
@@ -16,6 +17,7 @@
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",
+    "posthog-node": "npm:posthog-node@^4.2.1",
     "ulid": "npm:ulid@^3.0.1",
     "zod": "npm:zod@^3.21.4",
     "zod-to-json-schema": "npm:zod-to-json-schema@^3.24.6"

--- a/bin/si-mcp-server/src/analytics.ts
+++ b/bin/si-mcp-server/src/analytics.ts
@@ -1,0 +1,84 @@
+import { PostHog } from "posthog-node";
+import { USER_ID, WORKSPACE_ID } from "./si_client.ts";
+
+export class Analytics {
+  private posthog: PostHog | null = null;
+  private sessionId: string;
+
+  constructor() {
+    this.sessionId = crypto.randomUUID();
+    this.initializePostHog();
+  }
+
+  private initializePostHog() {
+    const apiKey = Deno.env.get("POSTHOG_API_KEY") || "phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK"; // Prod Posthog
+    const host = Deno.env.get("POSTHOG_HOST") || "https://e.systeminit.com";
+
+    if (apiKey) {
+      this.posthog = new PostHog(apiKey, { host });
+    }
+  }
+
+  private getDistinctId(): string {
+    return USER_ID;
+  }
+  private getWorkspaceId(): string {
+    return WORKSPACE_ID;
+  }
+
+
+  async identifyUser() {
+    if (!this.posthog || !USER_ID) return;
+    this.posthog.identify({
+      distinctId: USER_ID,
+      properties: {
+        userId: USER_ID,
+      }
+    });
+  }
+
+  async trackEvent(eventName: string, properties: Record<string, any> = {}) {
+    if (!this.posthog) return;
+    const event = `mcp-${eventName}`;
+    try {
+      this.posthog.capture({
+        distinctId: this.getDistinctId(),
+        event,
+        properties: {
+          $session_id: this.sessionId, // PostHog standard session property
+          workspace_id: this.getWorkspaceId(),
+          ...properties,
+        },
+      });
+    } catch (error) {
+      console.error("Analytics tracking failed:", error);
+    }
+  }
+
+  async trackToolUsage(toolName: string, executionTimeMs: number) {
+    await this.trackEvent("tool_used", {
+      toolName,
+      executionTimeMs,
+    });
+  }
+
+  async trackError(toolName: string, errorProperties?: Record<string, any>) {
+    await this.trackEvent("tool_error", {
+      toolName,
+      ...errorProperties
+    });
+  }
+
+  async trackServerStart() {
+    await this.trackEvent("mcp_server_started");
+  }
+
+  async trackServerEnd() {
+    await this.trackEvent("mcp_server_ended");
+    if (this.posthog) {
+      await this.posthog.shutdown();
+    }
+  }
+}
+
+export const analytics = new Analytics();

--- a/bin/si-mcp-server/src/cli.ts
+++ b/bin/si-mcp-server/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from "@cliffy/command";
 import { start_stdio } from "./stdio_transport.ts";
 import { createServer } from "./server.ts";
+import { analytics } from "./analytics.ts";
 
 export async function run() {
   const command = new Command()
@@ -28,6 +29,7 @@ export async function run() {
       "Start the SI MCP Server over the stdio transport",
     )
     .action(async () => {
+      await analytics.trackServerStart();
       const server = createServer();
       await start_stdio(server);
     });

--- a/bin/si-mcp-server/src/si_client.ts
+++ b/bin/si-mcp-server/src/si_client.ts
@@ -1,6 +1,7 @@
 import { Configuration } from "@systeminit/api-client";
 import { logger } from "./logger.ts";
 import { jwtDecode } from "jwt-decode";
+import { analytics } from "./analytics.ts";
 
 interface SIJwtPayload {
   workspaceId: string;
@@ -27,10 +28,14 @@ export const apiConfig = new Configuration({
 });
 const decoded = jwtDecode<SIJwtPayload>(apiToken);
 export const WORKSPACE_ID = decoded.workspaceId;
+export const USER_ID = decoded.userId;
 if (!WORKSPACE_ID) {
   logger.error(
     `Tried to extract workspace ID from API Token, but failed. Your token is likely malformed! The decoded token follows:\n\n${
       JSON.stringify(decoded, null, 2)
     }`,
   );
+}
+if (USER_ID) {
+  await analytics.identifyUser();
 }

--- a/bin/si-mcp-server/src/tools/actionList.ts
+++ b/bin/si-mcp-server/src/tools/actionList.ts
@@ -12,6 +12,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { ActionList, ActionSchema } from "../data/actions.ts";
 import { ChangeSet } from "../data/changeSets.ts";
@@ -55,6 +56,7 @@ export function actionListTool(server: McpServer) {
       outputSchema: ListActionsOutputSchemaRaw,
     },
     async ({ changeSetId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (!changeSetId) {
         const changeSetsApi = new ChangeSetsApi(apiConfig);
         try {
@@ -135,6 +137,7 @@ export function actionListTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/actionUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/actionUpdateStatus.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 
 const name = "action-update-status";
@@ -53,6 +54,7 @@ export function actionUpdateTool(server: McpServer) {
       outputSchema: UpdateActionOutputSchemaRaw,
     },
     async ({ changeSetId, newStatus, actionId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (!changeSetId) {
         return errorResponse({
           message:
@@ -105,6 +107,7 @@ export function actionUpdateTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/changeSetCreate.ts
+++ b/bin/si-mcp-server/src/tools/changeSetCreate.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { ChangeSetSchema } from "../data/changeSets.ts";
 
@@ -46,6 +47,7 @@ export function changeSetCreateTool(server: McpServer) {
       outputSchema: CreateChangeSetOutputSchemaRaw,
     },
     async ({ changeSetName }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (!changeSetName) {
         return errorResponse({
           message:
@@ -64,6 +66,7 @@ export function changeSetCreateTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/changeSetList.ts
+++ b/bin/si-mcp-server/src/tools/changeSetList.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { ChangeSetSchema } from "../data/changeSets.ts";
 
@@ -44,6 +45,7 @@ export function changeSetListTool(server: McpServer) {
       outputSchema: ListChangeSetsOutputSchemaRaw,
     },
     async (): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ChangeSetsApi(apiConfig);
       try {
         const response = await siApi.listChangeSets({
@@ -56,6 +58,7 @@ export function changeSetListTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 
 const name = "change-set-update-status";
@@ -55,6 +56,7 @@ export function changeSetUpdateTool(server: McpServer) {
       outputSchema: UpdateChangeSetOutputSchemaRaw,
     },
     async ({ changeSetId, newStatus }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (!changeSetId) {
         return errorResponse({
           message:
@@ -127,6 +129,7 @@ export function changeSetUpdateTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentCreate.ts
+++ b/bin/si-mcp-server/src/tools/componentCreate.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { AttributesSchema } from "../data/components.ts";
 
@@ -59,6 +60,7 @@ export function componentCreateTool(server: McpServer) {
     async (
       { changeSetId, componentName, schemaName, attributes },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ComponentsApi(apiConfig);
       try {
         const response = await siApi.createComponent({
@@ -82,6 +84,7 @@ export function componentCreateTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentDelete.ts
+++ b/bin/si-mcp-server/src/tools/componentDelete.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 
 const name = "component-delete";
@@ -58,6 +59,7 @@ export function componentDeleteTool(server: McpServer) {
       outputSchema: DeleteComponentOutputSchemaRaw,
     },
     async ({ changeSetId, componentId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ComponentsApi(apiConfig);
       try {
         await siApi.deleteComponent({
@@ -73,6 +75,7 @@ export function componentDeleteTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentDiscover.ts
+++ b/bin/si-mcp-server/src/tools/componentDiscover.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { AttributesSchema } from "../data/components.ts";
 
@@ -66,6 +67,7 @@ export function componentDiscoverTool(server: McpServer) {
     async (
       { changeSetId, schemaName, attributes },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (schemaName.startsWith("AWS")) {
         let hasCredential = false;
         let hasRegion = false;
@@ -168,6 +170,7 @@ export function componentDiscoverTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentEnqueueAction.ts
+++ b/bin/si-mcp-server/src/tools/componentEnqueueAction.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import _ from "lodash";
 
@@ -56,6 +57,7 @@ export function componentEnqueueActionTool(server: McpServer) {
     async (
       { changeSetId, componentId, actionName },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ComponentsApi(apiConfig);
       try {
         const response = await siApi.addAction({
@@ -74,6 +76,7 @@ export function componentEnqueueActionTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentErase.ts
+++ b/bin/si-mcp-server/src/tools/componentErase.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 
 const name = "component-erase";
@@ -56,6 +57,7 @@ export function componentEraseTool(server: McpServer) {
       outputSchema: EraseComponentOutputSchemaRaw,
     },
     async ({ changeSetId, componentId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ComponentsApi(apiConfig);
       try {
         await siApi.eraseComponent({
@@ -71,6 +73,7 @@ export function componentEraseTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentGet.ts
+++ b/bin/si-mcp-server/src/tools/componentGet.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import _ from "lodash";
 import { AttributesSchema } from "../data/components.ts";
@@ -109,6 +110,7 @@ export function componentGetTool(server: McpServer) {
     async (
       { changeSetId, componentId, code, qualifications },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ComponentsApi(apiConfig);
       try {
         const response = await siApi.getComponent({
@@ -216,6 +218,7 @@ export function componentGetTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentImport.ts
+++ b/bin/si-mcp-server/src/tools/componentImport.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { AttributesSchema } from "../data/components.ts";
 
@@ -66,6 +67,7 @@ export function componentImportTool(server: McpServer) {
     async (
       { changeSetId, schemaName, resourceId, attributes },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (schemaName.startsWith("AWS")) {
         let hasCredential = false;
         let hasRegion = false;
@@ -168,6 +170,7 @@ export function componentImportTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentList.ts
+++ b/bin/si-mcp-server/src/tools/componentList.ts
@@ -12,6 +12,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { ChangeSet } from "../data/changeSets.ts";
 
@@ -85,7 +86,8 @@ export function componentListTool(server: McpServer) {
       outputSchema: ListComponentsOutputSchemaRaw,
     },
     async ({ changeSetId, filters }): Promise<CallToolResult> => {
-      if (!changeSetId) {
+      return await withAnalytics(name, async () => {
+        if (!changeSetId) {
         const changeSetsApi = new ChangeSetsApi(apiConfig);
         try {
           const changeSetList = await changeSetsApi.listChangeSets({
@@ -117,6 +119,7 @@ export function componentListTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/componentUpdate.ts
+++ b/bin/si-mcp-server/src/tools/componentUpdate.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { AttributesSchema } from "../data/components.ts";
 
@@ -56,6 +57,7 @@ export function componentUpdateTool(server: McpServer) {
     async (
       { changeSetId, attributes, componentId },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new ComponentsApi(apiConfig);
       try {
         await siApi.updateComponent({
@@ -76,6 +78,7 @@ export function componentUpdateTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/funcRunGet.ts
+++ b/bin/si-mcp-server/src/tools/funcRunGet.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { decodeBase64 } from "@std/encoding/base64";
 
@@ -121,6 +122,7 @@ export function funcRunGetTool(server: McpServer) {
         result: showResult,
       },
     ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new FuncsApi(apiConfig);
       try {
         const response = await siApi.getFuncRun({
@@ -170,6 +172,7 @@ export function funcRunGetTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/schemaAttributesDocumentation.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesDocumentation.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { generateDescription, successResponse } from "./commonBehavior.ts";
+import { generateDescription, successResponse, withAnalytics } from "./commonBehavior.ts";
 import { getSchemaAttributeDocumentation } from "../data/cfDb.ts";
 
 const name = "schema-attributes-documentation";
@@ -55,7 +55,8 @@ export function schemaAttributesDocumentationTool(server: McpServer) {
       inputSchema: DocumentSchemaAttributesInputSchemaRaw,
       outputSchema: DocumentSchemaAttributesOutputSchemaRaw,
     },
-    ({ documentationToRetrive }): CallToolResult => {
+    async ({ documentationToRetrive }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const docs = [];
       for (const docSpec of documentationToRetrive) {
         const documentation = getSchemaAttributeDocumentation(
@@ -73,6 +74,7 @@ export function schemaAttributesDocumentationTool(server: McpServer) {
       return successResponse(
         docs,
       );
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/schemaAttributesList.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesList.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { generateDescription, successResponse } from "./commonBehavior.ts";
+import { generateDescription, successResponse, withAnalytics } from "./commonBehavior.ts";
 import { getAttributesForService } from "../data/cfDb.ts";
 
 const name = "schema-attributes-list";
@@ -56,7 +56,8 @@ export function schemaAttributesListTool(server: McpServer) {
       inputSchema: ListSchemaAttributesInputSchemaRaw,
       outputSchema: ListSchemaAttributesOutputSchemaRaw,
     },
-    ({ schemaName }): CallToolResult => {
+    async ({ schemaName }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       let responseData: ListSchemaAttributesOutput["data"];
 
       if (schemaName == "AWS::IAM::User") {
@@ -403,6 +404,7 @@ export function schemaAttributesListTool(server: McpServer) {
         responseData,
         "If this is an AWS resource, the attributes map 1:1 to to the Cloudformation resource, where the path is calculated by looking at the Cloudformation resources nesting. You should look up the documentation for any attribute by its schemaName and path with the schema-attributes-documentation tool before setting any values.",
       );
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 import { isValid } from "ulid";
 import { getDocumentationForService } from "../data/cfDb.ts";
@@ -69,6 +70,7 @@ export function schemaFindTool(server: McpServer) {
       outputSchema: FindSchemaOutputSchemaRaw,
     },
     async ({ changeSetId, schemaNameOrId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       if (!changeSetId) {
         const changeSetsApi = new ChangeSetsApi(apiConfig);
         try {
@@ -283,6 +285,7 @@ Alternatively, you can authenticate by assuming an IAM role, which provides long
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/bin/si-mcp-server/src/tools/validateCredentials.ts
+++ b/bin/si-mcp-server/src/tools/validateCredentials.ts
@@ -7,8 +7,10 @@ import {
   errorResponse,
   generateDescription,
   successResponse,
+  withAnalytics,
 } from "./commonBehavior.ts";
 
+const name = "validate-credentials";
 const description =
   `<description>Validates System Initiative API credentials and workspace access. Returns information about the user, workspace, and token on success. On failure, returns error details.</description><usage>Use this tool to confirm a working credential, or after an API failure due to authentication, to confirm the credentials are working.</usage>`;
 
@@ -47,7 +49,7 @@ const ValidateCredentialOutputSchema = z.object(
 
 export function validateCredentialsTool(server: McpServer) {
   server.registerTool(
-    "validate-credentials",
+    name,
     {
       title: "Validate credentials with System Initiative",
       description: generateDescription(
@@ -61,6 +63,7 @@ export function validateCredentialsTool(server: McpServer) {
       outputSchema: ValidateCredentialOutputSchemaRaw,
     },
     async (): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
       const siApi = new WhoamiApi(apiConfig);
       try {
         const response = await siApi.whoami();
@@ -70,6 +73,7 @@ export function validateCredentialsTool(server: McpServer) {
       } catch (error) {
         return errorResponse(error);
       }
+      });
     },
   );
 }

--- a/deno.lock
+++ b/deno.lock
@@ -69,6 +69,7 @@
     "npm:node-fetch@2.7.0": "2.7.0_encoding@0.1.13",
     "npm:openai@^4.85.1": "4.104.0_zod@3.25.76_encoding@0.1.13",
     "npm:pluralize@*": "8.0.0",
+    "npm:posthog-node@^4.2.1": "4.18.0",
     "npm:toml@3.0.0": "3.0.0",
     "npm:typescript@^4.9.5": "4.9.5",
     "npm:ulid@^3.0.1": "3.0.1",
@@ -1173,6 +1174,12 @@
     "pluralize@8.0.0": {
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
+    "posthog-node@4.18.0": {
+      "integrity": "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==",
+      "dependencies": [
+        "axios"
+      ]
+    },
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
@@ -1648,6 +1655,7 @@
           "npm:axios@^1.6.1",
           "npm:jwt-decode@4",
           "npm:lodash@^4.17.21",
+          "npm:posthog-node@^4.2.1",
           "npm:ulid@^3.0.1",
           "npm:zod-to-json-schema@^3.24.6",
           "npm:zod@^3.21.4"


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
This change adds basic posthog tracking to the mcp server. We’ll have events for:
- Server start/end
- Each time a tool is invoked
- Each time an error occurs during tool invocation

We’re not threading much data through yet, but this gives us some initial visibility.

I've also added a readme with some basic info to help with the dev loop. 
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:
<img width="832" height="253" alt="image" src="https://github.com/user-attachments/assets/cc570c26-9f0d-4120-897c-7d1b7b406beb" />

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:
Enriched tracking- for now I've added simple events but the plumbing is there if we wanted to track more specific interactions or activity
<!-- Anything this PR explicitly leaves out? -->

## How was it tested?
Use the MCP and see the events show up in Posthog!
<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

<div><img src="https://media3.giphy.com/media/211e4CYjahC2Q/giphy.gif?cid=5a38a5a2j0ax8n5unokzc5jxo6v7kjl2ip7sbjhrhfelknwq&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:225px;width:300px"/><br/>via <a href="https://giphy.com/gifs/beach-hedgehog-211e4CYjahC2Q">GIPHY</a></div>