### PR TITLE
unified collapsing styles, select first component on Review

### DIFF
--- a/app/web/src/newhotness/ComponentHistory.vue
+++ b/app/web/src/newhotness/ComponentHistory.vue
@@ -45,12 +45,7 @@
         v-for="auditLog in auditLogs"
         ref="logRefs"
         :key="identifier(auditLog)"
-        v-tooltip="
-          shouldExpand(auditLog)
-            ? 'Click to hide full audit log'
-            : 'Click to see full audit log'
-        "
-        class="grid grid-cols-[10px_1fr] gap-2xs items-stretch cursor-pointer"
+        class="grid grid-cols-[10px_1fr] gap-2xs items-stretch"
       >
         <div
           class="relative flex flex-row justify-center items-start h-full pt-sm self-stretch"
@@ -60,7 +55,8 @@
         <div
           :class="
             clsx(
-              'p-xs border rounded-sm min-h-[2.5rem] min-w-0 break-words',
+              'group/historylog',
+              'p-xs border rounded-sm min-h-[2.5rem] min-w-0 break-words cursor-pointer',
               themeClasses('border-neutral-400', 'border-neutral-600'),
             )
           "
@@ -92,7 +88,13 @@
                   refresh
                 />
                 <Icon
-                  class="text-neutral-400"
+                  v-tooltip="{
+                    content: shouldExpand(auditLog)
+                      ? 'Click to hide full audit log'
+                      : 'Click to see full audit log',
+                    placement: 'left',
+                  }"
+                  :class="clsx('group-hover/historylog:scale-125')"
                   :name="
                     shouldExpand(auditLog) ? 'chevron--down' : 'chevron--left'
                   "

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -405,6 +405,13 @@ const initializeFromUrl = () => {
   const componentIdFromUrl = route.query.component as ComponentId;
   if (componentIdFromUrl) {
     selectedComponentId.value = componentIdFromUrl;
+  } else {
+    // TODO(Wendy) - remove this part to not have the first component selected by default
+    nextTick(() => {
+      if (componentList.value[0]?.id) {
+        selectedComponentId.value = componentList.value[0].id;
+      }
+    });
   }
 };
 

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -39,6 +39,7 @@
     >
       <Icon
         v-if="!disableCollapse"
+        class="group-hover/header:scale-125"
         :name="showOpen ? 'chevron-down' : 'chevron-right'"
         size="sm"
       />

--- a/app/web/src/newhotness/layout_components/CollapsingGridItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingGridItem.vue
@@ -16,7 +16,7 @@
       <Icon
         class="group-hover/header:scale-125 mr-xs"
         :name="openState.open.value ? 'chevron-down' : 'chevron-right'"
-        size="md"
+        size="sm"
       />
       <slot name="header" />
       <div class="ml-auto" />


### PR DESCRIPTION
- Less aggressive tooltips on the `ComponentHistory` items, more unified collapsing element styles
- First component on the `Review` screen is now selected by default (we can remove this later)