### PR TITLE
review screen polish items pt 1

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -131,8 +131,11 @@
         data-testid="component-name-section"
         :class="
           clsx(
-            'name flex flex-row items-center gap-xs',
-            themeClasses('bg-white', 'bg-neutral-800'),
+            'name flex flex-row items-center gap-xs border-b',
+            themeClasses(
+              'bg-white border-neutral-300',
+              'bg-neutral-800 border-neutral-600',
+            ),
           )
         "
       >
@@ -1042,14 +1045,6 @@ section.grid.no-component {
   margin-top: -1em;
   padding: 0 0.5rem 0 0.5rem;
   height: 2.75rem;
-}
-.name {
-  border-top: 1px solid #d4d4d8; /* neutral-300 */
-  border-bottom: 1px solid #d4d4d8; /* neutral-300 */
-}
-:global(.dark) .name {
-  border-top: 1px solid #525252; /* neutral-600 */
-  border-bottom: 1px solid #525252; /* neutral-600 */
 }
 .attrs {
   grid-area: attrs;

--- a/app/web/src/newhotness/ComponentHistory.vue
+++ b/app/web/src/newhotness/ComponentHistory.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="auditLogs.length > 0"
+    v-if="auditLogs && auditLogs.length > 0"
     ref="scrollContainerRef"
     class="px-xs py-sm overflow-x-hidden max-h-full"
     @scrollend="handleScrollEnd"
@@ -164,12 +164,13 @@
       <span v-else-if="!hasNextPage"> All Entries Loaded </span>
     </div>
   </div>
+  <LoadingMessage v-else-if="!auditLogs" message="Loading History" />
   <EmptyState
     v-else
     class="p-lg"
     icon="component"
-    text="No Direct Changes"
-    secondaryText="There were no direct changes made to the component."
+    text="No History Found"
+    secondaryText="No history found for this component in this change set"
   />
 </template>
 
@@ -181,6 +182,7 @@ import {
   Timestamp,
   Icon,
   themeClasses,
+  LoadingMessage,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { ComponentId } from "@/api/sdf/dal/component";
@@ -275,8 +277,8 @@ const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
   });
 
 // Flatten all pages and filter out socket-related audit logs
