### PR TITLE
fix(web): Ensure consistency collapsing panel headers on component details page

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -393,22 +393,20 @@
             ><span class="text-sm">Subscriptions</span></template
           >
           <template #headerIcons>
-            <div class="ml-auto my-sm">
-              <VButton
-                label="Visualize Subscriptions"
-                size="xs"
-                :class="
-                  clsx(
-                    '!text-sm !border !cursor-pointer !px-xs',
-                    themeClasses(
-                      '!text-neutral-900 !bg-neutral-200 !border-neutral-400 hover:!bg-neutral-100 hover:!border-neutral-600',
-                      '!text-si-white !bg-neutral-700 !border-neutral-600 hover:!bg-neutral-600 hover:!border-neutral-600',
-                    ),
-                  )
-                "
-                @click="navigateToMap"
-              />
-            </div>
+            <VButton
+              label="Visualize Subscriptions"
+              size="xs"
+              :class="
+                clsx(
+                  '!text-sm !border !cursor-pointer !px-xs',
+                  themeClasses(
+                    '!text-neutral-900 !bg-neutral-200 !border-neutral-400 hover:!bg-neutral-100 hover:!border-neutral-600',
+                    '!text-si-white !bg-neutral-700 !border-neutral-600 hover:!bg-neutral-600 hover:!border-neutral-600',
+                  ),
+                )
+              "
+              @click="navigateToMap"
+            />
           </template>
           <ConnectionsPanel
             v-if="componentConnections && component"

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -21,7 +21,7 @@
         clsx(
           h3class,
           'group/header',
-          'flex-none flex items-center px-xs m-0',
+          'flex-none flex items-center px-xs m-0 min-h-[2.5rem]',
           !disableCollapse && [
             'cursor-pointer',
             themeClasses('hover:bg-neutral-100', 'hover:bg-neutral-700'),


### PR DESCRIPTION
Before:
<img width="1008" height="288" alt="Screenshot 2025-08-23 at 21 50 15" src="https://github.com/user-attachments/assets/ac90ca67-3f22-4f8c-8740-79b09e77dc9c" />


After: 
<img width="521" height="304" alt="Screenshot 2025-08-23 at 21 49 00" src="https://github.com/user-attachments/assets/380cfbbc-b0e1-4401-b8ce-b963cc83f342" />
