### PR TITLE
Grab Bag: Stale Time, lobby fixes

### DIFF
--- a/app/web/src/newhotness/ComponentHistory.vue
+++ b/app/web/src/newhotness/ComponentHistory.vue
@@ -205,6 +205,7 @@ const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
       }
       return { logs: [], canLoadMore: false };
     },
+    staleTime: 60 * 2 * 1000,
     initialPageParam: pageSize,
     getNextPageParam: (lastPage: AuditLogsForComponentResponse) => {
       if (!lastPage.canLoadMore) return undefined;

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -279,7 +279,6 @@ import { useComponentSearch } from "./logic_composables/search";
 const router = useRouter();
 const ctx = useContext();
 const queryClient = useQueryClient();
-queryClient.setDefaultOptions({ queries: { staleTime: Infinity } });
 
 // const changeSetName = computed(() => ctx.changeSet.value?.name);
 const selectedComponentId = ref<ComponentId>();

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -402,7 +402,7 @@ const checkOnboardingCompleteData = async () => {
 const lobby = computed(
   () =>
     coldStartInProgress.value ||
-    featureFlagsStore.INITIALIZER_ONBOARD === undefined || // Make sure twe don't show anything before the feature flags load
+    // not looking for feature flag values in here (if for any reason, network connectivity, posthog being down, we didn't get feature flags everyone would be stuck in the lobby)
     loadedOnboardingStateFromApi.value === false, // Don't continue before we got the response from the auth API
 );
 


### PR DESCRIPTION
## How does this PR change the system?

All HTTP API calls with tanStack ought to have a stale time. The we set the global default to be infinity, for the MVs, since we know definitively when to invalidate each of them. But API calls don't have the same behavior, we dont know to bust based on changes, so we need a stale time.

Fixed up a CORs issue locally with `/decide/` route. Don't stay in the lobby if feature flags don't load.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcW1tcWs2M3QyeXI4ZmNma2IzbmNsdnVwb2d5NXRmZzJpMHk2eHowciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT0xeuOy2Fcl9vDGiA/giphy.gif"/>