### PR TITLE
fix: show secret changes in subscriber diffs

### DIFF
--- a/app/web/src/newhotness/ReviewAttributeItem.vue
+++ b/app/web/src/newhotness/ReviewAttributeItem.vue
@@ -1,6 +1,9 @@
 <template>
+  <!--
+    NOTE: if you want to hide a diff, you almost certainly want to exclude it in
+    shouldIncludeDiff() in Review.vue (or don't send it in the ComponentDiff MV!).
+  -->
   <div
-    v-if="display"
     :class="
       clsx(
         'flex flex-col gap-xs p-xs border',
@@ -137,28 +140,6 @@ const disableRevertChildren = computed(
           "subscription")
     ),
 );
-
-const display = computed(() => {
-  if (!props.item.children) {
-    if (
-      props.item.diff?.new?.$source.value &&
-      props.item.diff.new.$source.value === props.item.diff?.old?.$source.value
-    ) {
-      // same manual or default value from the source
-      return false;
-    } else if (
-      props.item.diff?.new?.$value === props.item.diff?.old?.$value &&
-      props.item.diff?.new?.$source.component ===
-        props.item.diff?.old?.$source.component &&
-      props.item.diff?.new?.$source.path === props.item.diff?.old?.$source.path
-    ) {
-      // same subscription source and same value
-      return false;
-    }
-  }
-
-  return true;
-});
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
When a component subscribes to a credential, and the credential is replaced, we don't presently show it.

## How does this PR change the system?

We always show a component diff if it shows up in the AttributeTree. Since Review.vue already excludes diffs it doesn't want in `shouldIncludeDiff()` while building the tree, we rely on that.

#### Out of Scope:

Moving shouldIncludeDiff() stuff into the MV itself: our concept of what we want is changing rapidly--we will consolidate the filtering into the ComponentDiff MV when we're done.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: secret changes show now!