### PR TITLE
feat: Add "Executed AI Agent" flag to database

### DIFF
--- a/app/web/src/newhotness/Onboarding.vue
+++ b/app/web/src/newhotness/Onboarding.vue
@@ -6,6 +6,7 @@
     <div class="flex flex-row items-center justify-between w-full px-sm py-xs">
       <SiLogo class="block h-md w-md flex-none" />
       <VButton
+        aria-label="Skip Onboarding"
         class="text-neutral-400 hover:text-white font-normal"
         label="Skip"
         tone="empty"

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -133,6 +133,7 @@ import * as _ from "lodash-es";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import { Span, trace } from "@opentelemetry/api";
 import { themeClasses } from "@si/vue-lib/design-system";
+import { storeToRefs } from "pinia";
 import { useFeatureFlagsStore } from "@/store/feature_flags.store";
 import * as heimdall from "@/store/realtime/heimdall";
 import { useAuthStore } from "@/store/auth.store";
@@ -281,13 +282,16 @@ const reopenOnboarding = () => {
   onboardingCompleted.value = false;
 };
 
+const { user, userWorkspaceFlags } = storeToRefs(authStore);
+
 const ctx = computed<Context>(() => {
   return {
     workspacePk,
     changeSetId,
     changeSet,
     approvers,
-    user: authStore.user,
+    user: user.value,
+    userWorkspaceFlags,
     onHead: computed(() => {
       return changeSetId.value === _headChangeSetId.value;
     }),

--- a/app/web/src/newhotness/types.ts
+++ b/app/web/src/newhotness/types.ts
@@ -51,6 +51,7 @@ export interface Context {
   changeSet: Ref<ChangeSet | undefined>;
   approvers: Ref<string[]>;
   user: User | null;
+  userWorkspaceFlags: Ref<Record<string, boolean>>;
   onHead: ComputedRef<boolean>;
   headChangeSetId: Ref<string>;
   outgoingCounts: ComputedRef<Record<ComponentId, number>>;

--- a/app/web/src/store/realtime/realtime_events.ts
+++ b/app/web/src/store/realtime/realtime_events.ts
@@ -441,4 +441,9 @@ export type WsEventPayloadMap = {
     approvalRequirementDefinitionId: ApprovalRequirementDefinitionId;
     userId: UserId;
   };
+
+  UserWorkspaceFlagsUpdated: {
+    flags: Record<string, boolean>;
+    userPk: UserId;
+  };
 };

--- a/lib/dal/src/user.rs
+++ b/lib/dal/src/user.rs
@@ -39,6 +39,13 @@ pub struct OnlinePayload {
     pub idle: bool,
 }
 
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UserWorkspaceFlagsPayload {
+    user_pk: UserPk,
+    flags: serde_json::Value,
+}
+
 impl WsEvent {
     pub async fn cursor(
         workspace_pk: WorkspacePk,
@@ -57,5 +64,22 @@ impl WsEvent {
 
     pub async fn online(workspace_pk: WorkspacePk, online: OnlinePayload) -> WsEventResult<Self> {
         WsEvent::new_raw(workspace_pk, None, None, None, WsPayload::Online(online)).await
+    }
+
+    pub async fn user_workspace_flags_update(
+        workspace_pk: WorkspacePk,
+        user_pk: UserPk,
+        flags: serde_json::Value,
+    ) -> WsEventResult<Self> {
+        let payload = UserWorkspaceFlagsPayload { user_pk, flags };
+
+        WsEvent::new_raw(
+            workspace_pk,
+            None,
+            None,
+            None,
+            WsPayload::UserWorkspaceFlagsUpdated(payload),
+        )
+        .await
     }
 }

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -86,6 +86,7 @@ use crate::{
     user::{
         CursorPayload,
         OnlinePayload,
+        UserWorkspaceFlagsPayload,
     },
     workspace_snapshot::graph::validator::connections::{
         ConnectionMigratedPayload,
@@ -192,6 +193,7 @@ pub enum WsPayload {
     SetComponentPosition(ComponentSetPositionPayload),
     StatusUpdate(StatusUpdate),
     TemplateGenerated(TemplateGeneratedPayload),
+    UserWorkspaceFlagsUpdated(UserWorkspaceFlagsPayload),
     ViewComponentsUpdate(ViewComponentsUpdatePayload),
     ViewCreated(ViewWsPayload),
     ViewDeleted(ViewDeletedPayload),

--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -11,6 +11,7 @@ mod funcs;
 mod management_funcs;
 mod schemas;
 mod secrets;
+mod user;
 mod workspaces;
 
 pub use actions::{

--- a/lib/luminork-server/src/service/v1/user.rs
+++ b/lib/luminork-server/src/service/v1/user.rs
@@ -1,0 +1,100 @@
+use axum::{
+    http::StatusCode,
+    response::{
+        IntoResponse,
+        Response,
+    },
+};
+use dal::WsEvent;
+use sdf_core::EddaClientError;
+use sdf_extract::workspace::WorkspaceDalContext;
+use si_db::HistoryActor;
+use thiserror::Error;
+
+use crate::service::v1::common::ErrorIntoResponse;
+
+pub type UserResult<T> = Result<T, UserError>;
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum UserError {
+    #[error("action error: {0}")]
+    Action(#[from] dal::action::ActionError),
+    #[error("change set error: {0}")]
+    ChangeSet(#[from] dal::ChangeSetError),
+    #[error("change set apply error: {0}")]
+    ChangeSetApply(#[from] dal::ChangeSetApplyError),
+    #[error("component error: {0}")]
+    Component(#[from] dal::ComponentError),
+    #[error("db error: {0}")]
+    Db(#[from] si_db::Error),
+    #[error("edda client error: {0}")]
+    EddaClient(#[from] EddaClientError),
+    #[error("func error: {0}")]
+    Func(#[from] dal::FuncError),
+    #[error("missing user on request")]
+    MissingUser,
+    #[error("schema error: {0}")]
+    Schema(#[from] dal::SchemaError),
+    #[error("schema variant error: {0}")]
+    SchemaVariant(#[from] dal::SchemaVariantError),
+    #[error("transactions error: {0}")]
+    Transactions(#[from] dal::TransactionsError),
+    #[error("workspace error: {0}")]
+    Workspace(#[from] dal::WorkspaceError),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),
+    #[error("ws event error: {0}")]
+    WsEvent(#[from] dal::WsEventError),
+}
+
+impl ErrorIntoResponse for UserError {
+    fn status_and_message(&self) -> (StatusCode, String) {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
+    }
+}
+
+impl IntoResponse for UserError {
+    fn into_response(self) -> Response {
+        self.to_api_response()
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/user/set_ai_agent_executed",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier")
+    ),
+    tag = "user",
+    responses(
+        (status = 200, description = "Flag set successfully"),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn set_ai_agent_executed(
+    WorkspaceDalContext(ref ctx): WorkspaceDalContext,
+) -> UserResult<()> {
+    let HistoryActor::User(user_pk) = ctx.history_actor() else {
+        return Err(UserError::MissingUser);
+    };
+
+    let flags = si_db::User::set_flag_for_user_on_workspace(
+        ctx,
+        *user_pk,
+        ctx.workspace_pk()?,
+        "executedAgent",
+        serde_json::Value::Bool(true),
+    )
+    .await?;
+
+    WsEvent::user_workspace_flags_update(ctx.workspace_pk()?, *user_pk, flags)
+        .await?
+        .publish_on_commit(ctx)
+        .await?;
+
+    ctx.commit().await?;
+
+    Ok(())
+}

--- a/lib/luminork-server/src/service/v1/workspaces.rs
+++ b/lib/luminork-server/src/service/v1/workspaces.rs
@@ -25,6 +25,7 @@ use crate::{
         },
     },
     middleware::WorkspacePermissionLayer,
+    service::v1::user::set_ai_agent_executed,
 };
 
 #[remain::sorted]
@@ -93,6 +94,10 @@ pub fn routes(state: AppState) -> Router<AppState> {
                                 middleware::from_extractor::<TargetChangeSetIdentFromPath>(),
                             ),
                     ),
+            )
+            .nest(
+                "/user",
+                Router::new().route("/set_ai_agent_executed", post(set_ai_agent_executed)),
             )
             .route_layer(middleware::from_extractor_with_state::<
                 AuthorizedForAutomationRole,

--- a/lib/sdf-v1-routes-session/src/restore_authentication.rs
+++ b/lib/sdf-v1-routes-session/src/restore_authentication.rs
@@ -18,6 +18,7 @@ use crate::SessionResult;
 pub struct RestoreAuthenticationResponse {
     pub user: User,
     pub workspace: Workspace,
+    pub user_workspace_flags: serde_json::Value,
 }
 
 pub async fn restore_authentication(
@@ -30,7 +31,15 @@ pub async fn restore_authentication(
     let ctx = builder.build_head(access_builder).await?;
 
     let workspace = Workspace::get_by_pk(&ctx, workspace_id).await?;
-    let reply = RestoreAuthenticationResponse { user, workspace };
+
+    let user_workspace_flags =
+        User::get_flags_for_user_on_workspace(&ctx, user.pk(), workspace_id).await?;
+
+    let reply = RestoreAuthenticationResponse {
+        user,
+        workspace,
+        user_workspace_flags,
+    };
 
     Ok(Json(reply))
 }

--- a/lib/si-db/src/migrations/U3912__add_user_workspace_flags_to_join_table.sql
+++ b/lib/si-db/src/migrations/U3912__add_user_workspace_flags_to_join_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_belongs_to_workspaces ADD COLUMN flag_map jsonb DEFAULT '{}';

--- a/lib/si-db/src/queries/user/get_flags_by_pk_and_workspace.sql
+++ b/lib/si-db/src/queries/user/get_flags_by_pk_and_workspace.sql
@@ -1,0 +1,5 @@
+SELECT u.flag_map AS object
+FROM user_belongs_to_workspaces u
+WHERE u.user_pk = $1
+  AND u.workspace_pk = $2
+  AND u.visibility_deleted_at IS NULL

--- a/lib/si-db/src/queries/user/set_flags_by_pk_and_workspace.sql
+++ b/lib/si-db/src/queries/user/set_flags_by_pk_and_workspace.sql
@@ -1,0 +1,8 @@
+UPDATE user_belongs_to_workspaces
+SET flag_map = jsonb_set(
+        COALESCE(flag_map, '{}'::jsonb),
+        $3,
+        $4::jsonb)
+WHERE user_pk = $1
+  AND workspace_pk = $2
+RETURNING flag_map AS object;


### PR DESCRIPTION
Add a luminork endpoint (`/v1/w/{workspace_id}/user/set_ai_agent_executed`) to set a flag that indicates the user has used the AI agent once. 

Thread it to the auth store in web. Make that change reactive with a websocket event

#### Out of Scope:

There'll be another PR that uses this data on the MCP and the frontend

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Run system, make sure web ui still works, hit new endpoint on luminork, check if the reconnect endpoint has the flags data 
