### PR TITLE
Ignore Specific Luminork MVs

### DIFF
--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -44,6 +44,9 @@ export enum EntityKind {
   View = "View",
   ViewComponentList = "ViewComponentList",
   ViewList = "ViewList",
+  // IGNORING THESE
+  LuminorkDefaultVariant = "LuminorkDefaultVariant",
+  LuminorkSchemaVariant = "LuminorkSchemaVariant",
 }
 
 /**


### PR DESCRIPTION
## How does this PR change the system?

Make a list of `EntityKind` (MV) that the front end will not interact with. Don't patch it, don't throw hammers for it, don't allow lookups (e.g. `get`).