### PR TITLE
feat(web): Don't load reviews screen on HEAD

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -829,7 +829,7 @@ onMounted(() => {
     }
   });
 
-  keyEmitter.on("KeyR", () => {
+  keyEmitter.on("KeyF", () => {
     if (component.value?.toDelete) {
       restoreComponent();
     }
@@ -860,7 +860,7 @@ onBeforeUnmount(() => {
   keyEmitter.off("Escape");
   keyEmitter.off("KeyE");
   keyEmitter.off("Backspace");
-  keyEmitter.off("KeyR");
+  keyEmitter.off("KeyF");
   keyEmitter.off("KeyU");
   realtimeStore.unsubscribe(MGMT_RUN_KEY);
 });

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -2104,6 +2104,10 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
       return;
     }
 
+    if (ctx.onHead.value) {
+      return;
+    }
+
     if (featureFlagsStore.REVIEW_PAGE) {
       e.preventDefault();
       router.push({

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -596,6 +596,15 @@ watch(
   { deep: true },
 );
 
+watch(
+  () => ctx.onHead.value,
+  (onHead) => {
+    if (onHead) {
+      exitReview();
+    }
+  },
+);
+
 const selectComponent = (componentId: ComponentId) => {
   selectedComponentId.value = componentId;
 };


### PR DESCRIPTION
When on HEAD, there are no changes to view so we should just disable 
opening the review screen.

We should also exit the reviews screen when someone is in it and 
changes to HEAD