### PR TITLE
Polish component history for review screen

### DIFF
--- a/app/web/src/newhotness/ComponentHistory.vue
+++ b/app/web/src/newhotness/ComponentHistory.vue
@@ -1,42 +1,112 @@
 <template>
-  <div v-if="auditLogs.length > 0" class="p-sm my-xs overflow-x-hidden">
-    <ul class="space-y-md">
+  <div
+    v-if="auditLogs.length > 0"
+    ref="scrollContainerRef"
+    class="p-sm overflow-x-hidden max-h-full"
+    @scrollend="handleScrollEnd"
+  >
+    <!--
+    TODO(nick,paul): talk to Victoria about how we want these styled.
+    <div class="flex-1 flex flex-row justify-between items-center gap-xs">
+      <VButton
+        class="grow rounded-sm"
+        tone="neutral"
+        variant="ghost"
+        size="xs"
+        :rounded="false"
+        label="Expand All"
+        @click="handleAll('expand')"
+      />
+      <VButton
+        class="grow rounded-sm"
+        tone="neutral"
+        variant="ghost"
+        size="xs"
+        :rounded="false"
+        label="Collapse All"
+        @click="handleAll('collapse')"
+      />
+    </div>
+    -->
+    <ul class="space-y-sm">
       <li
         v-for="auditLog in auditLogs"
-        :key="auditLog.timestamp"
-        class="flex flex-row items-center gap-xs"
+        :key="identifier(auditLog)"
+        v-tooltip="
+          shouldExpand(auditLog)
+            ? 'Click to hide full audit log'
+            : 'Click to see full audit log'
+        "
+        class="flex cursor-pointer flex-row items-center gap-xs"
       >
-        <div class="w-2.5 h-2.5 rounded-full bg-neutral-500" />
+        <!--
+        TODO(nick): show the timeline-style view from our figma page.
+        <div class="w-2.5 h-2.5 rounded-full bg-neutral-500 flex-shrink-0" />
+        -->
         <div
-          class="flex flex-col p-xs border rounded-sm border-neutral-600"
-          @click="
-            () => (expand[auditLog.timestamp] = !expand[auditLog.timestamp])
-          "
+          class="flex-1 p-xs border rounded-sm border-neutral-600"
+          @click="toggleExpand(auditLog)"
         >
-          <div class="flex flex-row gap-xs items-center">
-            <TruncateWithTooltip>
-              {{ auditLog.title }} {{ auditLog.entityType }}
-            </TruncateWithTooltip>
-            <Timestamp
-              class="text-neutral-400"
-              :date="auditLog.timestamp"
-              relative="shorthand"
-              enableDetailTooltip
-              refresh
-            />
-            <Icon
-              class="text-neutral-400"
-              :name="
-                expand[auditLog.timestamp] ? 'chevron--down' : 'chevron--left'
-              "
-            />
+          <div class="flex flex-col">
+            <div class="flex flex-row gap-xs items-center justify-between">
+              <TruncateWithTooltip>
+                {{ auditLog.title }}
+              </TruncateWithTooltip>
+
+              <!-- Put the timestamp and chevron at the end. -->
+              <div class="flex flex-row gap-xs items-center">
+                <Timestamp
+                  class="text-neutral-400"
+                  :date="auditLog.inner.timestamp"
+                  relative="shorthand"
+                  enableDetailTooltip
+                  refresh
+                />
+                <Icon
+                  class="text-neutral-400"
+                  :name="
+                    shouldExpand(auditLog) ? 'chevron--down' : 'chevron--left'
+                  "
+                />
+              </div>
+            </div>
+            <div
+              v-if="auditLog.beforeValue && auditLog.afterValue"
+              class="flex flex-row gap-sm"
+            >
+              <TruncateWithTooltip class="line-through text-neutral-500">
+                {{ auditLog.beforeValue }}
+              </TruncateWithTooltip>
+              <TruncateWithTooltip class="text-neutral-300">
+                {{ auditLog.afterValue }}
+              </TruncateWithTooltip>
+            </div>
           </div>
-          <div v-if="expand[auditLog.timestamp]" class="mt-xs">
-            <CodeViewer :code="JSON.stringify(auditLog, null, 2)" />
-          </div>
+          <Transition
+            enterActiveClass="transition duration-100"
+            enterFromClass="opacity-0 scale-95"
+            enterToClass="opacity-100 scale-100"
+            leaveActiveClass="transition duration-100"
+            leaveFromClass="opacity-100 scale-100"
+            leaveToClass="opacity-0 scale-95"
+          >
+            <div v-if="shouldExpand(auditLog)" class="mt-xs transition-all">
+              <CodeViewer :code="JSON.stringify(auditLog.inner, null, 2)" />
+            </div>
+          </Transition>
         </div>
       </li>
     </ul>
+
+    <!-- Loading indicator and marker for when all entries are loaded. -->
+    <div
+      v-if="isFetchingNextPage || !hasNextPage"
+      class="flex flex-row items-center justify-center mt-md text-sm text-neutral-500"
+    >
+      <Icon v-if="isFetchingNextPage" name="loader" size="sm" />
+      <span v-if="isFetchingNextPage"> Loading More Logs... </span>
+      <span v-else-if="!hasNextPage"> All Entries Loaded </span>
+    </div>
   </div>
   <EmptyState
     v-else
