### PR TITLE
Application level keep-alive on the bifrost websocket

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -3617,11 +3617,17 @@ const dbInterface: TabDBInterface = {
       error(err);
     }
 
+    let interval: NodeJS.Timeout;
     sockets[workspaceId]?.addEventListener("close", () => {
+      if (interval) clearInterval(interval);
       updateConnectionStatus(workspaceId, false);
     });
     sockets[workspaceId]?.addEventListener("open", () => {
       updateConnectionStatus(workspaceId, true);
+      // heartbeat ping
+      interval = setInterval(() => {
+        sockets[workspaceId]?.send(new Uint8Array([0x9]));
+      }, 1000 * 20);
     });
 
     sockets[workspaceId]?.addEventListener("message", (messageEvent) => {

--- a/lib/sdf-v1-routes-ws/src/bifrost/proto.rs
+++ b/lib/sdf-v1-routes-ws/src/bifrost/proto.rs
@@ -305,12 +305,8 @@ impl BifrostStarted {
                                 handle: self.handle,
                             });
                         }
-                        // Received unexpected web socket message type
-                        Some(Ok(unexpected_message)) => {
-                            warn!(
-                                message = ?unexpected_message,
-                                "received unexpected message type; skipping",
-                            );
+                        Some(Ok(ws::Message::Binary(_payload))) => {
+                            // using as keep-alive traffic for the LB
                             continue;
                         }
                         // Next message was a web socket error


### PR DESCRIPTION
## How does this PR change the system?

In tools-prod/prod the LBs enforce an idle time. Every minute. So each websocket was opening, and if there were no MVs going across the wire, it would be shut down a minute later. And the client would reconnect.

By sending data, 3 times a minute, at least, we won't get shut down by the LB.

## How was it tested?

Locally we can see with log messages that the SDF web socket is receiving data.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZTh5a3YwcXhvaXNmcnIyaHp1Ymp2MGI2ZTgxNWsyc2NiOG54bTZ6aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/7W1rgKAxlDe3m/giphy.gif"/>