### PR TITLE
feat(dal): Adding audit log entry for AttributesAPI

### DIFF
--- a/lib/si-events-rs/src/audit_log.rs
+++ b/lib/si-events-rs/src/audit_log.rs
@@ -17,6 +17,8 @@ use crate::{
 
 mod v1;
 
+pub use v1::PropValueSource;
+
 pub type AuditLogKind = AuditLogKindV1;
 pub type AuditLogMetadata = AuditLogMetadataV1;
 

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -338,6 +338,13 @@ pub enum AuditLogKindV1 {
         func_name: String,
         run_status: bool,
     },
+    SetAttribute {
+        component_id: ComponentId,
+        attribute_value_id: AttributeValueId,
+        path: String,
+        before_value: Option<PropValueSource>,
+        after_value: Option<PropValueSource>,
+    },
     SetDefaultSubscriptionSource {
         component_id: ComponentId,
         av_id: AttributeValueId,
@@ -358,6 +365,12 @@ pub enum AuditLogKindV1 {
     UnlockSchemaVariant {
         schema_variant_id: SchemaVariantId,
         schema_variant_display_name: String,
+    },
+    UnsetAttribute {
+        component_id: ComponentId,
+        attribute_value_id: AttributeValueId,
+        path: String,
+        before_value: Option<PropValueSource>,
     },
     UpdateComponent {
         component_id: ComponentId,
@@ -814,6 +827,14 @@ pub enum AuditLogMetadataV1 {
         run_status: bool,
     },
     #[serde(rename_all = "camelCase")]
+    SetAttribute {
+        component_id: ComponentId,
+        attribute_value_id: AttributeValueId,
+        path: String,
+        before_value: Option<PropValueSource>,
+        after_value: Option<PropValueSource>,
+    },
+    #[serde(rename_all = "camelCase")]
     SetDefaultSubscriptionSource {
         component_id: ComponentId,
         av_id: AttributeValueId,
@@ -837,6 +858,13 @@ pub enum AuditLogMetadataV1 {
     UnlockSchemaVariant {
         schema_variant_id: SchemaVariantId,
         schema_variant_display_name: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    UnsetAttribute {
+        component_id: ComponentId,
+        attribute_value_id: AttributeValueId,
+        path: String,
+        before_value: Option<PropValueSource>,
     },
     #[serde(rename_all = "camelCase")]
     UpdateComponent {
@@ -1049,12 +1077,14 @@ impl AuditLogMetadataV1 {
             MetadataDiscrim::RestoreComponent => ("Restored", Some("Component")),
             MetadataDiscrim::RetryAction => ("Retried", Some("Action")),
             MetadataDiscrim::RunAction => ("Ran", Some("Action")),
+            MetadataDiscrim::SetAttribute => ("Set", Some("Attribute")),
             MetadataDiscrim::SetDefaultSubscriptionSource => {
                 ("Set Default", Some("Subscription Source"))
             }
             MetadataDiscrim::TestFunction => ("Tested", Some("Function")),
             MetadataDiscrim::UnlockFunc => ("Unlocked", Some("Function")),
             MetadataDiscrim::UnlockSchemaVariant => ("Unlocked", Some("Schema Variant")),
+            MetadataDiscrim::UnsetAttribute => ("Unset", Some("Attribute")),
             MetadataDiscrim::UpdateComponent => ("Updated", Some("Component")),
             MetadataDiscrim::UpdateComponentParent => ("Updated Parent", Some("Component")),
             MetadataDiscrim::UpdateDependentInputSocket => ("Set Dependent", Some("Input Socket")),
@@ -1541,6 +1571,19 @@ impl From<Kind> for Metadata {
                 func_name,
                 run_status,
             },
+            Kind::SetAttribute {
+                component_id,
+                attribute_value_id,
+                path,
+                before_value,
+                after_value,
+            } => Self::SetAttribute {
+                component_id,
+                attribute_value_id,
+                path,
+                before_value,
+                after_value,
+            },
             Kind::SetDefaultSubscriptionSource {
                 component_id,
                 av_id,
@@ -1578,6 +1621,17 @@ impl From<Kind> for Metadata {
             } => Self::UnlockSchemaVariant {
                 schema_variant_id,
                 schema_variant_display_name,
+            },
+            Kind::UnsetAttribute {
+                component_id,
+                attribute_value_id,
+                path,
+                before_value,
+            } => Self::UnsetAttribute {
+                component_id,
+                attribute_value_id,
+                path,
+                before_value,
             },
             Kind::UpdateComponent {
                 component_id,
@@ -1813,4 +1867,16 @@ impl From<Kind> for Metadata {
             },
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(dead_code)]
+pub enum PropValueSource {
+    Value(serde_json::Value),
+    Subscription {
+        value: Option<serde_json::Value>,
+        source_component_id: ComponentId,
+        source_path: String,
+    },
+    None,
 }


### PR DESCRIPTION
```
{
  "title": "Set",
  "userId": "01GW0KXH4YJBWC7BTBAZ6ZR7EA",
  "userEmail": "paul@systeminit.com",
  "userName": "stack72",
  "kind": "SetAttribute",
  "entityType": "Attribute",
  "entityName": "/secrets/AWS Credential",
  "timestamp": "2025-08-23T22:00:53.621959+00:00",
  "changeSetId": "01K3CF5MWH9KR6VC09K6VDVSG1",
  "changeSetName": "data-from-the-outside",
  "metadata": {
    "path": "/secrets/AWS Credential",
    "afterValue": {
      "Subscription": {
        "value": "9b71c0876cad05a1007f0ad16316c4e4",
        "source_path": "/secrets/AWS Credential",
        "source_component_id": "01K3CF5NMCVBCR2TY4WGSXCR2H"
      }
    },
    "beforeValue": "None”, // This is a new AV!
    "componentId": "01K3CF5S2EMW4YV9QP6T5M2F74",
    "attributeValueId": "01K3CF5S2NMWW33ZP7S7E3WB60"
  },
}
```