### PR TITLE
fixed newhotness colors, Explore spacing, menu bug

### DIFF
--- a/app/web/src/newhotness/ComponentDebugPanel.vue
+++ b/app/web/src/newhotness/ComponentDebugPanel.vue
@@ -143,7 +143,6 @@
                       <span
                         v-html-safe="highlight(attr.prop.kind)"
                         class="px-xs py-2xs rounded text-2xs"
-                        :class="kindTagClass"
                       >
                       </span>
                     </td>
@@ -414,6 +413,7 @@
 import { computed, ref } from "vue";
 import { useQuery } from "@tanstack/vue-query";
 import { SiSearch, themeClasses } from "@si/vue-lib/design-system";
+import { tw } from "@si/vue-lib";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { routes, useApi } from "./api_composables";
 import EmptyState from "./EmptyState.vue";
@@ -528,35 +528,29 @@ const expandedRows = ref(new Set<string>());
 // Style classes
 const cardClass = computed(() =>
   themeClasses(
-    "bg-shade-0 border-neutral-300",
-    "bg-shade-100 border-neutral-600",
+    tw`bg-shade-0 border-neutral-300`,
+    tw`bg-shade-100 border-neutral-600`,
   ),
 );
 const headerClass = computed(() =>
-  themeClasses("text-neutral-900", "text-neutral-100"),
+  themeClasses(tw`text-neutral-900`, tw`text-neutral-100`),
 );
 const docClass = computed(() =>
   themeClasses(
-    "bg-neutral-50 text-neutral-700",
-    "bg-neutral-800 text-neutral-300",
-  ),
-);
-const kindTagClass = computed(() =>
-  themeClasses(
-    "bg-purple-100 text-purple-800",
-    "bg-purple-800 text-purple-200",
+    tw`bg-neutral-50 text-neutral-700`,
+    tw`bg-neutral-800 text-neutral-300`,
   ),
 );
 const destructiveClass = computed(() =>
-  themeClasses("text-destructive-500", "text-destructive-400"),
+  themeClasses(tw`text-destructive-500`, tw`text-destructive-400`),
 );
 const tagClass = computed(() =>
   themeClasses(
-    "bg-neutral-100 text-neutral-700",
-    "bg-neutral-700 text-neutral-300",
+    tw`bg-neutral-100 text-neutral-700`,
+    tw`bg-neutral-700 text-neutral-300`,
   ),
 );
-const bgClass = computed(() => themeClasses("bg-white", "bg-neutral-900"));
+const bgClass = computed(() => themeClasses(tw`bg-white`, tw`bg-neutral-900`));
 
 // Utility functions
 const stripRootFromPath = (path: string): string => {

--- a/app/web/src/newhotness/ComponentListItem.vue
+++ b/app/web/src/newhotness/ComponentListItem.vue
@@ -18,7 +18,10 @@
       variant="component"
       :class="
         clsx(
-          themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+          themeClasses(
+            'text-newhotness-greenlight',
+            'text-newhotness-greendark',
+          ),
           'max-w-fit flex-1',
         )
       "
@@ -28,7 +31,15 @@
     <TextPill
       tighter
       variant="component"
-      :class="clsx('text-purple max-w-fit flex-1')"
+      :class="
+        clsx(
+          'max-w-fit flex-1',
+          themeClasses(
+            'text-newhotness-purplelight',
+            'text-newhotness-purpledark',
+          ),
+        )
+      "
     >
       <TruncateWithTooltip>{{ component.name }}</TruncateWithTooltip>
     </TextPill>

--- a/app/web/src/newhotness/ManagementConnectionCard.vue
+++ b/app/web/src/newhotness/ManagementConnectionCard.vue
@@ -18,7 +18,10 @@
       :class="
         clsx(
           'min-w-0',
-          themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+          themeClasses(
+            'text-newhotness-greenlight',
+            'text-newhotness-greendark',
+          ),
         )
       "
     >
@@ -29,10 +32,21 @@
         }}
       </TruncateWithTooltip>
     </TextPill>