@@ -48,16 +118,17 @@
 </template>
 
 <script setup lang="ts">
-import { useQuery } from "@tanstack/vue-query";
-import { computed, reactive } from "vue";
+import { useInfiniteQuery } from "@tanstack/vue-query";
+import { computed, reactive, ref } from "vue";
 import {
   TruncateWithTooltip,
   Timestamp,
   Icon,
 } from "@si/vue-lib/design-system";
 import { ComponentId } from "@/api/sdf/dal/component";
-import { AuditLog } from "@/workers/types/entity_kind_types";
+import { AuditLog, EntityKind } from "@/workers/types/entity_kind_types";
 import CodeViewer from "@/components/CodeViewer.vue";
+import { useMakeKey } from "@/store/realtime/heimdall";
 import { routes, useApi } from "./api_composables";
 import EmptyState from "./EmptyState.vue";
 import { useContext } from "./logic_composables/context";
@@ -66,44 +137,165 @@ const props = defineProps<{
   componentId: ComponentId;
 }>();
 
+const componentId = computed(() => props.componentId);
+
+const scrollContainerRef = ref<HTMLElement | null>(null);
+
 const ctx = useContext();
+const key = useMakeKey();
 
+const pageSize = 100;
+const increaseSize = 50;
+
+// Identifies the specific audit log we are working with.
+const identifier = (auditLog: ProcessedAuditLog) =>
+  `${props.componentId}-${auditLog.inner.kind}-${auditLog.inner.timestamp}`;
+
+// Keep track of which audit logs should be expanded.
 const expand = reactive<Record<string, boolean>>({});
+const toggleExpand = (auditLog: ProcessedAuditLog) => {
+  const key = identifier(auditLog);
+  if (expand[key] === undefined) {
+    expand[key] = true;
+  } else {
+    expand[key] = !expand[key];
+  }
+};
+const shouldExpand = (auditLog: ProcessedAuditLog): boolean => {
+  return expand[identifier(auditLog)] ?? false;
+};
 
-// TODO(nick): allow the user to load more.
-const size = "100";
+// TODO(nick,paul): this comes back when the expand and collapse buttons come back.
+// // Ability to expand and collapse everything.
+// const handleAll = (option: "expand" | "collapse") => {
+//   for (const auditLog of auditLogs.value) {
+//     expand[identifier(auditLog)] = option === "expand";
+//   }
+// };
+
+interface ProcessedAuditLog {
+  inner: AuditLog;
+  title: string;
+  beforeValue?: string;
+  afterValue?: string;
+}
+
+type AuditLogsForComponentResponse = {
+  logs: AuditLog[];
+  canLoadMore: boolean;
+};
 
 const auditLogsApi = useApi(ctx);
