### PR TITLE
BUG-959: optimistically update HEAD with actions list from the apply endpoint

### DIFF
--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -97,6 +97,8 @@ pub enum Error {
     ItemWithChecksumNotFound(WorkspacePk, ChangeSetId, String),
     #[error("latest item not found; workspace_pk={0}, change_set_id={1}, kind={2}")]
     LatestItemNotFound(WorkspacePk, ChangeSetId, String),
+    #[error("materialized view error: {0}")]
+    MaterializedView(#[from] Box<dal_materialized_views::Error>),
     #[error("prop error: {0}")]
     Prop(#[from] PropError),
     #[error("property editor error: {0}")]
@@ -133,6 +135,12 @@ pub enum Error {
     WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),
     #[error("ws event error: {0}")]
     WsEvent(#[from] WsEventError),
+}
+
+impl From<dal_materialized_views::Error> for Error {
+    fn from(error: dal_materialized_views::Error) -> Self {
+        Box::new(error).into()
+    }
 }
 
 impl IntoResponse for Error {


### PR DESCRIPTION
## How does this PR change the system?

Large amounts of actions that are compressed and batched in edda given the user the impression that their work has been lost. Until the actions pop up, potentially halfway completed.

**NOTE:** in the case where the edda patch _is really fast_ this will actually result in "going backward".
1. HTTP POST to apply
2. Rebaser runs
3. Hands to Edda
4. Returns to SDF
5. Race begins
6. Edda builds MV, and fires the patches
7. SDF builds MV, and responds to the HTTP call

## How was it tested?

1. Create a new component
8. Apply to HEAD
9. See data returned from endpoint
10. See actions list populated immediately before any patches

Here is what I saw:
- new action showed up spinning (edda patch)
- stopped spinning (http response)
- started spinning again (next edda patch)