### PR TITLE
Add change set-level MVs for luminork schema variants

### DIFF
--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -60,6 +60,7 @@ pub mod component_list;
 pub mod dependent_value_component_list;
 pub mod incoming_connections;
 pub mod incoming_connections_list;
+pub mod luminork;
 pub mod mgmt_prototype_view_list;
 pub mod schema_variant;
 pub mod schema_variant_categories;

--- a/lib/dal-materialized-views/src/luminork.rs
+++ b/lib/dal-materialized-views/src/luminork.rs
@@ -1,0 +1,1 @@
+pub mod schema;

--- a/lib/dal-materialized-views/src/luminork/schema.rs
+++ b/lib/dal-materialized-views/src/luminork/schema.rs
@@ -1,0 +1,1 @@
+pub mod variant;

--- a/lib/dal-materialized-views/src/luminork/schema/variant.rs
+++ b/lib/dal-materialized-views/src/luminork/schema/variant.rs
@@ -1,0 +1,57 @@
+use dal::{
+    DalContext,
+    Prop,
+    SchemaVariant,
+    SchemaVariantId,
+    schema::variant::root_prop::RootPropChild,
+    workspace_snapshot::traits::prop::PropExt,
+};
+use si_frontend_mv_types::luminork_schema_variant::LuminorkSchemaVariant as LuminorkSchemaVariantMv;
+use telemetry::prelude::*;
+
+pub mod default;
+
+#[instrument(
+    name = "dal_materialized_views.luminork.schema.variant",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(
+    ctx: DalContext,
+    id: SchemaVariantId,
+) -> crate::Result<LuminorkSchemaVariantMv> {
+    let schema_variant = SchemaVariant::get_by_id(&ctx, id).await?;
+
+    let variant_func_ids: Vec<_> = SchemaVariant::all_func_ids(&ctx, id)
+        .await?
+        .into_iter()
+        .collect();
+
+    let domain_props = {
+        let domain = Prop::find_prop_by_path(&ctx, id, &RootPropChild::Domain.prop_path()).await?;
+
+        let prop_schema_tree = ctx
+            .workspace_snapshot()?
+            .build_prop_schema_tree(&ctx, domain.id)
+            .await?;
+
+        Some(prop_schema_tree)
+    };
+
+    let is_default_variant = SchemaVariant::is_default_by_id(&ctx, id).await?;
+    let asset_func_id = schema_variant.asset_func_id_or_error()?;
+
+    Ok(LuminorkSchemaVariantMv::new(
+        id,
+        schema_variant.display_name().into(),
+        schema_variant.category().into(),
+        schema_variant.color().into(),
+        schema_variant.is_locked(),
+        schema_variant.description(),
+        schema_variant.link(),
+        asset_func_id,
+        variant_func_ids,
+        is_default_variant,
+        domain_props,
+    ))
+}

