### PR TITLE
feat(web) - unified component list on the review screen

### DIFF
--- a/app/web/src/components/StatusIndicatorIcon.vue
+++ b/app/web/src/components/StatusIndicatorIcon.vue
@@ -8,6 +8,12 @@
 
 <script lang="ts">
 const CONFIG = {
+  diff: {
+    Added: { iconName: "plus", tone: "success" },
+    Removed: { iconName: "minus", tone: "destructive" },
+    Modified: { iconName: "tilde", tone: "warning" },
+    None: { iconName: "empty", tone: "empty" },
+  },
   change: {
     added: { iconName: "plus-square", tone: "success" },
     deleted: { iconName: "minus-square", tone: "destructive" },

--- a/app/web/src/newhotness/ComponentListItem.vue
+++ b/app/web/src/newhotness/ComponentListItem.vue
@@ -12,7 +12,7 @@
       )
     "
   >
-    <StatusIndicatorIcon type="qualification" :status="qualificationStatus" />
+    <StatusIndicatorIcon class="flex-none" type="diff" :status="status" />
     <TextPill
       tighter
       variant="component"
@@ -23,6 +23,11 @@
     <TextPill tighter variant="component" class="text-purple">
       <TruncateWithTooltip>{{ component.name }}</TruncateWithTooltip>
     </TextPill>
+    <StatusIndicatorIcon
+      class="ml-auto flex-none"
+      type="qualification"
+      :status="qualificationStatus"
+    />
   </div>
 </template>
 
@@ -36,6 +41,7 @@ import clsx from "clsx";
 import { computed } from "vue";
 import {
   BifrostComponent,
+  ComponentDiffStatus,
   ComponentInList,
 } from "@/workers/types/entity_kind_types";
 import StatusIndicatorIcon from "@/components/StatusIndicatorIcon.vue";
@@ -43,6 +49,7 @@ import { getQualificationStatus } from "./ComponentTileQualificationStatus.vue";
 
 const props = defineProps<{
   component: ComponentInList | BifrostComponent;
+  status: ComponentDiffStatus;
   selected?: boolean;
 }>();
 

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -41,88 +41,43 @@
         @keydown.up="() => searchControl(true)"
         @keydown.down="() => searchControl(false)"
       />
-      <div class="flex flex-col gap-xs flex-grow">
-        <CollapsingFlexItem headerTextSize="sm" open>
-          <template #header>Created</template>
-          <template #headerIcons>
-            <PillCounter :count="addedComponentList.length" size="sm" />
-          </template>
-          <div class="flex flex-col gap-xs p-xs w-full h-full">
-            <EmptyState
-              v-if="componentCounts.Added === 0"
-              icon="component"
-              text="No components added"
-              class="p-sm"
-            />
-            <EmptyState
-              v-else-if="addedComponentList.length === 0"
-              icon="component"
-              text="No added components match your search"
-              class="p-sm"
-            />
-            <ComponentListItem
-              v-for="component in addedComponentList"
-              :key="component.id"
-              :component="component"
-              :selected="component.id === selectedComponentId"
-              @click="selectComponent(component.id)"
-            />
-          </div>
-        </CollapsingFlexItem>
-        <CollapsingFlexItem headerTextSize="sm" open>
-          <template #header>Changed</template>
-          <template #headerIcons>
-            <PillCounter :count="modifiedComponentList.length" size="sm" />
-          </template>
-          <div class="flex flex-col gap-xs p-xs w-full h-full">
-            <EmptyState
-              v-if="componentCounts.Modified === 0"
-              icon="diff"
-              text="No components changed"
-              class="p-sm"
-            />
-            <EmptyState
-              v-else-if="modifiedComponentList.length === 0"
-              icon="diff"
-              text="No changed components match your search"
-              class="p-sm"
-            />
-            <ComponentListItem
-              v-for="component in modifiedComponentList"
-              :key="component.id"
-              :component="component"
-              :selected="component.id === selectedComponentId"
-              @click="selectComponent(component.id)"
-            />
-          </div>
-        </CollapsingFlexItem>
-        <CollapsingFlexItem headerTextSize="sm" open>
-          <template #header>Removed</template>
-          <template #headerIcons>
-            <PillCounter :count="removedComponentList.length" size="sm" />
-          </template>
-          <div class="flex flex-col gap-xs p-xs w-full h-full">
-            <EmptyState
-              v-if="componentCounts.Removed === 0"
-              icon="trash"
-              text="No components deleted"
-              class="p-sm"
-            />
-            <EmptyState
-              v-else-if="removedComponentList.length === 0"
-              icon="trash"
-              text="No deleted components match your search"
-              class="p-sm"
-            />
-            <ComponentListItem
-              v-for="component in removedComponentList"
-              :key="component.id"
-              :component="component"
-              :selected="component.id === selectedComponentId"
-              @click="selectComponent(component.id)"
-            />
-          </div>
-        </CollapsingFlexItem>
+      <div class="flex flex-col gap-xs flex-grow scrollable">
+        <EmptyState
+          v-if="componentList.length === 0"
+          icon="diff"
+          text="No components changed"
+          class="p-sm"
+        />
+        <EmptyState
+          v-else-if="filteredComponentList.length === 0"
+          icon="diff"
+          text="No changed components match your search"
+          class="p-sm"
+        />
+        <ComponentListItem
+          v-for="component in addedComponentList"
+          :key="component.id"
+          :component="component"
+          status="Added"
+          :selected="component.id === selectedComponentId"
+          @click="selectComponent(component.id)"
+        />
+        <ComponentListItem
+          v-for="component in modifiedComponentList"
+          :key="component.id"
+          :component="component"
+          status="Modified"
+          :selected="component.id === selectedComponentId"
+          @click="selectComponent(component.id)"
+        />
+        <ComponentListItem
+          v-for="component in removedComponentList"
+          :key="component.id"
+          :component="component"
+          status="Removed"
+          :selected="component.id === selectedComponentId"
+          @click="selectComponent(component.id)"
+        />
       </div>
     </div>
     <div class="main flex flex-col gap-xs m-xs">
@@ -261,12 +216,7 @@
 import { useQueries, useQuery, useQueryClient } from "@tanstack/vue-query";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import clsx from "clsx";
-import {
-  PillCounter,
-  SiSearch,
-  themeClasses,
-  VButton,
-} from "@si/vue-lib/design-system";
+import { SiSearch, themeClasses, VButton } from "@si/vue-lib/design-system";
 import { useRouter } from "vue-router";
 import * as _ from "lodash-es";
 import {
@@ -534,18 +484,18 @@ function fixAttributeSourceAndValue(sourceAndValue?: AttributeSourceAndValue) {
 }
 
 /** Overall (non-filtered) component counts for each diff status */
-const componentCounts = computed(() => {
-  const result = {
-    Added: 0,
-    Modified: 0,
-    None: 0,
-    Removed: 0,
-  };
-  for (const component of componentList.value) {
-    result[component.diffStatus] += 1;
-  }
-  return result;
-});
+// const componentCounts = computed(() => {
+//   const result = {
+//     Added: 0,
+//     Modified: 0,
+//     None: 0,
+//     Removed: 0,
+//   };
+//   for (const component of componentList.value) {
+//     result[component.diffStatus] += 1;
+//   }
+//   return result;
+// });
 
 /** The currently-selected component data, including diffs */
 const selectedComponent = computed(() =>


### PR DESCRIPTION
Changes the review screen to have one unified component list instead of three separate ones.

<img width="480" height="315" alt="Screenshot 2025-08-24 at 6 37 02 PM" src="https://github.com/user-attachments/assets/ab1f48b5-8d4b-44d6-a120-9596edc29042" />
