### PR TITLE
feat(edda): Additional Diff MVs and Secret Data

### DIFF
--- a/lib/dal-materialized-views/src/action.rs
+++ b/lib/dal-materialized-views/src/action.rs
@@ -1,0 +1,3 @@
+pub mod action_diff_list;
+pub mod action_prototype_view_list;
+pub mod action_view_list;

--- a/lib/dal-materialized-views/src/action/action_diff_list.rs
+++ b/lib/dal-materialized-views/src/action/action_diff_list.rs
@@ -1,0 +1,90 @@
+use std::collections::{
+    HashMap,
+    HashSet,
+};
+
+use dal::{
+    DalContext,
+    action::Action,
+};
+use si_frontend_mv_types::action::action_diff_list::{
+    ActionDiffList as ActionDiffListMv,
+    ActionDiffStatus,
+    ActionDiffView,
+};
+use si_id::ActionId;
+use telemetry::prelude::*;
+
+#[instrument(
+    name = "dal_materialized_views.action_diff_list",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(new_ctx: DalContext) -> crate::Result<ActionDiffListMv> {
+    let new_ctx = &new_ctx;
+    let old_ctx = new_ctx.clone_with_head().await?;
+    let old_ctx = &old_ctx;
+
+    let new_action_ids: HashSet<ActionId> =
+        HashSet::from_iter(Action::list_topologically(new_ctx).await?);
+    let old_action_ids: HashSet<ActionId> =
+        HashSet::from_iter(Action::list_topologically(old_ctx).await?);
+
+    let mut action_diffs: HashMap<ActionId, ActionDiffView> = HashMap::new();
+    let only_old_actions: Vec<&ActionId> = old_action_ids.difference(&new_action_ids).collect();
+    for old_action in only_old_actions {
+        let Some(component_id) = Action::component_id(old_ctx, *old_action).await? else {
+            warn!(si.error.message="Found orphaned action while building Diff MV", si.action.id=%old_action.to_string());
+            continue;
+        };
+
+        let action_diff = ActionDiffView {
+            id: *old_action,
+            diff_status: ActionDiffStatus::Removed,
+            component_id,
+        };
+        action_diffs.insert(*old_action, action_diff);
+    }
+    let only_new_actions: Vec<&ActionId> = new_action_ids.difference(&old_action_ids).collect();
+    for new_action in only_new_actions {
+        let Some(component_id) = Action::component_id(new_ctx, *new_action).await? else {
+            warn!(si.error.message="Found orphaned action while building Diff MV", si.action.id=%new_action.to_string());
+            continue;
+        };
+        let state = Action::get_by_id(new_ctx, *new_action).await?.state();
+        let action_diff = ActionDiffView {
+            id: *new_action,
+            diff_status: ActionDiffStatus::Added { new_state: state },
+            component_id,
+        };
+        action_diffs.insert(*new_action, action_diff);
+    }
+
+    let actions_in_both: Vec<&ActionId> = old_action_ids.intersection(&new_action_ids).collect();
+    for action in actions_in_both {
+        let old_state = Action::get_by_id(old_ctx, *action).await?.state();
+        let new_state = Action::get_by_id(new_ctx, *action).await?.state();
+        let Some(component_id) = Action::component_id(new_ctx, *action).await? else {
+            warn!(si.error.message="Found orphaned action while building Diff MV", si.action.id=%action.to_string());
+            continue;
+        };
+        let has_different_state = old_state != new_state;
+        let diff_status = match has_different_state {
+            true => ActionDiffStatus::Modified {
+                old_state,
+                new_state,
+            },
+            false => ActionDiffStatus::None,
+        };
+        let action_diff = ActionDiffView {
+            id: *action,
+            diff_status,
+            component_id,
+        };
+        action_diffs.insert(*action, action_diff);
+    }
+
+    let id = new_ctx.workspace_pk()?;
+
+    Ok(ActionDiffListMv { id, action_diffs })
+}

--- a/lib/dal-materialized-views/src/action/action_prototype_view_list.rs
+++ b/lib/dal-materialized-views/src/action/action_prototype_view_list.rs
@@ -18,7 +18,7 @@ use telemetry::prelude::*;
 pub async fn assemble(
     ctx: DalContext,
     schema_variant_id: SchemaVariantId,
-) -> super::Result<ActionPrototypeViewListMv> {
+) -> crate::Result<ActionPrototypeViewListMv> {
     let ctx = &ctx;
 
     let action_prototypes_for_variant =

--- a/lib/dal-materialized-views/src/action/action_view_list.rs
+++ b/lib/dal-materialized-views/src/action/action_view_list.rs
@@ -19,7 +19,7 @@ use telemetry::prelude::*;
     level = "debug",
     skip_all
 )]
