### PR TITLE
fixed keyboard shortcuts and Grid tab context menu bug

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -818,4 +818,8 @@ const nameForm = wForm.newForm({
     }
   },
 });
+
+defineExpose({
+  focusSearch,
+});
 </script>

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -1834,7 +1834,7 @@ const allSelectedComponentsAreRestorable = computed(() => {
 
 const fixContextMenu = async () => {
   if (bulkEditing.value) return;
-  if (!focusedComponentRef.value) await nextTick();
+  await nextTick();
 
   // If we focus on the pinned component, do not bring up the context menu.
   if (
@@ -2103,9 +2103,8 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
     if (e.metaKey || e.ctrlKey) {
       // This is the chrome hotkey combo for refreshing the page! Let it happen!
       return;
-    }
-
-    if (ctx.onHead.value) {
+    } else if (ctx.onHead.value) {
+      // Can't open the review screen on Head
       return;
     }
 
@@ -2139,6 +2138,7 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
       mapRef.value?.onU(e);
     }
   },
+  // v: undefined,
   // w: undefined,
   // x: undefined,
   // y: undefined,


### PR DESCRIPTION
## How does this PR change the system?

The keyboard shortcuts on `ComponentDetails` were not set up properly so some of them just did not work. I fixed them, organized them like we do in `Explore`, and added the keyboard shortcut for going to the `Review` screen.

This PR also fixes a bug on the Grid view where the context menu would not be in the correct position when using the keyboard controls.