### PR TITLE
empty state for middle section of Review screen

### DIFF
--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -193,7 +193,7 @@
             </TruncateWithTooltip>
           </template>
 
-          <div class="flex flex-col gap-sm px-sm py-sm">
+          <div class="flex flex-col gap-sm px-sm py-sm min-h-full">
             <div
               v-if="selectedComponent.toDelete"
               :class="
@@ -253,6 +253,22 @@
                 secret
               />
             </template>
+
+            <div
+              v-if="noAVDiffs"
+              :class="
+                clsx(
+                  'w-full grow flex flex-row items-center justify-center border',
+                  themeClasses('border-neutral-400', 'border-neutral-600'),
+                )
+              "
+            >
+              <EmptyState
+                icon="diff"
+                text="No Attribute Values changed"
+                secondaryText="There are no attribute value changes to display for this component"
+              />
+            </div>
           </div>
         </CollapsingFlexItem>
         <div
@@ -996,6 +1012,13 @@ onBeforeUnmount(() => {
   keyEmitter.off("ArrowLeft", onArrowLeft);
   keyEmitter.off("ArrowRight", onArrowRight);
 });
+
+const noAVDiffs = computed(
+  () =>
+    !selectedComponent.value?.attributeDiffTree?.children?.si?.children?.name &&
+    !selectedComponent.value?.attributeDiffTree?.children?.domain?.children &&
+    !selectedComponent.value?.attributeDiffTree?.children?.secrets?.children,
+);
 </script>
 
 <style lang="css" scoped>


### PR DESCRIPTION
<img width="1431" height="759" alt="Screenshot 2025-08-25 at 4 49 16 PM" src="https://github.com/user-attachments/assets/c13014d0-8efa-4dc0-9f5b-fde703d00236" />

This PR only adds the UI, the actual ability for components without AV diffs but with queued actions to appear on the Review screen is still in progress but will land soon.