-const auditLogsQuery = useQuery<AuditLog[]>({
-  queryKey: ["auditlogs", ctx.changeSetId.value, props.componentId],
-  queryFn: async () => {
-    const call = auditLogsApi.endpoint<{
-      logs: AuditLog[];
-      canLoadMore: boolean;
-    }>(routes.AuditLogsForComponent, { componentId: props.componentId });
+const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  useInfiniteQuery({
+    queryKey: key(EntityKind.AuditLogsForComponent, componentId),
+    queryFn: async ({ pageParam = pageSize }) => {
+      const call = auditLogsApi.endpoint<AuditLogsForComponentResponse>(
+        routes.AuditLogsForComponent,
+        { componentId: componentId.value },
+      );
+      const response = await call.get(
+        new URLSearchParams({
+          size: `${pageParam}`,
+          sort_ascending: "false",
+        }),
+      );
+      if (auditLogsApi.ok(response)) {
+        return response.data;
+      }
+      return { logs: [], canLoadMore: false };
+    },
+    initialPageParam: pageSize,
+    getNextPageParam: (lastPage: AuditLogsForComponentResponse) => {
+      if (!lastPage.canLoadMore) return undefined;
+      return lastPage.logs.length + increaseSize;
+    },
+    maxPages: 1,
+  });
 
-    const response = await call.get(
-      new URLSearchParams({
-        size,
-        sort_ascending: "false",
-      }),
-    );
+// Flatten all pages and filter out socket-related audit logs
+const auditLogs = computed((): ProcessedAuditLog[] => {
+  if (!data.value) return [];
 
-    if (auditLogsApi.ok(response)) {
-      return response.data.logs;
-    }
+  // There should only be one page!
+  const allLogs = data.value.pages.flatMap(
+    (page: AuditLogsForComponentResponse) => page.logs,
+  );
 
-    return [] as AuditLog[];
-  },
+  return allLogs
+    .filter((auditLog: AuditLog) => {
+      // NOTE(nick,paul,brit): this is intentionally omega hacked. We expect this to change over time.
+      if (auditLog.kind === "UpdateDependentProperty") {
+        if (
+          ["codeItem", "qualificationItem", "resource_value"].includes(
+            auditLog.entityName,
+          )
+        )
+          return false;
+
+        // End my suffering.
+        const beforeValue = (auditLog.metadata.beforeValue as string) ?? "null";
+        const afterValue = (auditLog.metadata.afterValue as string) ?? "null";
+        if (beforeValue === afterValue) return false;
+      }
+
+      // Filter out sockets.
+      if (
+        auditLog.kind === "UpdateDependentOutputSocket" ||
+        auditLog.kind === "UpdateDependentInputSocket"
+      )
+        return false;
+
+      // We made it!
+      return true;
+    })
+    .map((filteredAuditLog: AuditLog): ProcessedAuditLog => {
+      // Now that we have filtered the audit logs to only those that are relevant to the user, we
+      // can change how they are displayed based on the kind.
+      if (
+        ["UpdateDependentProperty", "SetAttribute", "UnsetAttribute"].includes(
+          filteredAuditLog.kind,
+        )
+      ) {
+        if (filteredAuditLog.kind === "UpdateDependentProperty") {
+          return {
+            inner: filteredAuditLog,
+            title: `${filteredAuditLog.entityName} changed`,
+            beforeValue:
+              (filteredAuditLog.metadata.beforeValue as string) ?? "null",
+            afterValue:
+              (filteredAuditLog.metadata.afterValue as string) ?? "null",
+          };
+        } else {
+          const beforeValue = filteredAuditLog.metadata.beforeValue as Record<
+            string,
+            unknown
+          >;
+          const afterValue = filteredAuditLog.metadata.afterValue as Record<
+            string,
+            unknown
+          >;
+          return {
+            inner: filteredAuditLog,
+            title: `${filteredAuditLog.entityName} changed`,
+            beforeValue: (beforeValue.Value as string) ?? "null",
+            afterValue: (afterValue.Value as string) ?? "null",
+          };
+        }
+      }
+
+      // By default, display the audit log how we do in the audit trail screen.
+      return {
+        inner: filteredAuditLog,
+        title: `${filteredAuditLog.title} ${filteredAuditLog.entityType}`,
+      };
+    });
 });
 
-// Filter out socket-related audit logs.
-const auditLogs = computed(
-  (): AuditLog[] =>
-    auditLogsQuery.data.value?.filter(
-      (auditLog) =>
-        auditLog.kind !== "UpdateDependentOutputSocket" &&
-        auditLog.kind !== "UpdateDependentInputSocket",
-    ) ?? [],
-);
+const handleScrollEnd = () => {
+  if (!scrollContainerRef.value) return;
+  if (hasNextPage.value && !isFetchingNextPage.value) {
+    fetchNextPage();
+  }
+};
 </script>

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -205,8 +205,8 @@
     <div class="right flex flex-col p-xs">
       <CollapsingFlexItem open>
         <template #header>Component History</template>
-        <template v-if="selectedComponent">
-          <ComponentHistory :componentId="selectedComponent.id"
+        <template v-if="selectedComponentId">
+          <ComponentHistory :componentId="selectedComponentId"
         /></template>
         <EmptyState
           v-else
@@ -564,7 +564,8 @@ watch(
   (newSelectedComponent) => {
     if (newSelectedComponent) {
       queryClient.invalidateQueries({
-        queryKey: ["auditlogs", ctx.changeSetId.value, newSelectedComponent.id],
+        queryKey: key(EntityKind.AuditLogsForComponent, newSelectedComponent.id)
+          .value,
       });
     }
   },

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -19,6 +19,7 @@ export enum EntityKind {
   ActionPrototypeViewList = "ActionPrototypeViewList",
   ActionViewList = "ActionViewList",
   AttributeTree = "AttributeTree",
+  AuditLogsForComponent = "AuditLogsForComponent",
   CachedSchemas = "CachedSchemas",
   Component = "Component",
   ComponentDiff = "ComponentDiff",


### PR DESCRIPTION
## Description

This change polishes the component history for the review screen. This includes "useInfiniteQuery" via "scrollend", correct box sizing for each entry, transitions when collapsing and expanding entries, as well as advanced filtering of audit logs and conditional display changes (e.g. setting attributes shows a cool "before and after" second line).

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMTdkc3NqcDkzMzZ3YnQ1cXV2Nm9qbDh3am9icmx1MjRhNWZkOTJhaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/LtHhtCiLlo7xGv9RA3/giphy.gif"/>

## Screenshots

Collapsed and in the default view:

<img width="448" height="311" alt="Screenshot 2025-08-23 at 7 34 18 PM" src="https://github.com/user-attachments/assets/44447a0f-4081-4757-a28f-6b51f0a7b27f" />

Expanded and in the expanded view:

<img width="919" height="830" alt="Screenshot 2025-08-23 at 7 34 40 PM" src="https://github.com/user-attachments/assets/0898b0b8-1da6-4681-bfe4-849c45e04dbb" />

## Future Work

There is more work to be done, like fixing query reactivity when changing components and ensuring "canLoadMore" is reactive too. However, this is a good check-in point for this work.