-pub async fn assemble(ctx: DalContext) -> super::Result<ActionViewListMv> {
+pub async fn assemble(ctx: DalContext) -> crate::Result<ActionViewListMv> {
     let ctx = &ctx;
     let action_ids = Action::list_topologically(ctx).await?;
 

--- a/lib/dal-materialized-views/src/component.rs
+++ b/lib/dal-materialized-views/src/component.rs
@@ -22,6 +22,7 @@ use telemetry::prelude::*;
 
 pub mod attribute_tree;
 pub mod component_diff;
+pub mod erased_components;
 
 #[instrument(
     name = "dal_materialized_views.component_in_list",

--- a/lib/dal-materialized-views/src/component/erased_components.rs
+++ b/lib/dal-materialized-views/src/component/erased_components.rs
@@ -1,0 +1,47 @@
+use std::collections::{
+    HashMap,
+    HashSet,
+};
+
+use dal::{
+    Component,
+    ComponentId,
+    DalContext,
+};
+use si_frontend_mv_types::component::erased_components::ErasedComponents;
+use telemetry::prelude::*;
+
+#[instrument(
+    name = "dal_materialized_views.component_list",
+    level = "debug",
+    skip_all
+)]
+pub async fn assemble(new_ctx: DalContext) -> crate::Result<ErasedComponents> {
+    let new_ctx = &new_ctx;
+    let old_ctx = new_ctx.clone_with_head().await?;
+    let old_ctx = &old_ctx;
+    if new_ctx.change_set_id() == old_ctx.change_set_id() {
+        return Ok(ErasedComponents {
+            id: new_ctx.workspace_pk()?,
+            erased: HashMap::new(),
+        });
+    }
+    // Get all of the component Ids on head, and in this change set
+    let old_ids: HashSet<ComponentId> =
+        HashSet::from_iter(Component::list_ids(old_ctx).await?.iter().copied());
+    let new_ids: HashSet<ComponentId> =
+        HashSet::from_iter(Component::list_ids(new_ctx).await?.iter().copied());
+
+    let only_in_old: HashSet<&ComponentId> = old_ids.difference(&new_ids).collect();
+    let mut erased = HashMap::new();
+    for &component_id in only_in_old {
+        let diff = super::component_diff::assemble(new_ctx.clone(), component_id).await?;
+        erased.insert(component_id, diff);
+    }
+
+    let workspace_mv_id = new_ctx.workspace_pk()?;
+    Ok(ErasedComponents {
+        id: workspace_mv_id,
+        erased,
+    })
+}

--- a/lib/dal-materialized-views/src/lib.rs
+++ b/lib/dal-materialized-views/src/lib.rs
@@ -52,8 +52,7 @@
 
 use dal::WorkspaceSnapshotError;
 
