### PR TITLE
fix(web): terminate webworker if app is out of date

### DIFF
--- a/app/web/src/components/CachedAppNotification.vue
+++ b/app/web/src/components/CachedAppNotification.vue
@@ -1,10 +1,10 @@
 <template>
-  <Modal ref="modalRef" title="Please refresh your browser">
+  <Modal ref="modalRef" title="Please refresh your browser" noExit>
     <Stack>
       <RichText>
         <p>
-          Looks like you might be running a cached version of this web app. For
-          new features and to ensure compatibility, please refresh your browser.
+          Looks like you are running an out of date version of this web app. To
+          continue working, please refresh your browser.
         </p>
       </RichText>
       <VButton icon="refresh" @click="reloadBrowser">Refresh</VButton>
@@ -19,6 +19,7 @@ import { Modal, RichText, Stack, VButton } from "@si/vue-lib/design-system";
 import {
   cachedAppEmitter,
   SHOW_CACHED_APP_NOTIFICATION_EVENT,
+  cachedAppNotificationIsOpen,
 } from "@/store/realtime/cached_app_emitter";
 
 // const APP_FILENAME_REGEX = /\/?assets\/index-([0-9a-z]+).js/;
@@ -26,10 +27,17 @@ const getFilenameFromPath = (path: string) => path.split("/").pop();
 
 const runningHash = getRunningHash();
 
-const modalRef = ref();
+const modalRef = ref<InstanceType<typeof Modal>>();
+
+const openModal = () => {
+  if (modalRef.value) {
+    cachedAppNotificationIsOpen.value = true;
+    modalRef.value.open();
+  }
+};
 
 cachedAppEmitter.on(SHOW_CACHED_APP_NOTIFICATION_EVENT, () => {
-  modalRef.value?.open();
+  openModal();
 });
 
 async function check() {
@@ -46,7 +54,7 @@ async function check() {
 
     const latestHash = getFilenameFromPath(latestAppFileWithHash);
     if (runningHash && latestHash !== runningHash) {
-      modalRef.value?.open();
+      openModal();
     }
   } catch (err) {
     // local dev errors here because the manifest file doesn't exist

--- a/app/web/src/store/realtime/cached_app_emitter.ts
+++ b/app/web/src/store/realtime/cached_app_emitter.ts
@@ -1,5 +1,8 @@
 import mitt from "mitt";
+import { ref } from "vue";
 
 export const SHOW_CACHED_APP_NOTIFICATION_EVENT = "showCachedAppNotification";
 
 export const cachedAppEmitter = mitt();
+
+export const cachedAppNotificationIsOpen = ref(false);

--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -43,6 +43,7 @@ import { WorkspaceMetadata, WorkspacePk } from "@/api/sdf/dal/workspace";
 import {
   cachedAppEmitter,
   SHOW_CACHED_APP_NOTIFICATION_EVENT,
+  cachedAppNotificationIsOpen,
 } from "./cached_app_emitter";
 
 // We want an id right away, not later. But ulid fails if run in this context
@@ -91,6 +92,14 @@ const tabWorker = new Worker(new URL(WORKER_URL, import.meta.url), {
   name: `si-db-${__WEBWORKER_HASH__}`,
 });
 const tabDb: Comlink.Remote<TabDBInterface> = Comlink.wrap(tabWorker);
+
+watch(cachedAppNotificationIsOpen, (isOpen) => {
+  if (isOpen) {
+    // eslint-disable-next-line no-console
+    console.log("Shutting down tab webworker since user must refresh the page");
+    tabWorker.terminate();
+  }
+});
 
 const onSharedWorkerBootBroadcastChannel = new BroadcastChannel(
   SHARED_BROADCAST_CHANNEL_NAME,


### PR DESCRIPTION
If we are showing the CachedAppNotification, the user needs to refresh. This could mean that the webworker or shared worker is out of date. But the out of date webworker might be holding the lock! If it is, new windows that are not out of date are unlikely to work. So just terminate the webworker, which will release the lock and let a healthy tab pick it up.

To make this work, this also makes it impossible to dismiss the CachedAppNotification modal without refreshing the page.

I tested this by having two tabs open. In the tab with the lock, I forced CachedAppNotification to trigger (with code changes). The lock was released in the tab with the modal, and acquired by the other tab.