### PR TITLE
fix(dal): restore rebuild_for_deployment in cached_modules

### DIFF
--- a/lib/sdf-server/src/service/v2/admin.rs
+++ b/lib/sdf-server/src/service/v2/admin.rs
@@ -100,6 +100,8 @@ pub enum AdminAPIError {
     Component(#[from] dal::component::ComponentError),
     #[error("diagram error: {0}")]
     Diagram(#[from] sdf_v1_routes_diagram::DiagramError),
+    #[error("edda client error: {0}")]
+    Edda(#[from] edda_client::ClientError),
     #[error("func runner error: {0}")]
     FuncRunner(#[from] FuncRunnerError),
     #[error("inferred connection graph error: {0}")]

--- a/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
+++ b/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
@@ -87,7 +87,8 @@ pub async fn update_cached_modules_inner(
     edda_client: edda_client::EddaClient,
 ) -> AdminAPIResult<()> {
     info!("Starting module cache update");
-    CachedModule::update_cached_modules(ctx, edda_client).await?;
+    CachedModule::update_cached_modules(ctx, edda_client.clone()).await?;
+    edda_client.rebuild_for_deployment().await?;
 
     track(
         &posthog_client,


### PR DESCRIPTION
Ensure that we call rebuild_for_deployment when we update the cached modules via the admin paenl