### PR TITLE
feat(web): Implement the welcome banner with suggested prompts

### DIFF
--- a/app/web/src/newhotness/CopiableTextBlock.vue
+++ b/app/web/src/newhotness/CopiableTextBlock.vue
@@ -3,12 +3,7 @@
     class="bg-neutral-900 rounded-sm border border-neutral-600 flex flex-row p-xs items-center text-sm gap-3"
   >
     <span class="grow text-sm leading-4 break-all">{{ text }}</span>
-    <Icon
-      name="clipboard-copy"
-      size="xs"
-      class="cursor-pointer"
-      @click="copyText"
-    />
+    <Icon name="copy" size="xs" class="cursor-pointer" @click="copyText" />
   </div>
 </template>
 

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -248,8 +248,8 @@
               "
             >
               <span class="font-bold">Explore other ways to get started</span>
-              <span
-                >Prefer a different starting point? Here are a few other ways to
+              <span>
+                Prefer a different starting point? Here are a few other ways to
                 jump in and explore:
               </span>
               <div
@@ -294,6 +294,9 @@
             "
             :style="!bulkEditing && 'overflow-anchor: none;'"
           >
+            <WelcomeBanner
+              v-if="featureFlagsStore.INITIALIZER_ONBOARD && ctx.onHead.value"
+            />
             <ExploreGrid
               ref="exploreGridRef"
               :components="sortedAndGroupedComponents"
@@ -542,6 +545,7 @@ import ExploreGridSkeleton from "@/newhotness/skeletons/ExploreGridSkeleton.vue"
 import ExploreRightColumnSkeleton from "@/newhotness/skeletons/ExploreRightColumnSkeleton.vue";
 import { ChangeSet } from "@/api/sdf/dal/change_set";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
+import WelcomeBanner from "@/newhotness/WelcomeBanner.vue";
 import MapComponent from "./Map.vue";
 import {
   collapsingGridStyles,

--- a/app/web/src/newhotness/WelcomeBanner.vue
+++ b/app/web/src/newhotness/WelcomeBanner.vue
@@ -1,0 +1,71 @@
+<template>
+  <div
+    v-if="!closed"
+    class="flex flex-col gap-md border rounded-sm border-neutral-600 p-sm mt-xs mb-md leading-snug"
+  >
+    <div class="flex flex-col gap-xs">
+      <div class="flex flex-row justify-between">
+        <span class="font-medium">
+          Run these prompts and watch your AI agent bring AI-native
+          infrastructure to life, effortlessly
+        </span>
+        <Icon
+          name="x"
+          size="sm"
+          class="cursor-pointer hover:scale-110 rounded-full opacity-80 hover:opacity-100 self-start"
+          @click="closed = true"
+        />
+      </div>
+      <span class="text-sm">
+        You’re currently in HEAD. Once you run a prompt, the AI will create a
+        new change set (like a branch where you can do anything before changing
+        your real infrastructure). Ready to start?
+      </span>
+    </div>
+    <div class="flex flex-row gap-md">
+      <div
+        v-for="(prompt, index) in prompts"
+        :key="index"
+        class="flex flex-row gap-sm items-center justify-between border rounded-sm border-neutral-600 p-sm cursor-pointer bg-neutral-800 hover:bg-neutral-600 active:bg-neutral-700 italic select-none basis-1/3"
+        @click="copyText(prompt)"
+      >
+        <span>{{ prompt }}</span>
+        <Icon name="copy" size="sm" />
+      </div>
+    </div>
+    <div
+      class="flex flex-row justify-between bg-neutral-800 border border-neutral-600 rounded-sm px-sm py-xs items-center"
+    >
+      <span class="leading-snug">
+        See how it works with your real data; reach out and have us help you to
+        take the most out of System Initiative
+      </span>
+      <a
+        class="p-xs border border-neutral-600 rounded-sm bg-neutral-700 hover:bg-neutral-600 whitespace-nowrap font-medium"
+        href="https://www.systeminit.com/?modal=demo"
+        target="_blank"
+      >
+        Schedule a demo
+      </a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Icon } from "@si/vue-lib/design-system";
+import { useLocalStorage } from "@vueuse/core";
+
+const HAS_DISMISSED_WELCOME_BANNER_KEY = "dismissed-welcome-banner";
+
+const closed = useLocalStorage(HAS_DISMISSED_WELCOME_BANNER_KEY, false);
+
+const prompts = [
+  "Reach into my AWS account and pull out the default VPC. If additional VPCs are found, remove them from the model after discovery",
+  "Start from the VPC and discover related Subnets, Route tables, NAT Gateways and VPC Gateway Attachments and Internet Gateways.",
+  "Import all existing VPCs in my AWS account",
+];
+
+const copyText = (text: string) => {
+  navigator.clipboard.writeText(text);
+};
+</script>

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -162,6 +162,7 @@ import CarbonEdit from "~icons/carbon/edit";
 import Hourglass from "~icons/carbon/hourglass";
 import CarbonCompare from "~icons/carbon/compare";
 import CarbonMaximize from "~icons/carbon/maximize";
+import Copy from "~icons/carbon/copy";
 // TODO(Wendy) - for some reason this one specific icon fails to import? Not sure why.
 // import CarbonTransformCode from '~icons/carbon/transform-code';
 import CarbonTransformCode from "~icons/carbon/code"; // using this one as a placeholder for now
@@ -297,6 +298,7 @@ export const ICONS = Object.freeze({
   component: Cube,
   "component-plus": CubePlus,
   connection: MaterialSymbolsLink,
+  copy: Copy,
   create: Create,
   "credit-card": CreditCard,
   cursor: PhCursorTextBold,


### PR DESCRIPTION
#### Screenshots:

<img width="1879" height="741" alt="image" src="https://github.com/user-attachments/assets/54ddb097-adae-4a32-acb1-db3ae87ceebd" />

#### Out of Scope:

- Copy on this will still be updated, including prompts themselves

## How was it tested?

- [X] Go to head. Banner should be there. Clicking the prompts should copy them to your clipboard. Clicking "request demo" should open a new page. Closing it should keep it closed forever on that browser.