### PR TITLE
fix(web): Show the user that no value exists on HEAD

### DIFF
--- a/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
+++ b/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
@@ -48,14 +48,19 @@
     </AttributeValueBox>
     <TruncateWithTooltip
       v-else
-      :class="clsx('py-2xs min-w-0', old && 'line-through')"
+      :class="
+        clsx('py-2xs min-w-0', {
+          'line-through': !!($secret || $value),
+          italic: !($secret || $value),
+        })
+      "
     >
       <template v-if="$secret">
         <!-- TODO(Wendy) - Ideally we would put the secret's name here -->
         Secret {{ old ? "Removed" : "Added" }}
       </template>
       <template v-else>
-        {{ $value }}
+        {{ $value ?? "No value on HEAD" }}
       </template>
     </TruncateWithTooltip>
   </div>


### PR DESCRIPTION
We currently just show a `-` with no value


<img width="292" height="692" alt="Screenshot 2025-08-25 at 17 08 27" src="https://github.com/user-attachments/assets/b239095e-2ee6-4b4f-81cb-21641bc073a5" />
