### PR TITLE
fix: amend cypress tests to inject domain to restore cypress 13 behav…

### DIFF
--- a/app/web/cypress.config.ts
+++ b/app/web/cypress.config.ts
@@ -4,6 +4,7 @@ import vitePreprocessor from 'cypress-vite'
 
 export default defineConfig({
   e2e: {
+    injectDocumentDomain: true,
     specPattern: "cypress/**/*.cy.{js,jsx,ts,tsx}",
     setupNodeEvents(on, config) {
       on('file:preprocessor',


### PR DESCRIPTION
This restores Cypress 13's behaviour in the cypress tests to de-flake them hopefully.

**Test Runs:**
E2E on EC2-Node - https://github.com/systeminit/si/actions/runs/17219742113 (failed due to pop-up of firstTimeModal)
E2E on Tools - https://github.com/systeminit/si/actions/runs/17219799508

Fixed up firstTimeModal 
E2E on EC2-Node - https://github.com/systeminit/si/actions/runs/17219742113
