### PR TITLE
feat: improve map view experience

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1720,16 +1720,6 @@ watch(searchString, () => {
   });
 });
 
-// Clear the selection when the filter or search string changes
-// TODO leave the selection as long as it is still one of the filtered components?
-watch(filteredComponents, () => {
-  if (mapRef.value && typeof mapRef.value.deselect === "function") {
-    mapRef.value.deselect();
-  }
-  // TODO: when the underlying componentList changes, the indexes will change
-  // which means the selected indexes could have moved in either direction
-});
-
 // this is so that when on the map view, if you have a component selected
 // and start searching, we clear the selected component
 // on grid view, this has no impact, because you can't focus on the search box if you've got component(s) selected


### PR DESCRIPTION
### This PR does the following
- **Adds component selection tracking to the map redraw:** If a user has component A selected, on map redraw that user will continue to see component A selected, previously it dropped the selection
- **Adds pan consistency to map redraw:** If a user is looking at component A, map redraws caused by external events will keep the current viewport offset from component A, previously it dropped the pan/reset
- **Adds animation to added/removed components and edges on map redraw:** If new components are added or components removed, sister sessions from other users (or the same user) show smooth redraws/smooth pans for map rejigging, previously it 1-framed / harshly added components which was impossible to follow

### Testing Steps
All the permutations!
- If a user has multiple components selected and  one of those is deleted by another user, the remaining components should remain selected
- If a user has `all` it's selected components by a third party, the map/pan position should remain static during redraw
- If a user has an incoming or outgoing edge added to a selected component the viewport must remain passive/no-impact for user's view
- Add a component while looking at the map
- Have the map open while switching change sets
- Delete components while looking at the map, with and without filters
- Add & remove subscriptions while looking at the map, and with filters.

<div><img src="https://media1.giphy.com/media/d2jjuAZzDSVLZ5kI/giphy.gif?cid=5a38a5a2u7dojlso0hqi61wvoqtt1zpb3bubfqe88nbx9fc4&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/></div>