### PR TITLE
Prevent flicker: set the UI values 7 seconds after we make changes.

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -297,13 +297,22 @@ const updateCache = (
 };
 
 export const wsConnections = ref<Record<string, boolean>>({});
+export const _wsConnections = ref<Record<string, boolean>>({});
 
 const updateConnectionStatus: ConnStatusFn = (
   workspaceId: WorkspacePk,
   connected: boolean,
   noBroadcast?: boolean,
 ) => {
-  wsConnections.value[workspaceId] = connected;
+  _wsConnections.value[workspaceId] = connected;
+
+  // prevent blips in the UI
+  setTimeout(() => {
+    Object.entries(_wsConnections.value).forEach(([k, v]) => {
+      wsConnections.value[k] = v;
+    });
+  }, 7 * 1000);
+
   if (!noBroadcast) {
     db.broadcastMessage({
       messageKind: "updateConnectionStatus",


### PR DESCRIPTION
So if false becomes true quickly, you won't see the warning unnecessarily

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbzNiZnNlZXhsb21hYTU5MXhraXE3NmIyMjJrNWhrM2M1dWt3cm9vMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ctYlYideDlGW4/giphy.gif"/>