### PR TITLE
fix: Show secret names, and don't show defaults for added items

### DIFF
--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -534,6 +534,7 @@ function toAttributeDiffTree(componentDiff?: ComponentDiff): AttributeDiffTree {
     }
     child.diff = diff;
   }
+
   // Set the top level path correctly to / (kind of a special case)
   tree.path = "/";
   return tree;
@@ -541,20 +542,14 @@ function toAttributeDiffTree(componentDiff?: ComponentDiff): AttributeDiffTree {
 
 function shouldIncludeDiff(diff: AttributeDiff) {
   // If the values and sources are equal (which could happen in some cases on component
-  // upgrade), don't add this to the tree
+  // upgrade), don't show this diff.
   if (_.isEqual(diff.new, diff.old)) return false;
 
-  // If this is an empty default (schema unset/empty container) on an added/removed thing, don't
-  // include it in the diff
-  if (!diff.new || !diff.old) {
-    const singleDiff = diff.new ?? diff.old;
-    if (singleDiff.$value === undefined && singleDiff.$source.fromSchema)
-      return false;
-    if (singleDiff.$source.fromSchema) {
-      if (singleDiff.$value === undefined) return false;
-      if (Array.isArray(singleDiff.$value) && singleDiff.$value.length === 0)
-        return false;
-      // TODO empty object
+  if (!diff.old || !diff.new) {
+    const { $source, $value } = diff.old ?? diff.new;
+    // Don't show "uninteresting" (empty) default values.
+    if ($source.fromSchema) {
+      if (!$value || _.isEmpty($value)) return false;
     }
   }
 

--- a/app/web/src/newhotness/ReviewAttributeItem.vue
+++ b/app/web/src/newhotness/ReviewAttributeItem.vue
@@ -38,14 +38,12 @@
       <ReviewAttributeItemSourceAndValue
         v-if="diff?.new"
         :sourceAndValue="diff.new"
-        :secret="secret"
       />
       <!-- TODO use revertibleSource to determine revertibility (but right now revertibleSource seems not right!) -->
       <ReviewAttributeItemSourceAndValue
         v-if="diff?.old"
         :sourceAndValue="diff.old"
         old
-        :secret="secret"
       />
     </template>
 

--- a/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
+++ b/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-if="displayKind !== 'hidden'"
     :class="
       clsx(
         'flex flex-row items-center gap-xs font-mono h-10 p-xs rounded-sm',
@@ -21,7 +20,7 @@
       {{ old ? "-" : "+" }}
     </div>
 
-    <AttributeValueBox v-if="displayKind === 'subscription'" class="min-w-0">
+    <AttributeValueBox v-if="$source.component" class="min-w-0">
       <div
         :class="
           clsx(
@@ -31,20 +30,19 @@
         "
       >
         <TruncateWithTooltip :class="clsx(!old && 'text-purple')">
-          {{ rawSource.componentName }}
+          {{ $source.componentName }}
         </TruncateWithTooltip>
         <div class="flex-none">/</div>
         <TruncateWithTooltip
           :class="themeClasses('text-neutral-600', 'text-neutral-400')"
         >
-          <template v-if="secret">
-            <!-- TODO(Wendy) - Ideally we would put the secret's name here -->
-            secret
+          <template v-if="$secret">
+            {{ $secret.name }}
           </template>
-          <template v-if="rawValue !== undefined">
-            {{ rawValue }}
+          <template v-else-if="$value !== undefined">
+            {{ $value }}
           </template>
-          <template v-else> &lt;{{ rawSource.path }}&gt; </template>
+          <template v-else> &lt;{{ $source.path }}&gt; </template>
         </TruncateWithTooltip>
       </div>
     </AttributeValueBox>
@@ -52,12 +50,12 @@
       v-else
       :class="clsx('py-2xs min-w-0', old && 'line-through')"
     >
-      <template v-if="displayKind === 'secret'">
+      <template v-if="$secret">
         <!-- TODO(Wendy) - Ideally we would put the secret's name here -->
         Secret {{ old ? "Removed" : "Added" }}
       </template>
       <template v-else>
-        {{ rawValue }}
+        {{ $value }}
       </template>
     </TruncateWithTooltip>
   </div>
@@ -70,24 +68,15 @@ import { computed } from "vue";
 import { AttributeSourceAndValue } from "@/workers/types/entity_kind_types";
 import AttributeValueBox from "./layout_components/AttributeValueBox.vue";
 
-type DisplayKind = "hidden" | "value" | "subscription" | "secret" | "complex";
-
 const props = defineProps<{
   sourceAndValue: AttributeSourceAndValue;
   old?: boolean;
   secret?: boolean;
 }>();
 
-const rawValue = computed(() => props.sourceAndValue.$value);
-const rawSource = computed(() => props.sourceAndValue.$source);
-
-const displayKind = computed<DisplayKind>(() => {
-  if ("component" in rawSource.value) return "subscription";
-  if (props.secret) return "secret";
-  if ("value" in rawSource.value) return "value";
-  // TODO(Wendy) - complex AV diffs?
-  return "hidden";
-});
+const $source = computed(() => props.sourceAndValue.$source);
+const $value = computed(() => props.sourceAndValue.$value);
+const $secret = computed(() => props.sourceAndValue.$secret);
 
 const emit = defineEmits<{
   (e: "revert"): void;


### PR DESCRIPTION
Shows secret names when you subscribe, and shows fewer defaults for added items

<img width="1028" height="651" alt="image" src="https://github.com/user-attachments/assets/3cbdf14a-c35a-4276-85ab-5d1ecbff9373" />

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: review screen looketh right