### PR TITLE
Ensure both v1 and v2 SDF API endpoints consistently trigger and wait for index update on change set creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7484,6 +7484,7 @@ dependencies = [
  "edda-client",
  "edda-core",
  "frigg",
+ "futures-lite",
  "hyper 0.14.32",
  "nats-multiplexer-client",
  "once_cell",

--- a/lib/sdf-core/BUCK
+++ b/lib/sdf-core/BUCK
@@ -23,6 +23,7 @@ rust_library(
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:axum",
         "//third-party/rust:derive_more",
+        "//third-party/rust:futures-lite",
         "//third-party/rust:hyper",
         "//third-party/rust:once_cell",
         "//third-party/rust:remain",

--- a/lib/sdf-core/Cargo.toml
+++ b/lib/sdf-core/Cargo.toml
@@ -17,6 +17,7 @@ derive_more = { workspace = true }
 edda-client = { path = "../../lib/edda-client" }
 edda-core = { path = "../../lib/edda-core" }
 frigg = { path = "../../lib/frigg" }
+futures-lite = { workspace = true }
 hyper = { workspace = true }
 nats-multiplexer-client = { path = "../../lib/nats-multiplexer-client" }
 once_cell = { workspace = true }

--- a/lib/sdf-core/src/change_set_mvs.rs
+++ b/lib/sdf-core/src/change_set_mvs.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use dal::{
+    ChangeSetId,
+    WorkspacePk,
+    WorkspaceSnapshotAddress,
+};
+use futures_lite::StreamExt;
+use telemetry::prelude::*;
+use thiserror::Error;
+
+const WATCH_INDEX_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum ChangeSetMvsError {
+    #[error("Edda client error: {0}")]
+    EddaClient(#[from] edda_client::ClientError),
+    #[error("Frigg error: {0}")]
+    Frigg(#[from] frigg::FriggError),
+}
+
+pub type Result<T> = std::result::Result<T, ChangeSetMvsError>;
+
+#[instrument(
+    level = "info",
+    name = "sdf.change_set.create_index_for_new_change_set_and_watch",
+    skip_all,
+    fields(
+        si.edda_request.id = Empty
+    )
+)]
+pub async fn create_index_for_new_change_set_and_watch(
+    frigg: &frigg::FriggStore,
+    edda_client: &edda_client::EddaClient,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    base_change_set_id: ChangeSetId,
+    to_snapshot_address: WorkspaceSnapshotAddress,
+) -> Result<bool> {
+    let span = Span::current();
+    let mut watch = frigg
+        .watch_change_set_index(workspace_pk, change_set_id)
+        .await?;
+    let request_id = edda_client
+        .new_change_set(
+            workspace_pk,
+            change_set_id,
+            base_change_set_id,
+            to_snapshot_address,
+        )
+        .await?;
+    span.record("si.edda_request.id", request_id.to_string());
+
+    let timeout = WATCH_INDEX_TIMEOUT;
+    tokio::select! {
+        _ = tokio::time::sleep(timeout) => {
+            info!("timed out waiting for new change set index to be created");
+            Ok(false)
+        },
+        _ = watch.next() => Ok(true)
+    }
+}

--- a/lib/sdf-core/src/lib.rs
+++ b/lib/sdf-core/src/lib.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 pub mod api_error;
 pub mod app_state;
 pub mod async_route;
+pub mod change_set_mvs;
 pub mod dal_wrapper;
 pub mod force_change_set_response;
 pub mod generate_template;

--- a/lib/sdf-server/src/service/v2/change_set/create.rs
+++ b/lib/sdf-server/src/service/v2/change_set/create.rs
@@ -7,6 +7,7 @@ use dal::{
     ChangeSet,
     WsEvent,
 };
+use sdf_core::change_set_mvs::create_index_for_new_change_set_and_watch;
 use sdf_extract::{
     EddaClient,
     FriggStore,
@@ -20,7 +21,6 @@ use serde::{
 use si_events::audit_log::AuditLogKind;
 
 use super::Result;
-use crate::service::v2::change_set::create_index_for_new_change_set_and_watch;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/lib/sdf-v1-routes-change-sets/src/lib.rs
+++ b/lib/sdf-v1-routes-change-sets/src/lib.rs
@@ -48,6 +48,8 @@ pub enum ChangeSetError {
     ActionPrototype(#[from] ActionPrototypeError),
     #[error("cannot abandon head change set")]
     CannotAbandonHead,
+    #[error("change set mvs error: {0}")]
+    ChangeSetMvs(#[from] sdf_core::change_set_mvs::ChangeSetMvsError),
     #[error("component error: {0}")]
     Component(#[from] ComponentError),
     #[error("dal change set error: {0}")]


### PR DESCRIPTION
While the v1 endpoint was triggering the new change set message for Edda, only the v2 endpoint was actually waiting for the index update to happen.

The method used by v2 to do the trigger-and-wait is now in sdf-core where it can be used by both v1 and v2 endpoints.