-pub mod action_prototype_view_list;
-pub mod action_view_list;
+pub mod action;
 pub mod cached;
 pub mod component;
 pub mod component_list;

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -88,7 +88,7 @@ async fn actions(ctx: &DalContext) -> Result<()> {
     let create_action = Action::get_by_id(ctx, create_action_id).await?;
 
     // Check the frontend payload for actions.
-    let mut mv = dal_materialized_views::action_view_list::assemble(ctx.clone()).await?;
+    let mut mv = dal_materialized_views::action::action_view_list::assemble(ctx.clone()).await?;
     let action_view = mv.actions.pop().ok_or_eyre("empty actions")?;
     assert!(mv.actions.is_empty(), "only one action should exist");
     assert_eq!(
@@ -111,7 +111,7 @@ async fn actions(ctx: &DalContext) -> Result<()> {
     );
 
     // Check the frontend payload for action prototypes.
-    let mv = dal_materialized_views::action_prototype_view_list::assemble(
+    let mv = dal_materialized_views::action::action_prototype_view_list::assemble(
         ctx.clone(),
         schema_variant_id,
     )

--- a/lib/edda-server/src/materialized_view.rs
+++ b/lib/edda-server/src/materialized_view.rs
@@ -37,6 +37,7 @@ use si_frontend_mv_types::{
     action::{
         ActionPrototypeViewList as ActionPrototypeViewListMv,
         ActionViewList as ActionViewListMv,
+        action_diff_list::ActionDiffList as ActionDiffListMv,
     },
     checksum::FrontendChecksum,
     component::{
@@ -46,6 +47,7 @@ use si_frontend_mv_types::{
         SchemaMembers,
         attribute_tree::AttributeTree as AttributeTreeMv,
         component_diff::ComponentDiff as ComponentDiffMv,
+        erased_components::ErasedComponents as ErasedComponentsMv,
     },
     dependent_values::DependentValueComponentList as DependentValueComponentListMv,
     incoming_connections::{
@@ -1264,6 +1266,18 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
     workspace_pk: si_id::WorkspacePk,
 ) -> Result<(), MaterializedViewError> {
     match mv_kind {
+        ReferenceKind::ActionDiffList => {
+            let workspace_mv_id = workspace_pk.to_string();
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                ActionDiffListMv,
+                dal_materialized_views::action::action_diff_list::assemble(ctx.clone()),
+            );
+        }
         ReferenceKind::ActionPrototypeViewList => {
             let entity_mv_id = change.entity_id.to_string();
 
@@ -1274,7 +1288,7 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 change,
                 entity_mv_id,
                 ActionPrototypeViewListMv,
-                dal_materialized_views::action_prototype_view_list::assemble(
+                dal_materialized_views::action::action_prototype_view_list::assemble(
                     ctx.clone(),
                     si_events::ulid::Ulid::from(change.entity_id).into()
                 ),
@@ -1290,7 +1304,7 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 change,
                 workspace_mv_id,
                 ActionViewListMv,
-                dal_materialized_views::action_view_list::assemble(ctx.clone()),
+                dal_materialized_views::action::action_view_list::assemble(ctx.clone()),
             );
         }
         ReferenceKind::AttributeTree => {
@@ -1368,6 +1382,18 @@ async fn spawn_build_mv_task_for_change_and_mv_kind(
                 workspace_mv_id,
                 ComponentListMv,
                 dal_materialized_views::component_list::assemble(ctx.clone()),
+            );
+        }
+        ReferenceKind::ErasedComponents => {
+            let workspace_mv_id = workspace_pk.to_string();
+            spawn_build_mv_task!(
+                build_tasks,
+                ctx,
+                frigg,
+                change,
+                workspace_mv_id,
+                ErasedComponentsMv,
+                dal_materialized_views::component::erased_components::assemble(ctx.clone()),
             );
         }
         ReferenceKind::DependentValueComponentList => {

--- a/lib/si-events-rs/src/action.rs
+++ b/lib/si-events-rs/src/action.rs
@@ -30,7 +30,17 @@ pub enum ActionKind {
 }
 
 #[derive(
-    Debug, Copy, Clone, Deserialize, Serialize, EnumDiscriminants, PartialEq, Eq, Display, Hash,
+    Debug,
+    Copy,
+    Clone,
+    Deserialize,
+    Serialize,
+    EnumDiscriminants,
+    PartialEq,
+    Eq,
+    Display,
+    Hash,
+    Default,
 )]
 #[strum_discriminants(derive(strum::Display, Serialize, Deserialize))]
 pub enum ActionState {
@@ -44,6 +54,7 @@ pub enum ActionState {
     OnHold,
     /// Action is available to be dispatched once all of its prerequisites have succeeded, and been
     /// removed from the graph.
+    #[default]
     Queued,
     /// Action has been dispatched, and started execution in the job system. See the job history
     /// for details.

--- a/lib/si-frontend-mv-types-rs/src/action.rs
+++ b/lib/si-frontend-mv-types-rs/src/action.rs
@@ -17,6 +17,7 @@ use si_id::{
 
 use crate::reference::ReferenceKind;
 
+pub mod action_diff_list;
 pub mod prototype;
 
 pub use prototype::{

--- a/lib/si-frontend-mv-types-rs/src/action/action_diff_list.rs
+++ b/lib/si-frontend-mv-types-rs/src/action/action_diff_list.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    ActionState,
+    workspace_snapshot::EntityKind,
+};
+use si_id::{
+    ActionId,
+    ComponentId,
+    WorkspacePk,
+};
+use strum::{
+    AsRefStr,
+    Display,
+    EnumString,
+};
+
+use crate::reference::ReferenceKind;
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+    si_frontend_mv_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+  trigger_entity = EntityKind::CategoryAction,
+  reference_kind = ReferenceKind::ActionDiffList,
+  build_priority = "List",
+)]
+pub struct ActionDiffList {
+    pub id: WorkspacePk,
+    pub action_diffs: HashMap<ActionId, ActionDiffView>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionDiffView {
+    pub id: ActionId,
+    pub diff_status: ActionDiffStatus,
+    pub component_id: ComponentId,
+}
+
+#[remain::sorted]
+#[derive(
+    AsRefStr,
+    Deserialize,
+    Serialize,
+    Debug,
+    Display,
+    EnumString,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    si_frontend_mv_types_macros::FrontendChecksum,
+)]
+pub enum ActionDiffStatus {
+    Added {
+        new_state: ActionState,
+    },
+    Modified {
+        old_state: ActionState,
+        new_state: ActionState,
+    },
+    None,
+    Removed,
+}

--- a/lib/si-frontend-mv-types-rs/src/component.rs
+++ b/lib/si-frontend-mv-types-rs/src/component.rs
@@ -24,6 +24,7 @@ use crate::reference::{
 
 pub mod attribute_tree;
 pub mod component_diff;
+pub mod erased_components;
 
 #[derive(
     Debug,

--- a/lib/si-frontend-mv-types-rs/src/component/component_diff.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/component_diff.rs
@@ -11,6 +11,7 @@ use tuple_vec_map;
 use crate::{
     component::ComponentDiffStatus,
     reference::ReferenceKind,
+    secret::Secret,
 };
 
 /// Differences between a component in a changeset vs. head
@@ -56,6 +57,7 @@ pub struct ComponentDiff {
     si_frontend_mv_types_macros::FrontendChecksum,
 )]
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
+#[allow(clippy::large_enum_variant)]
 pub enum AttributeDiff {
     /// This value was added in the current changeset.
     Added { new: AttributeSourceAndValue },
@@ -218,6 +220,21 @@ pub enum SimplifiedAttributeSource {
     /// it.
     ///
     Prototype { prototype: String },
+    /// This attribute is set to a subscription to a secret Prop
+    ///
+    ///     { component: "My Region", path: "/secrets/AWS Credential", secret_name: "Production Creds" }
+    ///
+    SecretSubscription {
+        component: ComponentId,
+        path: String,
+        secret: Secret,
+    },
+
+    /// This attribute is set to a Secret Value
+    SecretValue {
+        value: serde_json::Value,
+        secret: Secret,
+    },
 }
 
 #[allow(clippy::panic_in_result_fn)]

--- a/lib/si-frontend-mv-types-rs/src/component/erased_components.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/erased_components.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+use si_events::workspace_snapshot::EntityKind;
+use si_id::{
+    ComponentId,
+    WorkspacePk,
+};
+
+use crate::{
+    component::component_diff::ComponentDiff,
+    reference::ReferenceKind,
+};
+
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    PartialEq,
+    Eq,
+    si_frontend_mv_types_macros::FrontendChecksum,
+    si_frontend_mv_types_macros::FrontendObject,
+    si_frontend_mv_types_macros::Refer,
+    si_frontend_mv_types_macros::MV,
+)]
+#[serde(rename_all = "camelCase")]
+#[mv(
+  trigger_entity = EntityKind::CategoryComponent,
+  reference_kind = ReferenceKind::ErasedComponents,
+  build_priority = "List",
+)]
+pub struct ErasedComponents {
+    pub id: WorkspacePk,
+    pub erased: HashMap<ComponentId, ComponentDiff>,
+}

--- a/lib/si-frontend-mv-types-rs/src/reference.rs
+++ b/lib/si-frontend-mv-types-rs/src/reference.rs
@@ -35,6 +35,7 @@ pub use weak::WeakReference;
 )]
 #[serde(rename_all = "PascalCase")]
 pub enum ReferenceKind {
+    ActionDiffList,
     ActionPrototypeViewList,
     ActionViewList,
     AttributeTree,
@@ -51,6 +52,7 @@ pub enum ReferenceKind {
     ComponentList,
     DependentValueComponentList,
     DeploymentMvIndex,
+    ErasedComponents,
     IncomingConnections,
     IncomingConnectionsList,
     LuminorkDefaultVariant,


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

<!-- Why: briefly what problem this solves and what the aim is as an overview -->
In order to correctly populate the Review screen, we need additional pieces of information:

`ErasedComponents` provides a map of components that exist on head but do not exist in this change set. Because we replay changes to head on open change sets, any change to components on head will trigger this MV to build. If you’ve erased a component in this change set, but it still exists on head, we’ll provide the same ComponentDiff, with all data populated on head. 

`ActionDiffList` provides a list of Actions and their diff status: 
- If the state has been changed in this change set (for example, putting an action on hold)
- If the action is new in this change set
- If the action has been removed in this change set

`ComponentDiff` now includes information specific to Secrets so we can correctly show when changes have been made regarding secrets. Note: We aren’t diffing the actual encrypted secret data, but whenever the secret data changes, we always end up with a new secret so we can show when non-encrypted data changes (name/description) as well as show when subscriptions to secrets change

I also fixed a bug where we were using the wrong `DalContext` when computing the `ComponentDiff`

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

Manual testing - all MVs look as expected on the front end 
I need to add automated tests still but wanted to get this out there to build upon

## In short: [:link:](https://giphy.com/)

<div><img src="https://media0.giphy.com/media/hWl65BEtMP5DO/200.gif?cid=5a38a5a2qjtxt8pl1947i3u1fb96it0wvxhnrtt2cc13ec33&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:124px;width:300px"/><br/>via <a href="https://giphy.com/gifs/reaction-different-im-hWl65BEtMP5DO">GIPHY</a></div>