### PR TITLE
Display disconnected WS status for a given workspace

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -31,6 +31,7 @@
         :changeSetId="changeSetId"
         :componentId="componentId"
         :viewId="viewId"
+        :connected="haveWSConn"
       />
 
       <!-- Right -->
@@ -195,6 +196,11 @@ const workspacePk = computed(() => props.workspacePk);
 const changeSetId = computed(() => props.changeSetId);
 
 const coldStartInProgress = computed(() => heimdall.muspelheimInProgress.value);
+
+const haveWSConn = computed<boolean>(() => {
+  if (!heimdall.initCompleted.value) return true; // dont show error if we havent gotten started
+  return !!heimdall.wsConnections.value[props.workspacePk];
+});
 
 // no tan stack queries hitting sqlite until after the cold start has finished
 const queriesEnabled = computed(

--- a/app/web/src/newhotness/nav/NavbarPanelCenter.vue
+++ b/app/web/src/newhotness/nav/NavbarPanelCenter.vue
@@ -2,36 +2,55 @@
   <div
     class="flex flex-row flex-none items-center h-full justify-center place-items-center mx-auto overflow-hidden"
   >
-    <NavbarButton
-      tooltipText="Compose"
-      icon="grid"
-      :selected="route.name?.toString().startsWith('new-hotness')"
-      :linkTo="compositionLink"
-    />
+    <template v-if="connected">
+      <NavbarButton
+        tooltipText="Compose"
+        icon="grid"
+        :selected="route.name?.toString().startsWith('new-hotness')"
+        :linkTo="compositionLink"
+      />
 
-    <NavbarButton
-      tooltipText="Customize"
-      icon="beaker"
-      :selected="route.matched.some((r) => r.name === 'workspace-lab')"
-      :linkTo="{
-        path: `/w/${workspaceId}/${changeSetId}/l`,
-      }"
-    />
+      <NavbarButton
+        tooltipText="Customize"
+        icon="beaker"
+        :selected="route.matched.some((r) => r.name === 'workspace-lab')"
+        :linkTo="{
+          path: `/w/${workspaceId}/${changeSetId}/l`,
+        }"
+      />
 
-    <NavbarButton
-      tooltipText="Audit"
-      icon="eye"
-      :selected="route.matched.some((r) => r.name === 'workspace-audit')"
-      :linkTo="{
-        path: `/w/${workspaceId}/${changeSetId}/a`,
-      }"
-    />
+      <NavbarButton
+        tooltipText="Audit"
+        icon="eye"
+        :selected="route.matched.some((r) => r.name === 'workspace-audit')"
+        :linkTo="{
+          path: `/w/${workspaceId}/${changeSetId}/a`,
+        }"
+      />
+    </template>
+    <div
+      v-else
+      :class="
+        clsx(
+          'p-md text-destructive-500 flex flex-row gap-sm items-center',
+          'animate-[pulse_2s_infinite]',
+          themeClasses(
+            'bg-destructive-100 text-destructive-900',
+            'bg-destructive-900 text-destructive-100',
+          ),
+        )
+      "
+    >
+      <Icon name="alert-square" size="md" /> Lost Connection, retrying...
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { clsx } from "clsx";
 import { computed } from "vue";
 import { useRoute } from "vue-router";
+import { themeClasses, Icon } from "@si/vue-lib/design-system";
 import NavbarButton from "@/components/layout/navbar/NavbarButton.vue";
 
 const route = useRoute();
@@ -41,6 +60,7 @@ const props = defineProps<{
   changeSetId: string;
   componentId?: string;
   viewId?: string;
+  connected: boolean;
 }>();
 
 const compositionLink = computed(() => {

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -41,6 +41,12 @@ export type IncomingManagementConnections = DefaultMap<
   Record<string, Connection>
 >;
 
+export type ConnStatusFn = (
+  workspaceId: string,
+  connected: boolean,
+  noBroadcast?: boolean,
+) => void;
+
 export type UpdateFn = (
   workspaceId: string,
   changeSetId: string,
@@ -93,6 +99,10 @@ export type BroadcastMessage =
         listIds: string[];
         removed: boolean;
       };
+    }
+  | {
+      messageKind: "updateConnectionStatus";
+      arguments: { workspaceId: string; connected: boolean };
     }
   | {
       messageKind: "listenerInFlight";
@@ -332,6 +342,7 @@ export interface TabDBInterface {
   addListenerReturned(fn: RainbowFn): void;
   addListenerLobbyExit(fn: LobbyExitFn): void;
   addAtomUpdated(fn: UpdateFn): void;
+  addConnStatusFn(fn: ConnStatusFn): void;
   changeSetExists(workspaceId: string, changeSetId: ChangeSetId): boolean;
   niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<boolean>;
   pruneAtomsForClosedChangeSet(
@@ -472,6 +483,7 @@ export interface WorkspaceIndexUpdate {
   meta: WorkspaceAtomMeta;
   kind: MessageKind.WORKSPACE_INDEXUPDATE;
   indexChecksum: string;
+  frontEndObject: IndexObject;
 }
 
 export interface DeploymentIndexUpdate {


### PR DESCRIPTION
## Screenshots:

Note: it pulses to indicate retrying.

<img width="1444" height="66" alt="image" src="https://github.com/user-attachments/assets/d64f6529-180e-4f56-9c55-38d831fde6de" />

## How was it tested?

1. Mocked up a timeout after the WS connects, that closes the WS. Displays the message.
2. Open up two tabs, make sure the one web worker communicates to both tabs.

Unfortunately the dev tools "offline" doesn't close down WS connections 🤷 

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaDRjMTh1N3Jsc3Q0aDZldnQyMnJncjJlNzRpMDFheWt6YzlnNGsycCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jU5x6T0CGpIOBqrKtu/giphy.gif"/>