### PR TITLE
feat: return 428 if dvu roots exist on force apply

### DIFF
--- a/.ci/delete-stacks.py
+++ b/.ci/delete-stacks.py
@@ -41,40 +41,93 @@ def delete_component(change_set_id: str, component_id: str):
     return response.json()
 
 
-def force_apply_change_set(change_set_id: str):
-    response = requests.post(
-        f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/force_apply",
-        headers=headers,
-        data="")
+def force_apply_change_set(change_set_id: str,
+                           timeout_seconds=120,
+                           retry_interval=5):
+    """Force apply change set with retry logic for if DVU roots still exist."""
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        try:
+            response = requests.post(
+                f"{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/force_apply",
+                headers=headers,
+                data="")
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 428:  # PRECONDITION_REQUIRED == DVU
+                elapsed = time.time() - start_time
+                remaining = timeout_seconds - elapsed
+                print(
+                    f'⏳ DVU Roots still present. Retrying in {retry_interval}s... ({remaining:.1f}s remaining)'
+                )
+                if remaining > retry_interval:
+                    time.sleep(retry_interval)
+                    continue
+                else:
+                    break
+            else:
+                raise e
+
+    raise TimeoutError(
+        f"❌ Force apply failed after {timeout_seconds}s - DVUs still processing"
+    )
+
+
+def get_change_set(change_set_id):
+    response = requests.get(
+        f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}',
+        headers=headers)
+    return response
+
+
+def delete_change_set(change_set_id):
+    response = requests.delete(
+        f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}',
+        headers=headers)
     response.raise_for_status()
     return response.json()
 
 
 def main():
-    print("🔍 Creating a change set for deletion...")
-    change_set_id = create_change_set("Delete All EC2 Components")
-    print(f"✅ Change set created: {change_set_id}")
+    try:
+        print("🔍 Creating a change set for deletion...")
+        change_set_id = create_change_set("Delete All EC2 Components")
+        print(f"✅ Change set created: {change_set_id}")
 
-    print("🔍 Searching for EC2 instance components...")
-    ec2_component_ids = search_ec2_components(change_set_id)
+        print("🔍 Searching for EC2 instance components...")
+        ec2_component_ids = search_ec2_components(change_set_id)
 
-    if not ec2_component_ids:
-        print("✅ No EC2 components found. Nothing to delete.")
-        return
+        if not ec2_component_ids:
+            print("✅ No EC2 components found. Nothing to delete.")
+            return
 
-    print(f"⚠️ Found {len(ec2_component_ids)} EC2 components. Deleting...")
-    for component_id in ec2_component_ids:
-        print(f"🗑️ Deleting component: {component_id}")
-        delete_component(change_set_id, component_id)
+        print(f"⚠️ Found {len(ec2_component_ids)} EC2 components. Deleting...")
+        for component_id in ec2_component_ids:
+            print(f"🗑️ Deleting component: {component_id}")
+            delete_component(change_set_id, component_id)
 
-    print("Waiting for DVU")
-    time.sleep(
-        30
-    )  # I really need a method here to detect DVU is complete more elegantly
+        print("🚀 Applying change set to execute deletions...")
+        force_apply_change_set(change_set_id)
+        print("✅ All EC2 components scheduled for deletion.")
 
-    print("🚀 Applying change set to execute deletions...")
-    force_apply_change_set(change_set_id)
-    print("✅ All EC2 components scheduled for deletion.")
+    except requests.exceptions.HTTPError as err:
+        print(f'HTTP Error: {err}')
+        print(f'Response: {err.response.text}')
+        sys.exit(1)
+    except Exception as err:
+        print(f'General Error: {err}')
+        sys.exit(1)
+    finally:
+        if change_set_id:
+            try:
+                response = get_change_set(change_set_id)
+                if response.status_code == 200:
+                    print(f'Cleaning up change set {change_set_id}...')
+                    delete_change_set(change_set_id)
+                    print('Change set deleted.')
+            except Exception as cleanup_err:
+                print(f'Failed to cleanup change set: {cleanup_err}')
 
 
 if __name__ == "__main__":

--- a/lib/luminork-server/src/service/v1/change_sets/force_apply.rs
+++ b/lib/luminork-server/src/service/v1/change_sets/force_apply.rs
@@ -32,6 +32,7 @@ use crate::extract::{
     responses(
         (status = 200, description = "Change Set force applied successfully", body = ForceApplyChangeSetV1Response),
         (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 428, description = "DVU Roots still exist, apply must be tried again later."),
         (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
     )
 )]

--- a/lib/luminork-server/src/service/v1/change_sets/mod.rs
+++ b/lib/luminork-server/src/service/v1/change_sets/mod.rs
@@ -66,6 +66,11 @@ impl ErrorIntoResponse for ChangeSetError {
             ChangeSetError::ChangeSet(dal::ChangeSetError::ChangeSetNotFound(_)) => {
                 (StatusCode::NOT_FOUND, self.to_string())
             }
+            ChangeSetError::ChangeSet(dal::ChangeSetError::DvuRootsNotEmpty(_)) => (
+                StatusCode::PRECONDITION_REQUIRED,
+                "There are dependent values that still need to be calculated. Please retry!"
+                    .to_string(),
+            ),
             ChangeSetError::CannotAbandonHead => (StatusCode::BAD_REQUEST, self.to_string()),
             ChangeSetError::CannotMergeHead => (StatusCode::BAD_REQUEST, self.to_string()),
             ChangeSetError::Validation(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),


### PR DESCRIPTION
## How does this PR change the system?

We currently return a 500 if DVU roots exist when running force_apply. This changes so we return [428 Precondition Required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/428) instead (which is what we do in SDF). This implies that the client should try again later.

In addition, the `validate main` tests will now retry force applies if they encounter this error every five seconds for up to two minutes.


## How was it tested?


- [X] Integration tests pass
- [X] Manual test: ran the pipeline manually. Technically it fails until luminork is redeployed

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdldWF3bXRhMTRvdmI3ZHJpdmRpaHpja204c2ZjamFoNWt5dTk2OXh4dCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Fy15IKOPnCCtfrv860/giphy.gif"/>