### PR TITLE
fix: Show components with enequeued actions in review

### DIFF
--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -1,7 +1,12 @@
 import { ActionProposedView } from "@/store/actions.store";
 import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 import { SchemaId, SchemaVariantId } from "@/api/sdf/dal/schema";
-import { ActionKind, ActionPrototypeId } from "@/api/sdf/dal/action";
+import {
+  ActionId,
+  ActionKind,
+  ActionPrototypeId,
+  ActionState,
+} from "@/api/sdf/dal/action";
 import { FuncId } from "@/api/sdf/dal/func";
 import { AttributeValueId } from "@/store/status.store";
 import { PropId, PropKind } from "@/api/sdf/dal/prop";
@@ -13,6 +18,7 @@ import { ViewId } from "@/api/sdf/dal/views";
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { DefaultMap } from "@/utils/defaultmap";
 import { ComponentName } from "@/store/components.store";
+import { WorkspacePk } from "@/newhotness/types";
 import { ComponentInfo } from "./dbinterface";
 
 export enum EntityKind {
@@ -152,6 +158,27 @@ export interface BifrostActionViewList {
   id: ChangeSetId;
   actions: ActionProposedView[];
 }
+
+export interface ActionDiffList {
+  id: WorkspacePk;
+  actionDiffs: Record<ActionId, ActionDiffView>;
+}
+
+export interface ActionDiffView {
+  id: ActionId;
+  componentId: ComponentId;
+  diffStatus: ActionDiffStatus;
+}
+
+export type ActionDiffStatus =
+  | {
+      Added: { new_state: ActionState };
+    }
+  | {
+      Modified: { old_state: ActionState; new_state: ActionState };
+    }
+  | "None"
+  | "Removed";
 
 export interface ComponentQualificationTotals {
   total: number;


### PR DESCRIPTION
If you enqueue an action for a component but *don't* make any other changes, it doesn't currently show up. This uses the ActionDiffList MV to determine which components have action changes.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: empty review screen shows no diffs, even with failed actions enqueue on HEAD
- [X] Manual test: adding or removing an action to an otherwise unedited component shows it in the review screen
- [X] Manual test: adding a component and enqueueing an action still shows it as "added"
- [X] Manual test: (regression check) non-action changes still show diffs for added, removed and modified components

## In short

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdla2hvNjNtczFtaG4xaWJ1MnVwbmJzZjZibXRpZm4yZWpqajZsdngxYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/TVXUrrdImTEd8nE21B/giphy.gif"/>