### PR TITLE
Fix odd compiler error by using string union type

### DIFF
--- a/app/web/src/components/ApplyHistoryItem.vue
+++ b/app/web/src/components/ApplyHistoryItem.vue
@@ -46,7 +46,7 @@
               v-tooltip="timestampTooltip"
               class="dark:hover:text-action-300 hover:text-action-500"
               size="normal"
-              relative
+              relative="standard"
               showTimeIfToday
               :date="new Date(actionBatch.startedAt)"
             />

--- a/app/web/src/components/SecretCard.vue
+++ b/app/web/src/components/SecretCard.vue
@@ -84,7 +84,7 @@
         <span class="italic">
           <Timestamp
             :date="new Date(secret.updatedInfo.timestamp)"
-            relative
+            relative="standard"
             size="normal"
           />
           by
@@ -96,7 +96,7 @@
         <span class="italic">
           <Timestamp
             :date="new Date(secret.createdInfo.timestamp)"
-            relative
+            relative="standard"
             size="normal"
           />
           by

--- a/app/web/src/components/Workspace/WorkspaceAuditLog.vue
+++ b/app/web/src/components/Workspace/WorkspaceAuditLog.vue
@@ -297,7 +297,7 @@ const columns = [
     cell: (info) =>
       h(Timestamp, {
         date: info.getValue(),
-        relative: true,
+        relative: "standard",
         enableDetailTooltip: true,
         refresh: true,
       }),

--- a/app/web/src/newhotness/ComponentHistory.vue
+++ b/app/web/src/newhotness/ComponentHistory.vue
@@ -20,7 +20,7 @@
             <Timestamp
               class="text-neutral-400"
               :date="auditLog.timestamp"
-              relativeShorthand
+              relative="shorthand"
               enableDetailTooltip
               refresh
             />

--- a/lib/vue-lib/src/design-system/general/Timestamp.vue
+++ b/lib/vue-lib/src/design-system/general/Timestamp.vue
@@ -20,8 +20,10 @@ const props = defineProps({
     type: [Date, String] as PropType<string | Date>,
     default: new Date(),
   },
-  relative: { type: Boolean, default: false },
-  relativeShorthand: { type: Boolean, default: false },
+  relative: {
+    type: String as PropType<"standard" | "shorthand" | "disabled">,
+    default: "disabled",
+  },
   showTimeIfToday: { type: Boolean, default: false },
   size: {
     type: String as PropType<TimestampSize>,
@@ -45,7 +47,6 @@ const dateStr = computed(() => {
       props.date,
       props.size,
       props.relative,
-      props.relativeShorthand,
       props.showTimeIfToday,
       props.dateClasses,
       props.timeClasses,
@@ -55,7 +56,6 @@ const dateStr = computed(() => {
     props.date,
     props.size,
     props.relative,
-    props.relativeShorthand,
     props.showTimeIfToday,
     props.dateClasses,
     props.timeClasses,

--- a/lib/vue-lib/src/design-system/utils/timestamp.ts
+++ b/lib/vue-lib/src/design-system/utils/timestamp.ts
@@ -17,8 +17,7 @@ const timeAgo = new TimeAgo("en-US");
 export function dateString(
   date: string | Date,
   size: TimestampSize,
-  relative = false,
-  relativeShorthand = false,
+  relative: "standard" | "shorthand" | "disabled" = "disabled",
   showTimeIfToday = false,
   dateClasses = "",
   timeClasses = "",
@@ -35,8 +34,7 @@ export function dateString(
   }
 
   if (
-    !relative &&
-    !relativeShorthand &&
+    relative === "disabled" &&
     showTimeIfToday &&
     d.toDateString() === new Date().toDateString()
   ) {
@@ -50,12 +48,12 @@ export function dateString(
   }
 
   if (size === "mini") {
-    if (relative) {
+    if (relative === "standard") {
       return timeAgo.format(d, "mini-minute-now");
     }
     return format(d, "M/d/y");
   } else if (size === "extended") {
-    if (relative) {
+    if (relative === "standard") {
       return `${formatDistanceToNow(d)} ago`;
     }
     return `${dateClassesSpan}${format(
@@ -66,7 +64,7 @@ export function dateString(
       "h:mm:ss a",
     )}${timeClassesCloseSpan}`;
   } else if (size === "long") {
-    if (relative) {
+    if (relative === "standard") {
       return `${formatDistanceToNow(d)} ago`;
     }
     return `${dateClassesSpan}${format(
@@ -78,9 +76,9 @@ export function dateString(
     )}${timeClassesCloseSpan}`;
   }
 
-  if (relative) {
+  if (relative === "standard") {
     return timeAgo.format(d);
-  } else if (relativeShorthand) {
+  } else if (relative === "shorthand") {
     return timeAgo.format(d, "twitter-first-minute");
   }
 


### PR DESCRIPTION
## Description

This change fixes an odd compiler error with the Timestamp component by using a string union for the "relative" prop on said component. All refactored locations have been tested.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZTc3NWl3bDc3N2J3NWlobmdwdzF5bjhreWd4d2I5emh4bG0zeGt0ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3ov9jU4ycPvfrPTsly/giphy-downsized-medium.gif"/>