### PR TITLE
fix: show revert button on review screen only when it will work

### DIFF
--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -446,28 +446,8 @@ function shouldIncludeDiff(diff: AttributeDiff) {
 function fixAttributeSourceAndValue(sourceAndValue?: AttributeSourceAndValue) {
   if (!sourceAndValue) return undefined;
   const { $source } = sourceAndValue;
-  if ("prototype" in $source && $source.prototype !== undefined) {
-    // subscription to /domain/region on Region changed (01K2N2CFSAE0PPHNJ31SKP97HH)
-    const { prototype, ...otherFields } = $source;
-    const match = prototype.match(/^subscription to (\/.+) on .+ \((\w+)\)/);
-    if (match) {
-      const [, path, component] = match;
-      if (path && component) {
-        const componentName = rawComponentList.value.find(
-          (c) => c.id === component,
-        )?.name;
-        return {
-          ...sourceAndValue,
-          $source: {
-            component,
-            componentName,
-            path,
-            ...otherFields,
-          },
-        } as AttributeSourceAndValue;
-      }
-    }
-  } else if ("component" in $source) {
+  // Add componentName to $source
+  if ("component" in $source) {
     const component = $source.component;
     const componentName = rawComponentList.value.find(
       (c) => c.id === component,

--- a/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
+++ b/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
@@ -41,9 +41,10 @@
             <!-- TODO(Wendy) - Ideally we would put the secret's name here -->
             secret
           </template>
-          <template v-else>
+          <template v-if="rawValue !== undefined">
             {{ rawValue }}
           </template>
+          <template v-else> &lt;{{ rawSource.path }}&gt; </template>
         </TruncateWithTooltip>
       </div>
     </AttributeValueBox>
@@ -59,30 +60,15 @@
         {{ rawValue }}
       </template>
     </TruncateWithTooltip>
-
-    <IconButton
-      v-if="revertible"
-      class="flex-none ml-auto"
-      icon="undo"
-      iconTone="shade"
-      iconIdleTone="shade"
-      tooltip="Revert to old value"
-      @click="emit('revert')"
-    />
   </div>
 </template>
 
 <script setup lang="ts">
-import {
-  IconButton,
-  themeClasses,
-  TruncateWithTooltip,
-} from "@si/vue-lib/design-system";
+import { themeClasses, TruncateWithTooltip } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed } from "vue";
 import { AttributeSourceAndValue } from "@/workers/types/entity_kind_types";
 import AttributeValueBox from "./layout_components/AttributeValueBox.vue";
-import { sourceAndValueDisplayKind } from "./ReviewAttributeItem.vue";
 
 type DisplayKind = "hidden" | "value" | "subscription" | "secret" | "complex";
 
@@ -90,19 +76,17 @@ const props = defineProps<{
   sourceAndValue: AttributeSourceAndValue;
   old?: boolean;
   secret?: boolean;
-  revertible?: boolean;
 }>();
 
 const rawValue = computed(() => props.sourceAndValue.$value);
 const rawSource = computed(() => props.sourceAndValue.$source);
 
 const displayKind = computed<DisplayKind>(() => {
-  const kind = sourceAndValueDisplayKind(rawSource.value, props.secret);
-
-  if (props.secret && props.old && !rawValue.value) {
-    return "hidden";
-  }
-  return kind;
+  if ("component" in rawSource.value) return "subscription";
+  if (props.secret) return "secret";
+  if ("value" in rawSource.value) return "value";
+  // TODO(Wendy) - complex AV diffs?
+  return "hidden";
 });
 
 const emit = defineEmits<{

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -396,8 +396,24 @@ export type AttributeDiff =
  *       }
  */
 export interface AttributeSourceAndValue {
+  /**
+   * Where the value comes from (the function, subscription, value, whether it comes from the
+   * schema, etc.).
+   */
   $source: AttributeSourceLocation & SimplifiedAttributeSource;
+
+  /**
+   * The current value.
+   *
+   * If it's a subscription or dynamic function, this will change when the value changes, even
+   * though the source does not.
+   */
   $value?: unknown;
+
+  /**
+   * If the source is pointed at a secret, this has name and other information about it.
+   */
+  $secret?: Secret;
 }
 
 /** The place in the tree this came from */
@@ -413,14 +429,12 @@ export type SimplifiedAttributeSource =
       component: ComponentId;
       componentName: ComponentName;
       path: AttributePath;
-      secret?: Secret;
 
       prototype?: undefined;
       value?: undefined;
     }
   | {
       value: unknown;
-      secret?: Secret;
 
       component?: undefined;
       componentName?: undefined;
@@ -433,7 +447,6 @@ export type SimplifiedAttributeSource =
       component?: undefined;
       componentName?: undefined;
       path?: undefined;
-      secret?: undefined;
       value?: undefined;
     };
 


### PR DESCRIPTION
Right now we show the revert button on attributes whether it works or not. We also don't handle the "reset" case correctly in all cases--you want to send `{ $source: null }` if the old value is not set.

<img width="1028" height="651" alt="image" src="https://github.com/user-attachments/assets/26579333-63b5-480b-b82f-f55e5022d27c" />

## How does this PR change the system?

* Does not show the revert button if:
  - source is unchanged (i.e. subscription or dynamic thing whose value has changed)
  - source is a parent subscription or dynamic value
  - has children and does not want to show a diff (i.e. "extra" when extra/Region has changed)
* Reverts unset values using `{ $source: null }`
* Uses a "Revert" button on the title itself
* MV change: moves `secret` out of `$source` in the MV and into `$secret` at the top level, so that you can diff two `$source`s reliably and know whether the source has changed.
* MV change: fixes a bug where subscriptions didn't get generated correctly as MVs

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: revert button shows for subscription and value changes
- [X] Manual test: revert button does not show when value changes but subscription does not
- [X] Manual test: attributes do not show revert buttons for new or old components