--- a/lib/dal-materialized-views/src/luminork/schema/variant/default.rs
+++ b/lib/dal-materialized-views/src/luminork/schema/variant/default.rs
@@ -1,0 +1,59 @@
+use dal::{
+    DalContext,
+    Prop,
+    Schema,
+    SchemaId,
+    SchemaVariant,
+    schema::variant::root_prop::RootPropChild,
+    workspace_snapshot::traits::prop::PropExt,
+};
+use si_frontend_mv_types::luminork_default_variant::LuminorkDefaultVariant as LuminorkDefaultVariantMv;
+use telemetry::prelude::*;
+
+#[instrument(
+    name = "dal_materialized_views.luminork.schema.variant.default",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(
+    ctx: DalContext,
+    schema_id: SchemaId,
+) -> crate::Result<LuminorkDefaultVariantMv> {
+    let default_variant_id = Schema::default_variant_id(&ctx, schema_id).await?;
+    let schema_variant = SchemaVariant::get_by_id(&ctx, default_variant_id).await?;
+
+    let variant_func_ids: Vec<_> = SchemaVariant::all_func_ids(&ctx, default_variant_id)
+        .await?
+        .into_iter()
+        .collect();
+
+    let domain_props = {
+        let domain =
+            Prop::find_prop_by_path(&ctx, default_variant_id, &RootPropChild::Domain.prop_path())
+                .await?;
+
+        let prop_schema_tree = ctx
+            .workspace_snapshot()?
+            .build_prop_schema_tree(&ctx, domain.id)
+            .await?;
+
+        Some(prop_schema_tree)
+    };
+
+    // Get the asset func ID
+    let asset_func_id = schema_variant.asset_func_id_or_error()?;
+
+    Ok(LuminorkDefaultVariantMv::new(
+        schema_id,
+        default_variant_id,
+        schema_variant.display_name().into(),
+        schema_variant.category().into(),
+        schema_variant.color().into(),
+        schema_variant.is_locked(),
+        schema_variant.description(),
+        schema_variant.link(),
+        asset_func_id,
+        variant_func_ids,
+        domain_props,
+    ))
+}

--- a/lib/edda-server/src/materialized_view.rs
+++ b/lib/edda-server/src/materialized_view.rs
@@ -1428,6 +1428,39 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 dal_materialized_views::incoming_connections_list::assemble(ctx.clone()),
             );
         }
