### PR TITLE
Update some of the Mvs to give the front end what it needs and start support these new Mvs in the Review Screen

### DIFF
--- a/app/web/src/newhotness/ActionWidget.vue
+++ b/app/web/src/newhotness/ActionWidget.vue
@@ -33,11 +33,12 @@ import { ActionId } from "@/api/sdf/dal/action";
 import {
   ActionPrototypeView,
   BifrostComponent,
+  ComponentInList,
 } from "@/workers/types/entity_kind_types";
 import { useComponentActions } from "./logic_composables/component_actions";
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: BifrostComponent | ComponentInList;
   actionPrototypeView: ActionPrototypeView;
   actionId?: ActionId;
 }>();

--- a/app/web/src/newhotness/ActionsPanel.vue
+++ b/app/web/src/newhotness/ActionsPanel.vue
@@ -23,19 +23,22 @@
       :key="actionPrototypeView.id"
       :actionPrototypeView="actionPrototypeView"
       :actionId="actionByPrototype[actionPrototypeView.id]?.id"
-      :component="props.component"
+      :component="component"
     />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { BifrostComponent } from "@/workers/types/entity_kind_types";
+import {
+  BifrostComponent,
+  ComponentInList,
+} from "@/workers/types/entity_kind_types";
 import ActionWidget from "./ActionWidget.vue";
 import EmptyState from "./EmptyState.vue";
 import { useComponentActions } from "./logic_composables/component_actions";
 
 const props = defineProps<{
-  component: BifrostComponent;
+  component: BifrostComponent | ComponentInList;
 }>();
 
 const { actionPrototypeViews, actionByPrototype } = useComponentActions(

--- a/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
+++ b/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
@@ -96,9 +96,14 @@ const props = defineProps<{
 const rawValue = computed(() => props.sourceAndValue.$value);
 const rawSource = computed(() => props.sourceAndValue.$source);
 
-const displayKind = computed<DisplayKind>(() =>
-  sourceAndValueDisplayKind(rawSource.value, props.secret),
-);
+const displayKind = computed<DisplayKind>(() => {
+  const kind = sourceAndValueDisplayKind(rawSource.value, props.secret);
+
+  if (props.secret && props.old && !rawValue.value) {
+    return "hidden";
+  }
+  return kind;
+});
 
 const emit = defineEmits<{
   (e: "revert"): void;

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -16,6 +16,7 @@ import { ComponentName } from "@/store/components.store";
 import { ComponentInfo } from "./dbinterface";
 
 export enum EntityKind {
+  ActionDiffList = "ActionDiffList",
   ActionPrototypeViewList = "ActionPrototypeViewList",
   ActionViewList = "ActionViewList",
   AttributeTree = "AttributeTree",
@@ -30,6 +31,7 @@ export enum EntityKind {
   ComponentsInViews = "ComponentsInViews",
   DefaultSubscriptions = "DefaultSubscriptions",
   DependentValueComponentList = "DependentValueComponentList",
+  ErasedComponents = "ErasedComponents",
   IncomingConnections = "IncomingConnections",
   IncomingConnectionsList = "IncomingConnectionsList",
   IncomingManagementConnections = "IncomingManagementConnections",
@@ -300,6 +302,10 @@ export interface ComponentDiff {
   id: ComponentId;
   diffStatus: ComponentDiffStatus;
   attributeDiffs: Record<AttributePath, AttributeDiff>;
+  resourceDiff: {
+    current?: string;
+    diff?: string;
+  };
 }
 
 /**
@@ -407,11 +413,15 @@ export type SimplifiedAttributeSource =
       component: ComponentId;
       componentName: ComponentName;
       path: AttributePath;
-      value?: undefined;
+      secret?: Secret;
+
       prototype?: undefined;
+      value?: undefined;
     }
   | {
       value: unknown;
+      secret?: Secret;
+
       component?: undefined;
       componentName?: undefined;
       path?: undefined;
@@ -419,11 +429,28 @@ export type SimplifiedAttributeSource =
     }
   | {
       prototype: string;
+
       component?: undefined;
       componentName?: undefined;
       path?: undefined;
+      secret?: undefined;
       value?: undefined;
     };
+
+export interface ErasedComponents {
+  id: string;
+  erased: Record<
+    ComponentId,
+    {
+      diff: ComponentDiff;
+      component: ComponentInList;
+      resourceDiff: {
+        current?: string;
+        diff?: string;
+      };
+    }
+  >;
+}
 
 // NOTE: when using `getMany` you don't end up with a BifrostComponent (b/c it doesnt have SchemaVariant)
 // You end up with a ComponentInList

--- a/lib/dal-materialized-views/src/component/erased_components.rs
+++ b/lib/dal-materialized-views/src/component/erased_components.rs
@@ -8,7 +8,10 @@ use dal::{
     ComponentId,
     DalContext,
 };
-use si_frontend_mv_types::component::erased_components::ErasedComponents;
+use si_frontend_mv_types::component::erased_components::{
+    ErasedComponents,
+    HeadComponent,
+};
 use telemetry::prelude::*;
 
 #[instrument(
@@ -36,7 +39,9 @@ pub async fn assemble(new_ctx: DalContext) -> crate::Result<ErasedComponents> {
     let mut erased = HashMap::new();
     for &component_id in only_in_old {
         let diff = super::component_diff::assemble(new_ctx.clone(), component_id).await?;
-        erased.insert(component_id, diff);
+        let component = crate::component::assemble_in_list(old_ctx.clone(), component_id).await?;
+
+        erased.insert(component_id, HeadComponent { diff, component });
     }
 
     let workspace_mv_id = new_ctx.workspace_pk()?;

--- a/lib/si-frontend-mv-types-rs/src/component/component_diff.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/component_diff.rs
@@ -9,7 +9,10 @@ use si_events::{
 use tuple_vec_map;
 
 use crate::{
-    component::ComponentDiffStatus,
+    component::{
+        ComponentDiffStatus,
+        ComponentTextDiff,
+    },
     reference::ReferenceKind,
     secret::Secret,
 };
@@ -45,6 +48,8 @@ pub struct ComponentDiff {
     // (for more ergonomic APIs)
     #[serde(with = "tuple_vec_map")]
     pub attribute_diffs: Vec<(String, AttributeDiff)>,
+    // Also include the TextDiff as we always need it when we need this MV
+    pub resource_diff: ComponentTextDiff,
 }
 
 #[derive(
@@ -307,10 +312,14 @@ mod test {
                             }
                         }
                     ),
-                ]
+                ],
+                resource_diff: ComponentTextDiff {
+                    current: None,
+                    diff: None
+                }
             },
             serde_json::from_str(&format!(
-                r#"{{ "id": {}, "diffStatus": "Added", "attributeDiffs": {} }}"#,
+                r#"{{ "id": {}, "diffStatus": "Added", "resourceDiff": {{}}, "attributeDiffs": {} }}"#,
                 serde_json::to_string(&id)?,
                 r#"{
                         "/domain/Foo": {

--- a/lib/si-frontend-mv-types-rs/src/component/erased_components.rs
+++ b/lib/si-frontend-mv-types-rs/src/component/erased_components.rs
@@ -8,7 +8,10 @@ use si_id::{
 };
 
 use crate::{
-    component::component_diff::ComponentDiff,
+    component::{
+        ComponentInList,
+        component_diff::ComponentDiff,
+    },
     reference::ReferenceKind,
 };
 
@@ -31,5 +34,11 @@ use crate::{
 )]
 pub struct ErasedComponents {
     pub id: WorkspacePk,
-    pub erased: HashMap<ComponentId, ComponentDiff>,
+    pub erased: HashMap<ComponentId, HeadComponent>,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, si_frontend_mv_types_macros::FrontendChecksum)]
+#[serde(rename_all = "camelCase")]
+pub struct HeadComponent {
+    pub diff: ComponentDiff,
+    pub component: ComponentInList,
 }


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Consolidates some of the data needed to hydrate this Review screen including: 
1. Include the json diff in the `ComponentDiff`
2. Include a `ComponentInList` MV for the erased components (Components that are only on head) 
3. Adds the necessary types to `entity_kind_types.ts` 
4. **Starts** to consume this on the Front End 
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:
Here's an example component that does not exist in this Change Set being reviewed
<img width="1516" height="973" alt="image" src="https://github.com/user-attachments/assets/a2b91f71-5897-4b0a-b224-b1a8cd612395" />

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Known Areas to fix (non-exhaustive)
Functional gaps:
1. The revert button does not show up at the right time (notice, we shouldn't see any of the fields for the erased component as revertible
2. Secrets information is not being propagated correctly - we now have the Secret Name in the DiffMV that we can use
3. Changes made to Secret subscriptions don't show at all 


