### PR TITLE
fix(dal): use correct context in mgmt state transitions

### DIFF
--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -452,12 +452,13 @@ impl ManagementFuncJob {
         ctx_clone.restart_connections().await?;
 
         if new_state == ManagementState::Failure {
-            if let Ok(snap) = ctx.workspace_snapshot() {
+            if let Ok(snap) = ctx_clone.workspace_snapshot() {
                 snap.revert().await;
             }
         }
+
         ManagementFuncJobState::transition_state(
-            ctx,
+            &ctx_clone,
             execution_state_id,
             new_state,
             func_run_id,


### PR DESCRIPTION
The wrong context was being used for management func state transitions which resulted in rollbacks in the failure case, leaving a failed function in a "pending" state. In the success case the outer context commited the transition transactions so it appeared to work.

To test: fail a management function (a discover with no region is a good case). Then try to run it again. It should run again every time if it has failed (or succeeded)