### PR TITLE
Disable the revert button on erased and ghosted components

### DIFF
--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -251,6 +251,7 @@
               :item="
                 selectedComponent.attributeDiffTree.children.si.children.name
               "
+              :disableRevert="disableRevert"
             />
             <!-- Show children of /si/domain -->
             <template
@@ -265,6 +266,7 @@
                 :selectedComponentId="selectedComponentId"
                 :name="name"
                 :item="item"
+                :disableRevert="disableRevert"
               />
             </template>
             <!-- Show children of /si/secrets -->
@@ -280,7 +282,7 @@
                 :selectedComponentId="selectedComponentId"
                 :name="name"
                 :item="item"
-                secret
+                :disableRevert="disableRevert"
               />
             </template>
 
@@ -692,6 +694,12 @@ function shouldIncludeDiff(diff: AttributeDiff) {
   return true;
 }
 
+/**
+ * Augment AttributeSourceAndValue with component name.
+ *
+ * This is where we put any fixups we need while working in the frontend; any changes here need
+ * to move to the backend MV.
+ */
 function fixAttributeSourceAndValue(sourceAndValue?: AttributeSourceAndValue) {
   if (!sourceAndValue) return undefined;
   const { $source } = sourceAndValue;
@@ -729,6 +737,10 @@ function fixAttributeSourceAndValue(sourceAndValue?: AttributeSourceAndValue) {
 /** The currently-selected component data, including diffs */
 const selectedComponent = computed(() =>
   componentList.value.find((c) => c.id === selectedComponentId.value),
+);
+
+const disableRevert = computed(
+  () => selectedComponent.value?.diffStatus === "Removed",
 );
 
 // When absolutely anything in the selected component changes, or the selection itself changes,

--- a/app/web/src/newhotness/ReviewAttributeItem.vue
+++ b/app/web/src/newhotness/ReviewAttributeItem.vue
@@ -20,7 +20,7 @@
         {{ name }}
       </h1>
       <VButton
-        v-if="!!revertToSource"
+        v-if="!disableRevert && !!revertToSource"
         size="xs"
         label="Revert"
         :class="
@@ -55,6 +55,7 @@
           :selectedComponentId="selectedComponentId"
           :name="childName"
           :item="childItem"
+          :disableRevert="disableRevert"
         />
       </template>
     </div>
@@ -80,7 +81,7 @@ const props = defineProps({
   },
   name: { type: String, required: true },
   item: { type: Object as PropType<AttributeDiffTree>, required: true },
-  secret: { type: Boolean },
+  disableRevert: { type: Boolean, required: true },
 });
 
 const path = computed(() => props.item.path);


### PR DESCRIPTION
You can't revert values on erased components, and it's sort of confusing if we let you revert values on ghosted components. This PR removes the Revert buttons from attributes on both types, while keeping them for added/modified components.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: revert buttons don't show on removed or ghosted components
- [X] Manual test: (regression check) revert buttons still show on added and modified components