### PR TITLE
fix(si-mcp-server): Make change set id optional to func run get

### DIFF
--- a/bin/si-mcp-server/src/tools/funcRunGet.ts
+++ b/bin/si-mcp-server/src/tools/funcRunGet.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { FuncsApi } from "@systeminit/api-client";
+import { ChangeSetsApi, FuncsApi } from "@systeminit/api-client";
 import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
 import {
   errorResponse,
@@ -9,90 +9,124 @@ import {
   successResponse,
   withAnalytics,
 } from "./commonBehavior.ts";
+import { ChangeSetItem } from "../data/changeSets.ts";
 import { decodeBase64 } from "@std/encoding/base64";
 
 const name = "func-run-get";
 const title = "Get a function run information";
-const description =
-  `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
+const description = `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
 
 const GetFuncRunInputSchemaRaw = {
-  changeSetId: z.string().describe(
-    "The change set to look up actions in",
-  ),
+  changeSetId: z
+    .string()
+    .optional()
+    .describe(
+      "The change set to look up the schema in; if not provided, HEAD will be used",
+    ),
   funcRunId: z.string().describe("the func run id to look up"),
-  logs: z.boolean().optional().describe(
-    "the logs for the function run; logs can be very long, and you should only request them when you are sure you need them for analysis.",
-  ),
-  code: z.boolean().optional().describe(
-    "the function body; this can be very long, and you should only request it if you need it for analysis.",
-  ),
-  args: z.boolean().optional().describe(
-    "the arguments to the function; these can be very long, and you should only request them if you need them for deep analysis.",
-  ),
-  result: z.boolean().optional().describe(
-    "the results of the function; this can be very long, and you should only request it if you need it for analysis.",
-  ),
+  logs: z
+    .boolean()
+    .optional()
+    .describe(
+      "the logs for the function run; logs can be very long, and you should only request them when you are sure you need them for analysis.",
+    ),
+  code: z
+    .boolean()
+    .optional()
+    .describe(
+      "the function body; this can be very long, and you should only request it if you need it for analysis.",
+    ),
+  args: z
+    .boolean()
+    .optional()
+    .describe(
+      "the arguments to the function; these can be very long, and you should only request them if you need them for deep analysis.",
+    ),
+  result: z
+    .boolean()
+    .optional()
+    .describe(
+      "the results of the function; this can be very long, and you should only request it if you need it for analysis.",
+    ),
 };
 
 const GetFuncRunOutputSchemaRaw = {
   status: z.enum(["success", "failure"]),
-  errorMessage: z.string().optional().describe(
-    "If the status is failure, the error message will contain information about what went wrong",
-  ),
-  data: z.object({
-    funcRunId: z.string().describe("the func run id"),
-    funcRunState: z.enum([
-      "Created",
-      "Dispatched",
-      "Killed",
-      "Running",
-      "PostProcessing",
-      "Failure",
-      "Success",
-    ]).describe(
-      "the state of this function execution run. 'Created' is the initial state, but not yet dispatched to the job system. 'Dispatched' means it is send to the job system. 'Killed' means it has been manually stopped during execution. 'Running' means it is currently executing. 'PostProcessing' means the system is taking the results of the function and appying them to System Initiative. 'Failure' means the function execution has failed. 'Success' means the function has run succesfully (but it does not neccessarily mean that it was successful from the user perspective; it only means the function executed without error.",
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "If the status is failure, the error message will contain information about what went wrong",
     ),
-    componentId: z.string().describe(
-      "the component id this function run was for",
-    ),
-    componentName: z.string().describe(
-      "the component name this function run was for",
-    ),
-    schemaName: z.string().describe(
-      "the schema name of the component this function was for",
-    ),
-    functionName: z.string().describe("the name of the function"),
-    functionKind: z.enum([
-      "Action",
-      "Attribute",
-      "Authentication",
-      "CodeGeneration",
-      "Intrinsic",
-      "Qualification",
-      "SchemaVariantDefinition",
-      "Unknown",
-      "Management",
-    ]).describe(
-      "'Action' means an action function on a component; 'Attribute' means an attribute function on a components attribute; 'CodeGeneration' means a code generation function on a component; 'Intrinsic' means it is not a javascript function, but instead implemented directly by SI; 'Qualification' means a qualification that a component is valid; 'SchemaVariantDefinition' means the typescript that defines the schema for a component; 'Unknown' means a function type that is not yet known to the system; 'Management' means a management function on a component (like import or discover.)",
-    ),
-    args: z.string().optional().describe(
-      "A JSON string representing the arguments passed as input to this function",
-    ),
-    resultValue: z.string().optional().describe(
-      "A JSON string representing the return value of the function",
-    ),
-    logs: z.string().optional().describe(
-      "A string of logs produced by the function; only included if the logs argument to the tool is true",
-    ),
-    code: z.string().optional().describe(
-      "The source code executed for this func run; useful for troubleshooting. Only included if the code argument to the tool is true",
-    ),
-  }).describe("the func run data"),
+  data: z
+    .object({
+      funcRunId: z.string().describe("the func run id"),
+      funcRunState: z
+        .enum([
+          "Created",
+          "Dispatched",
+          "Killed",
+          "Running",
+          "PostProcessing",
+          "Failure",
+          "Success",
+        ])
+        .describe(
+          "the state of this function execution run. 'Created' is the initial state, but not yet dispatched to the job system. 'Dispatched' means it is send to the job system. 'Killed' means it has been manually stopped during execution. 'Running' means it is currently executing. 'PostProcessing' means the system is taking the results of the function and appying them to System Initiative. 'Failure' means the function execution has failed. 'Success' means the function has run succesfully (but it does not neccessarily mean that it was successful from the user perspective; it only means the function executed without error.",
+        ),
+      componentId: z
+        .string()
+        .describe("the component id this function run was for"),
+      componentName: z
+        .string()
+        .describe("the component name this function run was for"),
+      schemaName: z
+        .string()
+        .describe("the schema name of the component this function was for"),
+      functionName: z.string().describe("the name of the function"),
+      functionKind: z
+        .enum([
+          "Action",
+          "Attribute",
+          "Authentication",
+          "CodeGeneration",
+          "Intrinsic",
+          "Qualification",
+          "SchemaVariantDefinition",
+          "Unknown",
+          "Management",
+        ])
+        .describe(
+          "'Action' means an action function on a component; 'Attribute' means an attribute function on a components attribute; 'CodeGeneration' means a code generation function on a component; 'Intrinsic' means it is not a javascript function, but instead implemented directly by SI; 'Qualification' means a qualification that a component is valid; 'SchemaVariantDefinition' means the typescript that defines the schema for a component; 'Unknown' means a function type that is not yet known to the system; 'Management' means a management function on a component (like import or discover.)",
+        ),
+      args: z
+        .string()
+        .optional()
+        .describe(
+          "A JSON string representing the arguments passed as input to this function",
+        ),
+      resultValue: z
+        .string()
+        .optional()
+        .describe(
+          "A JSON string representing the return value of the function",
+        ),
+      logs: z
+        .string()
+        .optional()
+        .describe(
+          "A string of logs produced by the function; only included if the logs argument to the tool is true",
+        ),
+      code: z
+        .string()
+        .optional()
+        .describe(
+          "The source code executed for this func run; useful for troubleshooting. Only included if the code argument to the tool is true",
+        ),
+    })
+    .describe("the func run data"),
 };
-const GetFuncRunOutputSchema = z.object(
-  GetFuncRunOutputSchemaRaw,
-);
+const GetFuncRunOutputSchema = z.object(GetFuncRunOutputSchemaRaw);
 
 type FuncRunResult = z.infer<typeof GetFuncRunOutputSchema>["data"];
 
@@ -112,66 +146,88 @@ export function funcRunGetTool(server: McpServer) {
       inputSchema: GetFuncRunInputSchemaRaw,
       outputSchema: GetFuncRunOutputSchemaRaw,
     },
-    async (
-      {
-        changeSetId,
-        funcRunId,
-        logs,
-        code,
-        args: showArguments,
-        result: showResult,
-      },
-    ): Promise<CallToolResult> => {
+    async ({
+      changeSetId,
+      funcRunId,
+      logs,
+      code,
+      args: showArguments,
+      result: showResult,
+    }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new FuncsApi(apiConfig);
-      try {
-        const response = await siApi.getFuncRun({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          funcRunId: funcRunId,
-        });
-        const result: FuncRunResult = {
-          funcRunId: response.data.funcRun.id,
-          funcRunState: response.data.funcRun
-            .state as FuncRunResult["funcRunState"],
-          componentId: response.data.funcRun.componentId,
-          componentName: response.data.funcRun.componentName,
-          schemaName: response.data.funcRun.schemaName,
-          functionName: response.data.funcRun.functionDisplayName ||
-            response.data.funcRun.functionName,
-          functionKind: response.data.funcRun
-            .functionKind as FuncRunResult["functionKind"],
-        };
-        if (showArguments && response.data.funcRun.functionArgs) {
-          result.args = JSON.stringify(response.data.funcRun.functionArgs);
-        }
-        if (showResult && response.data.funcRun.resultValue) {
-          result.resultValue = JSON.stringify(
-            response.data.funcRun.resultValue,
-          );
-        }
-
-        if (logs && response.data.funcRun.logs?.logs) {
-          let logOutput = "";
-          for (const logLine of response.data.funcRun.logs.logs) {
-            logOutput += (logLine as { message: string }).message;
+        if (!changeSetId) {
+          const changeSetsApi = new ChangeSetsApi(apiConfig);
+          try {
+            const changeSetList = await changeSetsApi.listChangeSets({
+              workspaceId: WORKSPACE_ID,
+            });
+            const head = (
+              changeSetList.data.changeSets as ChangeSetItem[]
+            ).find((cs) => cs.isHead);
+            if (!head) {
+              return errorResponse({
+                message:
+                  "No HEAD change set found; this is a bug! Tell the user we are sorry.",
+              });
+            }
+            changeSetId = head.id;
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            return errorResponse({
+              message: `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+            });
           }
-          result.logs = logOutput;
-        }
-        if (code && response.data.funcRun.functionCodeBase64) {
-          const codeString = decodeBase64(
-            response.data.funcRun.functionCodeBase64,
-          );
-          const textDecoder = new TextDecoder();
-          result.code = textDecoder.decode(codeString);
         }
 
-        return successResponse(
-          result,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+        const siApi = new FuncsApi(apiConfig);
+        try {
+          const response = await siApi.getFuncRun({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            funcRunId: funcRunId,
+          });
+          const result: FuncRunResult = {
+            funcRunId: response.data.funcRun.id,
+            funcRunState: response.data.funcRun
+              .state as FuncRunResult["funcRunState"],
+            componentId: response.data.funcRun.componentId,
+            componentName: response.data.funcRun.componentName,
+            schemaName: response.data.funcRun.schemaName,
+            functionName:
+              response.data.funcRun.functionDisplayName ||
+              response.data.funcRun.functionName,
+            functionKind: response.data.funcRun
+              .functionKind as FuncRunResult["functionKind"],
+          };
+          if (showArguments && response.data.funcRun.functionArgs) {
+            result.args = JSON.stringify(response.data.funcRun.functionArgs);
+          }
+          if (showResult && response.data.funcRun.resultValue) {
+            result.resultValue = JSON.stringify(
+              response.data.funcRun.resultValue,
+            );
+          }
+
+          if (logs && response.data.funcRun.logs?.logs) {
+            let logOutput = "";
+            for (const logLine of response.data.funcRun.logs.logs) {
+              logOutput += (logLine as { message: string }).message;
+            }
+            result.logs = logOutput;
+          }
+          if (code && response.data.funcRun.functionCodeBase64) {
+            const codeString = decodeBase64(
+              response.data.funcRun.functionCodeBase64,
+            );
+            const textDecoder = new TextDecoder();
+            result.code = textDecoder.decode(codeString);
+          }
+
+          return successResponse(result);
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );


### PR DESCRIPTION
FIXES: BUG-986

We can make changeSetId optional to the fund-run-get so it prefers HEAD 
when dealing with actions.

If this was required and you prompted it to look for the details of why 
an action failed and didn’t specify HEAD but the component existed in 
Multiple change sets, you would get an error like this:

```
⏺ system-initiative - func-run-get (MCP)(funcRunId:
                                        "01K3JR36X3KBP6YSEY70H8D4BX", logs:
                                        true, result: true)
  ⎿  Error: MCP error -32602: MCP error -32602: Invalid arguments for tool 
     func-run-get: [
       {
         "code": "invalid_type",
         "expected": "string",
         "received": "undefined",
         "path": [
           "changeSetId"
         ],
         "message": "Required"
       }
     … +1 line (ctrl+r to see all)

⏺ system-initiative - func-run-get (MCP)(funcRunId:
                                        "01K3JR36X3T4WWKCM4TRJAQKHG", logs:
                                        true, result: true)
  ⎿  Error: MCP error -32602: MCP error -32602: Invalid arguments for tool 
     func-run-get: [
       {
         "code": "invalid_type",
         "expected": "string",
         "received": "undefined",
         "path": [
           "changeSetId"
         ],
         "message": "Required"
       }
     … +1 line (ctrl+r to see all)

⏺ system-initiative - func-run-get (MCP)(funcRunId:
                                        "01K3JR36YHS0881YK49BJ5SJTQ", logs:
                                        true, result: true)
  ⎿  Error: MCP error -32602: MCP error -32602: Invalid arguments for tool 
     func-run-get: [
       {
         "code": "invalid_type",
         "expected": "string",
         "received": "undefined",
         "path": [
           "changeSetId"
         ],
         "message": "Required"
       }
     … +1 line (ctrl+r to see all)

⏺ Let me check the HEAD change set ID and then examine the function run
  details:
  ⎿ <response>{"status":"success","data":[{"id":"01K3JHWPHRGFH7PWN3DQ58EG0Y","n
    ame":"HEAD","status":"Open","isHead":true}]}</response>
    <hints>Apply, Force-Apply, and Abandon change sets using their 'id' and the
    … +1 line (ctrl+r to expand)
```

Now it will try HEAD first if you don’t prompt it to:

```
I am trying to deploy a VPC and there's a failed action can you tell me what is wrong?

⏺ I'll help you diagnose the failed action for your VPC deployment. Let me start by checking your System Initiative
  workspace and finding the failed action.

  Update Todos
  ⎿  ☐ Validate SI credentials and check workspace access
     ☐ List change sets to find the VPC deployment
     ☐ Find failed actions related to VPC
     ☐ Analyze the failed action details

  Update Todos
  ⎿  ☐ Validate SI credentials and check workspace access
     ☐ List change sets to find the VPC deployment
     ☐ Find failed actions related to VPC
     ☐ Analyze the failed action details
  ⎿ <response>{"status":"success","data":{"userId":"01GW0KXH4YJBWC7BTBAZ6ZR7EA","userEmail":"paul@systeminit.com","workspace
    Id":"01HPJ3K7RC486W9RPR3T0B6HS2","token":{"iat":1755457114,"exp":1787014714,"sub":"01GW0KXH4YJBWC7BTBAZ6ZR7EA","jti":"01
    K2WPBM811PWAWHRY0YQM1C5G","version":"2","userId":"01GW0KXH4YJBWC7BTBAZ6ZR7EA","workspaceId":"01HPJ3K7RC486W9RPR3T0B6HS2"
    … +1 line (ctrl+r to expand)




  Update Todos
  ⎿  ☒ Validate SI credentials and check workspace access
     ☐ List change sets to find the VPC deployment
     ☐ Find failed actions related to VPC
     ☐ Analyze the failed action details
  ⎿ <response>{"status":"success","data":[{"id":"01K3A23AJP3DX9G753T289V6RG","name":"HEAD","status":"Open","isHead":true},{"
    id":"01K3FB88JGFE96XHQDAS6XXDPW","name":"testing-diff","status":"Open","isHead":false},{"id":"01K3GJSJ3BVMM43BZ4FNCQ2CWE
    ","name":"IAM Role for EC2 Interaction","status":"Open","isHead":false},{"id":"01K3H3CCPHTJHREP9EA7EG0N93","name":"testi
    … +3 lines (ctrl+r to expand)




  Update Todos
  ⎿  ☒ Validate SI credentials and check workspace access
     ☒ List change sets to find the VPC deployment
     ☐ Find failed actions related to VPC
     ☐ Analyze the failed action details
  ⎿ <response>{"status":"success","data":[{"actionId":"01K3K9MH90ME5D0Z1HSP6G80W9","componentId":"01K3K9MH89NVWQYH9E9XMJJST7
    ","componentName":"testing broken delete","schemaName":"AWS::EC2::VPC","name":"Create","kind":"Create","funcRunId":"01K3
    K9N7FF5VAJQECW5XG87V5J","state":"Failed"}]}</response>
    … +2 lines (ctrl+r to expand)



⏺ Perfect! I found a failed action for an AWS::EC2::VPC component. Let me analyze the function run details to understand
  what went wrong.

  Update Todos
  ⎿  ☒ Validate SI credentials and check workspace access
     ☒ List change sets to find the VPC deployment
     ☒ Find failed actions related to VPC
     ☐ Analyze the failed action details

⏺ si-mcp-server - func-run-get (MCP)(funcRunId: "01K3K9N7FF5VAJQECW5XG87V5J", logs: true, result: true)
  ⎿ <response>{"status":"success","data":{"funcRunId":"01K3K9N7FF5VAJQECW5XG87V5J","funcRunState":"Success","componentId":"0
    1K3K9MH89NVWQYH9E9XMJJST7","componentName":"testing broken delete","schemaName":"AWS::EC2::VPC","functionName":"Create A
    sset","functionKind":"Action","resultValue":"{\"error\":\"{\\\"kind\\\":{\\\"UserCodeException\\\":\\\"Error\\\"},\\\"me
    … +12 lines (ctrl+r to expand)




  Update Todos
  ⎿  ☒ Validate SI credentials and check workspace access
     ☒ List change sets to find the VPC deployment
     ☒ Find failed actions related to VPC
     ☒ Analyze the failed action details

⏺ The VPC deployment failed due to invalid AWS credentials. The error message shows:

  An error occurred (UnrecognizedClientException) when calling the CreateResource operation: The security token included in
  the request is invalid.

  The Problem:
  Your AWS credentials are either:
  1. Expired or invalid
  2. Not configured properly in the AWS Credential component
  3. Missing required permissions

  To Fix This:
  1. Update your AWS Credential component with valid credentials (Access Key ID, Secret Access Key, and optionally Session
  Token if using temporary credentials)
  2. Ensure the credentials have the necessary IAM permissions for EC2 VPC operations (at minimum ec2:CreateVpc and related
  permissions)
  3. Retry the failed action once credentials are updated

  Would you like me to help you check your AWS Credential component configuration or retry the action once you've updated
  the credentials?
```