### PR TITLE
Add actions to review screen

### DIFF
--- a/app/web/src/newhotness/ActionPills.vue
+++ b/app/web/src/newhotness/ActionPills.vue
@@ -1,0 +1,64 @@
+<template>
+  <div
+    :class="
+      clsx(
+        'gap-1 items-center',
+        mode === 'grid' && 'grid grid-cols-5',
+        mode === 'row' && 'flex flex-row',
+      )
+    "
+  >
+    <TextPill
+      v-for="(actionData, actionName) in actionCounts"
+      :key="actionName"
+      v-tooltip="getTooltip(actionName, actionData.count, actionData.hasFailed)"
+      variant="key2"
+      size="sm"
+      class="text-xs flex items-center gap-1"
+    >
+      <Icon
+        :name="getIcon(actionName)"
+        :class="
+          actionData.hasFailed ? 'text-destructive-500' : 'text-neutral-500'
+        "
+        size="xs"
+      />
+      {{ actionData.count }}
+    </TextPill>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Icon, IconNames, TextPill } from "@si/vue-lib/design-system";
+import clsx from "clsx";
+
+defineProps<{
+  actionCounts?: Record<string, { count: number; hasFailed: boolean }>;
+  mode: "grid" | "row";
+}>();
+
+const getIcon = (actionName: string): IconNames => {
+  const iconMap: Record<string, IconNames> = {
+    Create: "plus",
+    Update: "tilde",
+    Refresh: "refresh",
+    Destroy: "trash",
+    Delete: "trash",
+    Manual: "play",
+  };
+  return iconMap[actionName] || "play";
+};
+
+const getTooltip = (actionName: string, count: number, hasFailed: boolean) => {
+  const actionWord = actionName.toLowerCase();
+  const plural = count > 1 ? "s" : "";
+
+  if (hasFailed && count === 1) {
+    return `1 pending ${actionWord} action failed`;
+  } else if (hasFailed) {
+    return `${count} pending ${actionWord} action${plural} (including failed)`;
+  } else {
+    return `${count} pending ${actionWord} action${plural}`;
+  }
+};
+</script>

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -136,31 +136,7 @@
           </TextPill>
         </template>
         <template v-else-if="rowContent === 'pending'">
-          <div class="grid grid-cols-5 gap-1 items-center">
-            <TextPill
-              v-for="(actionData, actionName) in pendingActionCounts"
-              :key="actionName"
-              v-tooltip="
-                getPendingActionTooltip(
-                  actionName,
-                  actionData.count,
-                  actionData.hasFailed,
-                )
-              "
-              variant="key2"
-              size="sm"
-              class="text-xs flex items-center gap-1"
-            >
-              <Icon
-                :name="getPendingActionIcon(actionName)"
-                :class="
-                  getPendingActionIconClass(actionName, actionData.hasFailed)
-                "
-                size="xs"
-              />
-              {{ actionData.count }}
-            </TextPill>
-          </div>
+          <ActionPills :actionCounts="pendingActionCounts" mode="grid" />
         </template>
       </li>
       <!-- NOTE: when coming from the Map page we don't have accurate outputCount, hiding this -->
@@ -216,7 +192,6 @@
 <script lang="ts" setup>
 import {
   Icon,
-  IconNames,
   PillCounter,
   TextPill,
   themeClasses,
@@ -229,6 +204,7 @@ import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
 import { getAssetIcon } from "../util";
 import { assertIsDefined, Context, ExploreContext } from "../types";
 import ComponentTileQualificationStatus from "../ComponentTileQualificationStatus.vue";
+import ActionPills from "../ActionPills.vue";
 
 const props = defineProps<{
   component: ComponentInList;
@@ -296,40 +272,6 @@ const toggleSelection = () => {
     emit("deselect");
   } else {
     emit("select");
-  }
-};
-
-const getPendingActionIcon = (actionName: string): IconNames => {
-  const iconMap: Record<string, IconNames> = {
-    Create: "plus",
-    Update: "tilde",
-    Refresh: "refresh",
-    Destroy: "trash",
-    Delete: "trash",
-    Manual: "play",
-  };
-  return iconMap[actionName] || "play";
-};
-
-const getPendingActionIconClass = (actionName: string, hasFailed: boolean) => {
-  // Red if failed, grey otherwise
-  return hasFailed ? "text-destructive-500" : "text-neutral-500";
-};
-
-const getPendingActionTooltip = (
-  actionName: string,
-  count: number,
-  hasFailed: boolean,
-) => {
-  const actionWord = actionName.toLowerCase();
-  const plural = count > 1 ? "s" : "";
-
-  if (hasFailed && count === 1) {
-    return `1 pending ${actionWord} action failed`;
-  } else if (hasFailed) {
-    return `${count} pending ${actionWord} action${plural} (including failed)`;
-  } else {
-    return `${count} pending ${actionWord} action${plural}`;
   }
 };
 

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -63,6 +63,9 @@
           <slot name="header" />
         </div>
       </template>
+      <template #titleIcons>
+        <slot name="headerIcons" />
+      </template>
       <div class="scrollable max-h-[70vh]">
         <slot />
       </div>


### PR DESCRIPTION
## Description

This change adds actions to the review screen. In addition to this change, the actions pills themselves have been split into a new component for both the review screen and grid tiles to use. This is an intentional port of the "ActionsPanel" without additional styling changes.

This change also adds icons to expand modals. This doesn't only add icons to the actions modal in the review screen, but also to all other expand modals, like qualifications in component details.

## Screenshots

Actions in review (note that "zero" counts are included):

<img width="305" height="286" alt="Screenshot 2025-08-24 at 2 25 30 PM" src="https://github.com/user-attachments/assets/44e8522a-caa9-4087-ad38-ec9344e271fc" />

Explore grid tile:

<img width="940" height="214" alt="Screenshot 2025-08-24 at 2 25 25 PM" src="https://github.com/user-attachments/assets/3b6cfee1-61a6-4067-8fd7-50e1b2291396" />

Nothing is selected:

<img width="1002" height="410" alt="Screenshot 2025-08-24 at 1 27 45 PM" src="https://github.com/user-attachments/assets/31d8156b-3cfa-4a77-be07-d96f6271682a" />

Actions expand modal:

<img width="1035" height="348" alt="Screenshot 2025-08-24 at 2 54 05 PM" src="https://github.com/user-attachments/assets/fdad68ad-b0e9-439f-a3f5-2b624cee0bb2" />

Qualifications expand modal in component details:

<img width="1004" height="410" alt="Screenshot 2025-08-24 at 2 53 53 PM" src="https://github.com/user-attachments/assets/abb96bde-211a-4c05-84a8-5e4059213cb1" />

## Testing

- Toggle actions in review, component details AND component context menu for a given component
- Observe that grid tile, component details AND component context menu are reflected accurately
- Note that component grid tile icons AND Context menu still works as before
- Note that component details actions menu still works as before