+        ReferenceKind::LuminorkSchemaVariant => {
+            let entity_mv_id = change.entity_id.to_string();
+
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                si_frontend_mv_types::luminork_schema_variant::LuminorkSchemaVariant,
+                dal_materialized_views::luminork::schema::variant::assemble(
+                    ctx.clone(),
+                    si_events::ulid::Ulid::from(change.entity_id).into()
+                ),
+            );
+        }
+        ReferenceKind::LuminorkDefaultVariant => {
+            let schema_id = si_events::ulid::Ulid::from(change.entity_id);
+            let entity_mv_id = change.entity_id.to_string();
+
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                entity_mv_id,
+                si_frontend_mv_types::luminork_default_variant::LuminorkDefaultVariant,
+                dal_materialized_views::luminork::schema::variant::default::assemble(
+                    ctx.clone(),
+                    schema_id.into()
+                ),
+            );
+        }
         ReferenceKind::SchemaMembers => {
             let entity_mv_id = change.entity_id.to_string();
 

--- a/lib/luminork-server/src/service/v1/schemas/get_default_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_default_variant.rs
@@ -1,11 +1,7 @@
 use axum::extract::Path;
 use dal::{
-    Prop,
     Schema,
-    SchemaVariant,
     cached_module::CachedModule,
-    schema::variant::root_prop::RootPropChild,
-    workspace_snapshot::traits::prop::PropExt,
 };
 use sdf_extract::{
     EddaClient,
@@ -14,6 +10,7 @@ use sdf_extract::{
 use serde_json::json;
 use si_frontend_mv_types::{
     cached_default_variant::CachedDefaultVariant,
+    luminork_default_variant::LuminorkDefaultVariant,
     reference::ReferenceKind,
 };
 use telemetry::prelude::*;
@@ -53,74 +50,96 @@ use crate::extract::{
 pub async fn get_default_variant(
     ChangeSetDalContext(ref ctx): ChangeSetDalContext,
     FriggStore(frigg): FriggStore,
-    _edda_client: EddaClient,
+    edda_client: EddaClient,
     tracker: PosthogEventTracker,
     Path(SchemaV1RequestPath { schema_id }): Path<SchemaV1RequestPath>,
 ) -> SchemaResult<SchemaVariantResponseV1> {
-    // Try DAL lookup first (installed schema)
-    if let Ok(default_variant_id) = Schema::default_variant_id(ctx, schema_id).await {
-        if let Ok(Some(variant)) = SchemaVariant::get_by_id_opt(ctx, default_variant_id).await {
-            let variant_func_ids: Vec<_> = SchemaVariant::all_func_ids(ctx, default_variant_id)
-                .await?
-                .into_iter()
-                .collect();
-
-            let domain = Prop::find_prop_by_path(
-                ctx,
-                default_variant_id,
-                &RootPropChild::Domain.prop_path(),
-            )
-            .await
-            .map_err(Box::new)?;
-            let domain_prop_schema = ctx
-                .workspace_snapshot()?
-                .build_prop_schema_tree(ctx, domain.id)
-                .await?
-                .into();
-
-            tracker.track(
-                ctx,
-                "api_get_default_variant",
-                json!({
-                    "schema_id": schema_id,
-                    "schema_variant_id": default_variant_id,
-                    "schema_variant_name": variant.display_name(),
-                    "schema_variant_category": variant.category(),
-                    "is_locked": variant.is_locked(),
-                    "source": "dal"
-                }),
-            );
-
-            return Ok(SchemaVariantResponseV1::Success(Box::new(
-                GetSchemaVariantV1Response {
-                    variant_id: default_variant_id,
-                    display_name: variant.display_name().into(),
-                    category: variant.category().into(),
-                    color: variant.color().into(),
-                    is_locked: variant.is_locked(),
-                    description: variant.description(),
-                    link: variant.link(),
-                    asset_func_id: variant.asset_func_id_or_error()?,
-                    variant_func_ids,
-                    is_default_variant: true,
-                    domain_props: Some(domain_prop_schema),
-                },
-            )));
-        }
-    }
-
-    // Fall back to MV lookup for uninstalled schemas using direct CachedDefaultVariant lookup
     match frigg
-        .get_current_deployment_object(ReferenceKind::CachedDefaultVariant, &schema_id.to_string())
+        .get_current_workspace_object(
+            ctx.workspace_pk()?,
+            ctx.change_set_id(),
+            &ReferenceKind::LuminorkDefaultVariant.to_string(),
+            &schema_id.to_string(),
+        )
         .await
     {
         Ok(Some(obj)) => {
+            if let Ok(luminork_default_variant) =
+                serde_json::from_value::<LuminorkDefaultVariant>(obj.data)
+            {
+                // Clone values for logging before moving them
+                let display_name_for_log = luminork_default_variant.display_name.clone();
+                let category_for_log = luminork_default_variant.category.clone();
+
+                let response = GetSchemaVariantV1Response {
+                    variant_id: luminork_default_variant.variant_id,
+                    display_name: luminork_default_variant.display_name,
+                    category: luminork_default_variant.category,
+                    color: luminork_default_variant.color,
+                    is_locked: luminork_default_variant.is_locked,
+                    description: luminork_default_variant.description,
+                    link: luminork_default_variant.link,
+                    asset_func_id: luminork_default_variant.asset_func_id,
+                    variant_func_ids: luminork_default_variant.variant_func_ids,
+                    is_default_variant: true, // Always true for default variant endpoint
+                    domain_props: luminork_default_variant.domain_props.map(Into::into),
+                };
+
+                tracker.track(
+                    ctx,
+                    "api_get_default_variant",
+                    json!({
+                        "schema_id": schema_id,
+                        "schema_variant_id": luminork_default_variant.variant_id,
+                        "schema_variant_name": display_name_for_log,
+                        "schema_variant_category": category_for_log,
+                        "is_locked": luminork_default_variant.is_locked
+                    }),
+                );
+
+                return Ok(SchemaVariantResponseV1::Success(Box::new(response)));
+            }
+        }
+        Ok(None) => {
+            // LuminorkDefaultVariant MV not found - check if schema exists in graph (installed)
+            if Schema::get_by_id_opt(ctx, schema_id).await?.is_some() {
+                // Schema exists in graph but LuminorkDefaultVariant MV not built yet
+                // Send edda rebuild request to trigger MV generation
+                if let Err(e) = edda_client
+                    .rebuild_for_change_set(ctx.workspace_pk()?, ctx.change_set_id())
+                    .await
+                {
+                    warn!(
+                        "Failed to send edda rebuild request for schema {}: {}",
+                        schema_id, e
+                    );
+                }
+
+                return Ok(SchemaVariantResponseV1::Building(BuildingResponseV1 {
+                    status: "building".to_string(),
+                    message: "Default variant data is being generated from workspace graph, please retry shortly".to_string(),
+                    retry_after_seconds: 2,
+                    estimated_completion_seconds: 5,
+                }));
+            }
+        }
+        Err(e) => {
+            warn!(
+                "Failed to get LuminorkDefaultVariant MV for schema {}: {}",
+                schema_id, e
+            );
+            // Continue to fallback logic
+        }
+    }
+
+    match frigg
+        .get_current_deployment_object(ReferenceKind::CachedDefaultVariant, &schema_id.to_string())
+        .await?
+    {
+        Some(obj) => {
             if let Ok(cached_default_variant) =
                 serde_json::from_value::<CachedDefaultVariant>(obj.data)
             {
-                // For uninstalled variants, domain props don't exist in DAL, so we set them to None
-                // This matches the behavior in get_variant endpoint for cached variants
-
                 // Clone values for logging before moving them
                 let display_name_for_log = cached_default_variant.display_name.clone();
                 let category_for_log = cached_default_variant.category.clone();
@@ -147,34 +166,24 @@ pub async fn get_default_variant(
                         "schema_variant_id": cached_default_variant.variant_id,
                         "schema_variant_name": display_name_for_log,
                         "schema_variant_category": category_for_log,
-                        "is_locked": cached_default_variant.is_locked,
-                        "source": "materialized_view"
+                        "is_locked": cached_default_variant.is_locked
                     }),
                 );
 
                 return Ok(SchemaVariantResponseV1::Success(Box::new(response)));
             }
         }
-        Ok(None) => {
+        None => {
             // CachedDefaultVariant not found - check if schema exists in cached_modules DB table
             match CachedModule::find_latest_for_schema_id(ctx, schema_id).await {
                 Ok(Some(_)) => {
-                    // Schema exists in cached_modules but CachedDefaultVariant MV not built yet - trigger rebuild and return 202
-                    //
-                    // Until the performance issues in building the deployment-level MVs are fixed,
-                    // this is only going to be deployed through the manual module sync process.
-                    //
-                    // if let Err(e) = edda_client.rebuild_for_deployment().await {
-                    //     warn!("Failed to trigger MV rebuild: {}", e);
-                    // }
-                    let building_response = BuildingResponseV1 {
+                    // Schema exists in cached_modules but CachedDefaultVariant MV not built yet
+                    return Ok(SchemaVariantResponseV1::Building(BuildingResponseV1 {
                         status: "building".to_string(),
-                        message: "Schema variant data is being generated, please retry shortly"
-                            .to_string(),
+                        message: "Default variant data is being generated from cached modules, please retry shortly".to_string(),
                         retry_after_seconds: 2,
                         estimated_completion_seconds: 10,
-                    };
-                    return Ok(SchemaVariantResponseV1::Building(building_response));
+                    }));
                 }
                 Ok(None) => {
                     // Schema doesn't exist in cached_modules at all - return 404
@@ -185,45 +194,11 @@ pub async fn get_default_variant(
                         "Failed to check cached module for schema {}: {}",
                         schema_id, e
                     );
-                    // Fall through to 404 if we can't check the DB
-                }
-            }
-        }
-        Err(e) => {
-            warn!(
-                "Failed to get MV for default variant of schema {}: {}",
-                schema_id, e
-            );
-            // Fall through to check if schema exists
-            match CachedModule::find_latest_for_schema_id(ctx, schema_id).await {
-                Ok(Some(_)) => {
-                    // Schema exists but MV lookup failed - trigger rebuild and return 202
-                    //
-                    // Until the performance issues in building the deployment-level MVs are fixed,
-                    // this is only going to be deployed through the manual module sync process.
-                    //
-                    // if let Err(e) = edda_client.rebuild_for_deployment().await {
-                    //     warn!("Failed to trigger MV rebuild: {}", e);
-                    // }
-                    let building_response = BuildingResponseV1 {
-                        status: "building".to_string(),
-                        message: "Schema variant data is being generated, please retry shortly"
-                            .to_string(),
-                        retry_after_seconds: 2,
-                        estimated_completion_seconds: 10,
-                    };
-                    return Ok(SchemaVariantResponseV1::Building(building_response));
-                }
-                Ok(None) => {
-                    // Schema doesn't exist - return 404
-                }
-                Err(_) => {
-                    // Can't check DB - fall through to 404
                 }
             }
         }
     }
 
-    // Schema not found in either DAL or cached_modules
+    // Schema not found anywhere
     Err(SchemaError::SchemaNotFound(schema_id))
 }

--- a/lib/luminork-server/src/service/v1/schemas/mod.rs
+++ b/lib/luminork-server/src/service/v1/schemas/mod.rs
@@ -11,8 +11,10 @@ use dal::{
     PropId,
     SchemaId,
     SchemaVariantId,
+    TransactionsError,
     prop::PropError,
 };
+use frigg::FriggError;
 use serde::{
     Deserialize,
     Serialize,
@@ -36,6 +38,8 @@ pub enum SchemaError {
     CachedModule(#[from] dal::cached_module::CachedModuleError),
     #[error("decode error: {0}")]
     Decode(#[from] ulid::DecodeError),
+    #[error("frigg error: {0}")]
+    Frigg(#[from] FriggError),
     #[error("prop error: {0}")]
     Prop(#[from] Box<PropError>),
     #[error("schema error: {0}")]
@@ -50,6 +54,8 @@ pub enum SchemaError {
     SchemaVariantNotFound(SchemaVariantId),
     #[error("schema variant {0} not a variant for the schema {1} error")]
     SchemaVariantNotMemberOfSchema(SchemaId, SchemaVariantId),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] TransactionsError),
     #[error("validation error: {0}")]
     Validation(String),
     #[error("workspace snapshot error: {0}")]

--- a/lib/si-frontend-mv-types-rs/src/lib.rs
+++ b/lib/si-frontend-mv-types-rs/src/lib.rs
@@ -33,6 +33,8 @@ pub mod component;
 pub mod dependent_values;
 pub mod incoming_connections;
 pub mod index;
+pub mod luminork_default_variant;
+pub mod luminork_schema_variant;
 pub mod management;
 pub mod materialized_view;
 pub mod object;

--- a/lib/si-frontend-mv-types-rs/src/luminork_default_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/luminork_default_variant.rs
@@ -1,0 +1,79 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    FuncId,
+    SchemaId,
+    SchemaVariantId,
+    workspace_snapshot::EntityKind,
+};
+
+use crate::{
+    prop_schema::PropSchemaV1,
+    reference::ReferenceKind,
+};
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+    si_frontend_mv_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::Schema,
+    reference_kind = ReferenceKind::LuminorkDefaultVariant,
+)]
+pub struct LuminorkDefaultVariant {
+    pub id: SchemaId,
+    pub schema_id: SchemaId,
+    pub variant_id: SchemaVariantId,
+    pub display_name: String,
+    pub category: String,
+    pub color: String,
+    pub is_locked: bool,
+    pub description: Option<String>,
+    pub link: Option<String>,
+    pub asset_func_id: FuncId,
+    pub variant_func_ids: Vec<FuncId>,
+    pub domain_props: Option<PropSchemaV1>,
+}
+
+impl LuminorkDefaultVariant {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        schema_id: SchemaId,
+        variant_id: SchemaVariantId,
+        display_name: String,
+        category: String,
+        color: String,
+        is_locked: bool,
+        description: Option<String>,
+        link: Option<String>,
+        asset_func_id: FuncId,
+        variant_func_ids: Vec<FuncId>,
+        domain_props: Option<PropSchemaV1>,
+    ) -> Self {
+        Self {
+            id: schema_id, // Use schema_id as the MV object ID
+            schema_id,
+            variant_id,
+            display_name,
+            category,
+            color,
+            is_locked,
+            description,
+            link,
+            asset_func_id,
+            variant_func_ids,
+            domain_props,
+        }
+    }
+}

--- a/lib/si-frontend-mv-types-rs/src/luminork_schema_variant.rs
+++ b/lib/si-frontend-mv-types-rs/src/luminork_schema_variant.rs
@@ -1,0 +1,78 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    FuncId,
+    SchemaVariantId,
+    workspace_snapshot::EntityKind,
+};
+
+use crate::{
+    prop_schema::PropSchemaV1,
+    reference::ReferenceKind,
+};
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+    si_frontend_mv_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+    trigger_entity = EntityKind::SchemaVariant,
+    reference_kind = ReferenceKind::LuminorkSchemaVariant,
+)]
+pub struct LuminorkSchemaVariant {
+    pub id: SchemaVariantId,
+    pub variant_id: SchemaVariantId,
+    pub display_name: String,
+    pub category: String,
+    pub color: String,
+    pub is_locked: bool,
+    pub description: Option<String>,
+    pub link: Option<String>,
+    pub asset_func_id: FuncId,
+    pub variant_func_ids: Vec<FuncId>,
+    pub is_default_variant: bool,
+    pub domain_props: Option<PropSchemaV1>,
+}
+
+impl LuminorkSchemaVariant {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        variant_id: SchemaVariantId,
+        display_name: String,
+        category: String,
+        color: String,
+        is_locked: bool,
+        description: Option<String>,
+        link: Option<String>,
+        asset_func_id: FuncId,
+        variant_func_ids: Vec<FuncId>,
+        is_default_variant: bool,
+        domain_props: Option<PropSchemaV1>,
+    ) -> Self {
+        Self {
+            id: variant_id, // Use variant_id as the MV object ID
+            variant_id,
+            display_name,
+            category,
+            color,
+            is_locked,
+            description,
+            link,
+            asset_func_id,
+            variant_func_ids,
+            is_default_variant,
+            domain_props,
+        }
+    }
+}

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -53,6 +53,8 @@ pub enum ReferenceKind {
     DeploymentMvIndex,
     IncomingConnections,
     IncomingConnectionsList,
+    LuminorkDefaultVariant,
+    LuminorkSchemaVariant,
     ManagementConnections,
     SchemaMembers,
     SchemaVariant,


### PR DESCRIPTION
Creates LuminorkSchemaVariant and LuminorkDefaultVariant materialized
views that are built from workspace graph data for installed schema
variants. These complement the existing cached variants (built from
deployment-level cached modules) to provide consistent responses for
both installed and uninstalled modules.

Updates luminork endpoints to prioritize these new change set-level MVs
for installed variants, falling back to cached variants for uninstalled
modules. This ensures consistent API responses regardless of whether a
schema variant exists in the workspace graph or only in cached modules.

## How does this PR change the system?

Luminork API responses for installed variants in `get_variant`, and `get_default_variant` are no longer built "live", and are fetched from the MVs in frigg, instead.

## Out of Scope:

This leaves the Luminork* MVs in with the "normal" MVs that the frontend is normally told about, and would normally fetch. Eventually, we should have a more general pool of MVs that things like SDF & Luminork can use without having them automatically sent to the front-end.

## How was it tested?

- [X] Manual test: Luminork swagger UI, `get_variant` and `get_default_variant` response times <1s in testing.
