### PR TITLE
fix: missing import in delete-stacks

### DIFF
--- a/.ci/delete-stacks.py
+++ b/.ci/delete-stacks.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import sys
 import time
 
 API_TOKEN = os.environ.get('SI_API_TOKEN')


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Missed an import. 

Ran py_compile and it is good.

```
❯ python3 -m py_compile  .ci/deploy-stack.py .ci/delete-stacks.py  && echo GOOD
GOOD
```