-    <TextPill mono class="text-purple min-w-0">
-      <TruncateWithTooltip>{{
-        ctx.componentDetails.value[componentId]?.name ?? componentId
-      }}</TruncateWithTooltip>
+    <TextPill
+      mono
+      :class="
+        clsx(
+          'min-w-0',
+          themeClasses(
+            'text-newhotness-purplelight',
+            'text-newhotness-purpledark',
+          ),
+        )
+      "
+    >
+      <TruncateWithTooltip>
+        {{ ctx.componentDetails.value[componentId]?.name ?? componentId }}
+      </TruncateWithTooltip>
     </TextPill>
   </li>
 </template>

--- a/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
+++ b/app/web/src/newhotness/ReviewAttributeItemSourceAndValue.vue
@@ -29,7 +29,17 @@
           )
         "
       >
-        <div :class="clsx(!old && 'text-purple')">
+        <div
+          :class="
+            clsx(
+              !old &&
+                themeClasses(
+                  'text-newhotness-purplelight',
+                  'text-newhotness-purpledark',
+                ),
+            )
+          "
+        >
           {{ $source.componentName }}
         </div>
         <div class="flex-none">/</div>

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -1027,19 +1027,4 @@ body.dark .skeleton-shimmer::before {
  * END Shimmer for skeleton divs
  * ================================================================================================
  */
-
-// other cards may look differently, can be defined globally, or piecemeal
-
-/* TODO(Wendy) - temporary color classes for the new UI */
-.text-purple {
-  color: #d4b4fe;
-}
-
-.text-green-light-mode {
-  color: #3b8e48;
-}
-
-.text-green-dark-mode {
-  color: #aafec7;
-}
 </style>

--- a/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
+++ b/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
@@ -69,7 +69,10 @@
               :class="
                 clsx(
                   'min-w-0',
-                  themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+                  themeClasses(
+                    'text-newhotness-greenlight',
+                    'text-newhotness-greendark',
+                  ),
                 )
               "
             >
@@ -77,7 +80,18 @@
                 {{ component.schemaVariantName }}
               </TruncateWithTooltip>
             </TextPill>
-            <TextPill mono class="text-purple min-w-0">
+            <TextPill
+              mono
+              :class="
+                clsx(
+                  'min-w-0',
+                  themeClasses(
+                    'text-newhotness-purplelight',
+                    'text-newhotness-purpledark',
+                  ),
+                )
+              "
+            >
               <TruncateWithTooltip>
                 {{ component.name }}
               </TruncateWithTooltip>

--- a/app/web/src/newhotness/layout_components/AttrComponentList.vue
+++ b/app/web/src/newhotness/layout_components/AttrComponentList.vue
@@ -16,7 +16,10 @@
         :class="
           clsx(
             'min-w-0',
-            themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+            themeClasses(
+              'text-newhotness-greenlight',
+              'text-newhotness-greendark',
+            ),
           )
         "
       >
@@ -24,7 +27,18 @@
           {{ component.schemaName }}
         </TruncateWithTooltip>
       </TextPill>
-      <TextPill mono class="text-purple min-w-0">
+      <TextPill
+        mono
+        :class="
+          clsx(
+            'min-w-0',
+            themeClasses(
+              'text-newhotness-purplelight',
+              'text-newhotness-purpledark',
+            ),
+          )
+        "
+      >
         <TruncateWithTooltip>
           {{ component.componentName }}
         </TruncateWithTooltip>

--- a/app/web/src/newhotness/layout_components/AttrValue.vue
+++ b/app/web/src/newhotness/layout_components/AttrValue.vue
@@ -6,11 +6,22 @@
         'p-2xs text-sm font-bold',
         strikeout && 'line-through',
         isSecret &&
-          themeClasses('text-green-light-mode', 'text-green-dark-mode'),
+          themeClasses(
+            'text-newhotness-greenlight',
+            'text-newhotness-greendark',
+          ),
       )
     "
   >