-const auditLogs = computed((): ProcessedAuditLog[] => {
-  if (!data.value) return [];
+const auditLogs = computed((): ProcessedAuditLog[] | undefined => {
+  if (!data.value) return undefined;
 
   // There should only be one page!
   const allLogs = data.value.pages.flatMap(

--- a/app/web/src/newhotness/ComponentListItem.vue
+++ b/app/web/src/newhotness/ComponentListItem.vue
@@ -16,11 +16,20 @@
     <TextPill
       tighter
       variant="component"
-      :class="themeClasses('text-green-light-mode', 'text-green-dark-mode')"
+      :class="
+        clsx(
+          themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+          'max-w-fit flex-1',
+        )
+      "
     >
       <TruncateWithTooltip>{{ component.schemaName }}</TruncateWithTooltip>
     </TextPill>
-    <TextPill tighter variant="component" class="text-purple">
+    <TextPill
+      tighter
+      variant="component"
+      :class="clsx('text-purple max-w-fit flex-1')"
+    >
       <TruncateWithTooltip>{{ component.name }}</TruncateWithTooltip>
     </TextPill>
     <StatusIndicatorIcon

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -3,8 +3,11 @@
     <div
       :class="
         clsx(
-          'header flex-none flex flex-row items-center gap-xs px-sm py-xs',
-          themeClasses('bg-white', 'bg-neutral-800'),
+          'header flex-none flex flex-row items-center gap-xs px-sm py-xs border-b',
+          themeClasses(
+            'bg-white border-neutral-300',
+            'bg-neutral-800 border-neutral-600',
+          ),
         )
       "
     >
@@ -168,20 +171,26 @@
           headerTextSize="sm"
         >
           <template #header>
-            <div
+            <TruncateWithTooltip
               :class="
-                clsx(themeClasses('text-neutral-800', 'text-neutral-100'))
+                clsx(
+                  'py-2xs max-w-fit flex-1',
+                  themeClasses('text-neutral-800', 'text-neutral-100'),
+                )
               "
             >
               {{ selectedComponent.schemaName }}
-            </div>
-            <div
+            </TruncateWithTooltip>
+            <TruncateWithTooltip
               :class="
-                clsx(themeClasses('text-neutral-600', 'text-neutral-400'))
+                clsx(
+                  'py-2xs max-w-fit flex-1',
+                  themeClasses('text-neutral-600', 'text-neutral-400'),
+                )
               "
             >
               ({{ selectedComponent.name }})
-            </div>
+            </TruncateWithTooltip>
           </template>
 
           <div class="flex flex-col gap-sm px-sm py-sm">
@@ -349,6 +358,7 @@ import {
   themeClasses,
   VButton,
   IconButton,
+  TruncateWithTooltip,
 } from "@si/vue-lib/design-system";
 import { useRouter, useRoute } from "vue-router";
 import * as _ from "lodash-es";

--- a/app/web/src/newhotness/ReviewAttributeItem.vue
+++ b/app/web/src/newhotness/ReviewAttributeItem.vue
@@ -16,7 +16,9 @@
   >
     <!-- Title and revert button-->
     <div class="flex flex-row items-center">
-      <h1 class="h-10 py-xs mr-auto text-sm">{{ name }}</h1>
+      <h1 class="h-10 py-xs mr-auto text-sm">
+        {{ name }}
+      </h1>
       <VButton
         v-if="!!revertToSource"
         size="xs"

--- a/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
+++ b/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
@@ -2,7 +2,7 @@
   <div
     :class="
       clsx(
-        'flex flex-row items-center gap-xs font-mono h-10 p-xs rounded-sm text-xs',
+        'flex flex-row items-center gap-xs font-mono min-h-10 p-xs rounded-sm text-xs',
         old
           ? themeClasses('text-neutral-600', 'text-neutral-400')
           : themeClasses('bg-success-200', 'bg-newhotness-success'),
@@ -29,13 +29,11 @@
           )
         "
       >
-        <TruncateWithTooltip :class="clsx(!old && 'text-purple')">
+        <div :class="clsx(!old && 'text-purple')">
           {{ $source.componentName }}
-        </TruncateWithTooltip>
+        </div>
         <div class="flex-none">/</div>
-        <TruncateWithTooltip
-          :class="themeClasses('text-neutral-600', 'text-neutral-400')"
-        >
+        <div :class="themeClasses('text-neutral-600', 'text-neutral-400')">
           <template v-if="$secret">
             {{ $secret.name }}
           </template>
@@ -43,13 +41,13 @@
             {{ $value }}
           </template>
           <template v-else> &lt;{{ $source.path }}&gt; </template>
-        </TruncateWithTooltip>
+        </div>
       </div>
     </AttributeValueBox>
-    <TruncateWithTooltip
+    <div
       v-else
       :class="
-        clsx('py-2xs min-w-0', {
+        clsx('py-2xs min-w-0 break-words', {
           'line-through': !!old && !!($secret || $value),
           italic: !($secret || $value),
         })
@@ -62,12 +60,12 @@
       <template v-else>
         {{ $value ?? "No value on HEAD" }}
       </template>
-    </TruncateWithTooltip>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { themeClasses, TruncateWithTooltip } from "@si/vue-lib/design-system";
+import { themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed } from "vue";
 import { AttributeSourceAndValue } from "@/workers/types/entity_kind_types";
@@ -82,8 +80,4 @@ const props = defineProps<{
 const $source = computed(() => props.sourceAndValue.$source);
 const $value = computed(() => props.sourceAndValue.$value);
 const $secret = computed(() => props.sourceAndValue.$secret);
-
-const emit = defineEmits<{
-  (e: "revert"): void;
-}>();
 </script>


### PR DESCRIPTION
- Values inside of each AV diff can now display on multiple lines instead of truncating
- ComponentHistory now has a loader and a better empty state
- Fixed consistency of headers across `Review` and `ComponentDetails`
- Added truncation to the header of the middle section of `Review`
- Fixed truncation balance in a few places