### PR TITLE
feat(sdf-server): Adds a component json endpoint

### DIFF
--- a/lib/sdf-server/src/service/v2/component.rs
+++ b/lib/sdf-server/src/service/v2/component.rs
@@ -28,6 +28,7 @@ pub mod attributes;
 pub mod autosubscribe;
 pub mod debug_component;
 pub mod delete_components;
+pub mod get_json;
 pub mod manage;
 pub mod name;
 pub mod restore_components;
@@ -112,6 +113,7 @@ pub fn v2_routes() -> Router<AppState> {
             "/:componentId",
             Router::new()
                 .route("/debug", get(debug_component::debug_component))
+                .route("/json", get(get_json::get_json))
                 .nest("/attributes", attributes::v2_routes())
                 .nest("/name", name::v2_routes())
                 .nest("/secret", secrets::v2_routes())

--- a/lib/sdf-server/src/service/v2/component/get_json.rs
+++ b/lib/sdf-server/src/service/v2/component/get_json.rs
@@ -1,0 +1,35 @@
+use axum::{
+    Json,
+    extract::Path,
+};
+use dal::{
+    Component,
+    component::properties::ComponentProperties,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::Result;
+use crate::service::v2::component::ComponentIdFromPath;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonResponse {
+    pub json: ComponentProperties,
+}
+
+pub(crate) async fn get_json(
+    ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
+    _tracker: PosthogEventTracker,
+    Path(ComponentIdFromPath { component_id }): Path<ComponentIdFromPath>,
+) -> Result<Json<JsonResponse>> {
+    let json = Component::get_json_representation(ctx, component_id).await?;
+
+    Ok(Json(JsonResponse { json }))
+}


### PR DESCRIPTION
There’s 1 route in func_test.vue that calls the JSON endpoint for a 
component. This is the last route for the v1-component-routes crate. 

We will migrate to this new route and delete the old crate