-    <TruncateWithTooltip v-if="showComponentName" class="text-purple">
+    <TruncateWithTooltip
+      v-if="showComponentName"
+      :class="
+        themeClasses(
+          'text-newhotness-purplelight',
+          'text-newhotness-purpledark',
+        )
+      "
+    >
       {{ componentName }}
     </TruncateWithTooltip>
     <div v-if="showComponentName" class="flex-none">/</div>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -120,8 +120,8 @@
                       clsx(
                         'max-w-full flex flex-row items-center [&>*]:min-w-0 [&>*]:flex-1 [&>*]:max-w-fit',
                         themeClasses(
-                          'text-green-light-mode',
-                          'text-green-dark-mode',
+                          'text-newhotness-greenlight',
+                          'text-newhotness-greendark',
                         ),
                       )
                     "
@@ -141,7 +141,14 @@
                 class="max-w-full flex flex-row items-center [&>*]:min-w-0 [&>*]:flex-1 [&>*]:max-w-fit"
               >
                 <!-- TODO: Paul make this an actual tailwind color! -->
-                <TruncateWithTooltip class="text-purple">
+                <TruncateWithTooltip
+                  :class="
+                    themeClasses(
+                      'text-newhotness-purplelight',
+                      'text-newhotness-purpledark',
+                    )
+                  "
+                >
                   {{ externalSources[0]?.componentName }}
                 </TruncateWithTooltip>
                 <div class="flex-none">/</div>
@@ -159,7 +166,10 @@
             <AttributeValueBox
               v-else-if="isSecret && field.state.value"
               :class="
-                themeClasses('text-green-light-mode', 'text-green-dark-mode')
+                themeClasses(
+                  'text-newhotness-greenlight',
+                  'text-newhotness-greendark',
+                )
               "
             >
               {{ field.state.value }}

--- a/app/web/src/newhotness/layout_components/AttributeInputPossibleConnection.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInputPossibleConnection.vue
@@ -25,11 +25,23 @@
       class="flex flex-row items-center gap-xs font-mono [&>*]:basis-1/2 [&>*]:flex-grow [&>*]:max-w-fit"
     >
       <TruncateWithTooltip
-        :class="themeClasses('text-green-light-mode', 'text-green-dark-mode')"
+        :class="
+          themeClasses(
+            'text-newhotness-greenlight',
+            'text-newhotness-greendark',
+          )
+        "
       >
         {{ connection.schemaName }}
       </TruncateWithTooltip>
-      <TruncateWithTooltip class="text-purple">
+      <TruncateWithTooltip
+        :class="
+          themeClasses(
+            'text-newhotness-purplelight',
+            'text-newhotness-purpledark',
+          )
+        "
+      >
         {{ connection.componentName }}
       </TruncateWithTooltip>
     </div>

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -69,7 +69,14 @@
               >
                 Set via subscription to
               </span>
-              <span class="text-purple">
+              <span
+                :class="
+                  themeClasses(
+                    'text-newhotness-purplelight',
+                    'text-newhotness-purpledark',
+                  )
+                "
+              >
                 {{
                   attributeTree.attributeValue.externalSources[0]?.componentName
                 }}

--- a/lib/vue-lib/src/tailwind/tailwind_customization/colors.json
+++ b/lib/vue-lib/src/tailwind/tailwind_customization/colors.json
@@ -65,6 +65,10 @@
   },
   "newhotness": {
     "destructive": "#332222",
-    "success": "#354139"
+    "success": "#354139",
+    "purpledark": "#d4b4fe",
+    "purplelight": "#631AC2",
+    "greendark": "#aafec7",
+    "greenlight": "#3b8e48"
   }
 }


### PR DESCRIPTION
This PR does three things -

- Fixed colors for the newhotness UI - all new colors are inside of Tailwind now and we have light/dark mode versions for the colors which need them.
- Fixed spacing for the Explore page - the spacing was `xs` (8px) when it should've been `sm` (16px)
- Fixed menu flashing bugs for the Explore page (see comments)