### PR TITLE
fix: Restore button for ghosted components in review

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -153,26 +153,26 @@
           >{{ component.name }}</TruncateWithTooltip
         >
         <div class="ml-auto flex gap-xs">
-          <template v-if="component.toDelete">
-            <VButton
-              v-tooltip="'Restore (R)'"
-              size="sm"
-              :label="restoreLoading ? 'Restoring...' : 'Restore'"
-              :loading="restoreLoading"
-              :disabled="restoreLoading"
-              loadingIcon="loader"
-              :class="
-                clsx(
-                  '!text-sm !border !cursor-pointer !px-xs',
-                  themeClasses(
-                    '!text-neutral-100 !bg-[#1264BF] !border-[#318AED] hover:!bg-[#2583EC]',
-                    '!text-neutral-100 !bg-[#1264BF] !border-[#318AED] hover:!bg-[#2583EC]',
-                  ),
-                )
-              "
-              @click="restoreComponent"
-            />
-          </template>
+          <VButton
+            v-if="component.toDelete"
+            v-tooltip="'Restore (R)'"
+            size="sm"
+            label="Restore"
+            :loading="restoreLoading"
+            loadingText="Restoring..."
+            loadingIcon="loader"
+            :disabled="restoreLoading"
+            :class="
+              clsx(
+                '!text-sm !border !cursor-pointer !px-xs',
+                themeClasses(
+                  '!text-neutral-100 !bg-[#1264BF] !border-[#318AED] hover:!bg-[#2583EC]',
+                  '!text-neutral-100 !bg-[#1264BF] !border-[#318AED] hover:!bg-[#2583EC]',
+                ),
+              )
+            "
+            @click="restoreComponent"
+          />
           <template v-else>
             <VButton
               v-tooltip="'Erase (E)'"


### PR DESCRIPTION
This shows a Restore button for ghosted components in the review screen.

<img width="1242" height="151" alt="image" src="https://github.com/user-attachments/assets/374b4094-e0ce-43d5-bd7c-f36338510e7a" />

This PR also changes our main component filter so that we don't show components if we ignored all the diffs (i.e. don't plan to show them or allow reverts).

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: button click shows loading state, disappears when successful