### PR TITLE
Fix overflowing group selector bar

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -108,7 +108,7 @@
           </InstructiveVormInput>
         </div>
         <div
-          class="flex-none flex flex-row items-center gap-xs justify-between"
+          class="flex-none flex flex-row flex-wrap items-center gap-xs justify-between"
         >
           <TabGroupToggle
             ref="groupRef"
@@ -132,7 +132,7 @@
               />
             </template>
           </TabGroupToggle>
-          <div v-if="showGrid" class="flex flex-row gap-xs">
+          <div v-if="showGrid" class="flex flex-row flex-wrap gap-xs">
             <DefaultSubscriptionsButton
               v-if="featureFlagsStore.DEFAULT_SUBS"
               :selected="gridMode.mode === 'defaultSubscriptions'"


### PR DESCRIPTION
## Description

This change fixes the overflowing group selector bar. It keeps everything in the same DOM order to retain compatibility with tests.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNWowbXNwN2g4bTRvM2ZnNWlhZTN1NW54N3M3Ym9mZjB3bXBmeWo4aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/tABB1KKo2ORFeoxmTp/giphy.gif"/>

## Screenshots

Normal view:

<img width="1214" height="468" alt="Screenshot 2025-08-26 at 3 14 49 PM" src="https://github.com/user-attachments/assets/242e8902-8436-4a60-9fa4-edea817156ba" />

Compressed view:

<img width="975" height="275" alt="Screenshot 2025-08-26 at 3 14 57 PM" src="https://github.com/user-attachments/assets/79980856-8d87-4bf0-86d2-0011753b51aa" />