### PR TITLE
feat: Remove all parents and socket connections in migration

### DIFF
--- a/lib/dal/src/attribute/prototype.rs
+++ b/lib/dal/src/attribute/prototype.rs
@@ -514,6 +514,24 @@ impl AttributePrototype {
         )
     }
 
+    // If this is a prototype for a prop, returns the PropId. Otherwise, returns None.
+    pub async fn prop_id(
+        ctx: &DalContext,
+        apa_id: AttributePrototypeId,
+    ) -> AttributePrototypeResult<Option<PropId>> {
+        let workspace_snapshot = ctx.workspace_snapshot()?;
+        if let Some(for_id) = workspace_snapshot
+            .source_opt(apa_id, EdgeWeightKindDiscriminants::Prototype)
+            .await?
+        {
+            if let NodeWeight::Prop(node) = workspace_snapshot.get_node_weight(for_id).await? {
+                return Ok(Some(node.id().into()));
+            }
+        }
+
+        Ok(None)
+    }
+
     /// If this prototype is defined at the component level, it will have an incoming edge from the
     /// AttributeValue for which it is the prototype. Otherwise this will return None, indicating a
     /// prototype defined at the schema variant level (which has no attribute value)

--- a/lib/dal/src/attribute/prototype/argument.rs
+++ b/lib/dal/src/attribute/prototype/argument.rs
@@ -584,6 +584,22 @@ impl AttributePrototypeArgument {
         }
     }
 
+    pub async fn list_references_to_value_source(
+        ctx: &DalContext,
+        value_source_id: impl Into<Ulid> + Into<ValueSource>,
+    ) -> AttributePrototypeArgumentResult<Vec<AttributePrototypeArgumentId>> {
+        Ok(ctx
+            .workspace_snapshot()?
+            .incoming_sources_for_edge_weight_kind(
+                value_source_id,
+                EdgeWeightKind::PrototypeArgumentValue,
+            )
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
     pub async fn prototype_id(
         ctx: &DalContext,
         attribute_prototype_argument_id: AttributePrototypeArgumentId,

--- a/lib/dal/src/workspace_snapshot/graph/validator/connections.rs
+++ b/lib/dal/src/workspace_snapshot/graph/validator/connections.rs
@@ -964,6 +964,7 @@ pub struct ConnectionMigrationSummary {
     pub connections: usize,
     pub migrated: usize,
     pub unmigrateable: usize,
+    pub removed_parents: usize,
 }
 
 /// Sent when a connection migration is run (though it may not actually be migrated; see

--- a/lib/sdf-server/src/service/v2/admin.rs
+++ b/lib/sdf-server/src/service/v2/admin.rs
@@ -100,6 +100,8 @@ pub enum AdminAPIError {
     Component(#[from] dal::component::ComponentError),
     #[error("edda client error: {0}")]
     Edda(#[from] edda_client::ClientError),
+    #[error("frame error: {0}")]
+    Frame(#[from] dal::component::frame::FrameError),
     #[error("func runner error: {0}")]
     FuncRunner(#[from] FuncRunnerError),
     #[error("inferred connection graph error: {0}")]

--- a/lib/sdf-server/src/service/v2/admin/migrate_connections.rs
+++ b/lib/sdf-server/src/service/v2/admin/migrate_connections.rs
@@ -5,6 +5,7 @@ use std::collections::{
 
 use axum::extract::Path;
 use dal::{
+    AttributePrototype,
     AttributeValue,
     ChangeSetId,
     Component,
@@ -16,6 +17,7 @@ use dal::{
         prototype::argument::AttributePrototypeArgument,
         value::subscription::ValueSubscription,
     },
+    component::frame::Frame,
     slow_rt,
     workspace_snapshot::{
         graph::validator::connections::{
@@ -73,28 +75,28 @@ pub async fn migrate_connections_async(
     parent_span: Span,
     dry_run: bool,
 ) -> () {
-    let span = Span::current();
-    span.record("si.change_set.id", ctx.change_set_id().to_string());
-    span.record(
-        "si.workspace.id",
-        ctx.workspace_pk().unwrap_or_default().to_string(),
-    );
-
     // Capture a summary even if we fail, so we can report what we *did* do.
     let mut summary = ConnectionMigrationSummary {
         connections: 0,
         migrated: 0,
         unmigrateable: 0,
+        removed_parents: 0,
     };
     let err = migrate_connections_async_fallible(ctx, dry_run, &mut summary)
         .await
         .err();
 
-    // Report state in span, WsEvent and Posthog event.
-    span.record("connections", summary.connections);
-    span.record("migrated", summary.migrated);
-    span.record("unmigrateable", summary.unmigrateable);
-    span.record("error", err.is_some());
+    // Report summary in tracing, WsEvent and Posthog event.
+    info!(
+        si.workspace.id = ctx.workspace_pk().unwrap_or_default().to_string(),
+        si.change_set.id = ctx.change_set_id().to_string(),
+        dry_run,
+        connections = summary.connections,
+        migrated = summary.migrated,
+        unmigrateable = summary.unmigrateable,
+        error = err.is_some(),
+        "Migration summary"
+    );
     tracker.track(
         ctx,
         if dry_run {
@@ -140,7 +142,8 @@ async fn migrate_connections_async_fallible(
     let connections = get_connection_migrations(ctx).await?;
     summary.connections = connections.len();
 
-    // Migrate.
+    // Remove remaining connections, and replace anything that couldn't be migrated with its
+    // static value.
     let mut migrations = Vec::with_capacity(connections.len());
     for mut connection in connections {
         let migrated = match migrate_connection(ctx, &connection).await {
@@ -210,6 +213,20 @@ async fn migrate_connections_async_fallible(
         ctx.commit().await?;
     }
 
+    // Remove all parentage everywhere
+    for component in ctx.workspace_snapshot()?.nodes().await? {
+        let component_id = component.id().into();
+        if Component::get_parent_by_id(ctx, component_id)
+            .await?
+            .is_some()
+        {
+            let component_title = Component::fmt_title(ctx, component_id).await;
+            info!(component = component_title, "remove_parent");
+            Frame::orphan_child(ctx, component_id).await?;
+            summary.removed_parents += 1;
+        }
+    }
+
     Ok(())
 }
 
@@ -244,34 +261,22 @@ async fn migrate_connection(
     ctx: &DalContext,
     migration: &ConnectionMigration,
 ) -> AdminAPIResult<Option<bool>> {
-    match &migration.issue {
-        // If there's no issue, we can migrate.
-        None => {}
-        // We can migrate schema mismatches by removing the socket connection.
-        // (We check migration.prop_connections to make sure we won't accidentally create a new
-        // connection.)
-        Some(
-            ConnectionUnmigrateableBecause::DestinationSocketSchemaMismatch
-            | ConnectionUnmigrateableBecause::SourceSocketSchemaMismatch,
-        ) if migration.prop_connections.is_empty() => {}
-        // If there's an issue, we can't migrate.
-        Some(_) => {
-            // If it's an inferred connection, we still want to make it explicit! No more
-            // inferred connections.
-            if migration.explicit_connection_id.is_none() {
-                info!("Making inferred socket connection explicit due to issues");
-            }
-            return Ok(None);
-        }
-    }
-
     let mut did_something = false;
-    for prop_connection in &migration.prop_connections {
-        if add_prop_connection(ctx, prop_connection).await? {
-            did_something = true;
+    match &migration.issue {
+        // If there is no migration issue, create the prop connection
+        None => {
+            for prop_connection in &migration.prop_connections {
+                if add_prop_connection(ctx, prop_connection).await? {
+                    did_something = true;
+                }
+            }
+        }
+        // If there was an issue, freeze connection values (because we're going to
+        // remove the socket connection no matter what)
+        Some(_) => {
+            freeze_connection_values(ctx, &migration.socket_connection).await?;
         }
     }
-
     if remove_socket_connection(
         ctx,
         migration.explicit_connection_id,
@@ -281,7 +286,6 @@ async fn migrate_connection(
     {
         did_something = true;
     }
-
     Ok(Some(did_something))
 }
 
@@ -323,38 +327,80 @@ async fn add_prop_connection(
     Ok(true)
 }
 
-/// Remove the existing socket connection (unless it was inferred, in which case there isn't one)
+// Look at the target socket, and follow it to any props, and replace their values with
+// their current static value if they haven't already been set (which will happen if it was
+// unmigrateable).
+// (If we already migrated something, it will have its value set!)
+async fn freeze_connection_values(
+    ctx: &DalContext,
+    socket_connection: &Option<SocketConnection>,
+) -> AdminAPIResult<bool> {
+    let mut did_something = false;
+
+    if let &Some(SocketConnection {
+        to: (to_component_id, to_socket_id),
+        ..
+    }) = socket_connection
+    {
+        for apa_id in
+            AttributePrototypeArgument::list_references_to_value_source(ctx, to_socket_id).await?
+        {
+            let prototype_id = AttributePrototypeArgument::prototype_id(ctx, apa_id).await?;
+            if let Some(prop_id) = AttributePrototype::prop_id(ctx, prototype_id).await? {
+                let av_id =
+                    Component::attribute_value_for_prop_id(ctx, to_component_id, prop_id).await?;
+                // Only set its value if it isn't already set!
+                if AttributeValue::component_prototype_id(ctx, av_id)
+                    .await?
+                    .is_none()
+                {
+                    // Pull the current value from the AV, and set it explicitly to that value
+                    // so it remains the same, but doesn't rely on the connection anymore
+                    let value = AttributeValue::view(ctx, av_id).await?;
+                    AttributeValue::update(ctx, av_id, value).await?;
+                    did_something = true;
+                }
+            }
+        }
+    }
+
+    Ok(did_something)
+}
+
+/// Remove the existing socket connection, and replace any target props' values with their
+/// static value.
 async fn remove_socket_connection(
     ctx: &DalContext,
     explicit_connection_id: Option<AttributePrototypeArgumentId>,
     socket_connection: &Option<SocketConnection>,
 ) -> AdminAPIResult<bool> {
-    // We don't remove inferred connections
-    let Some(explicit_connection_id) = explicit_connection_id else {
-        return Ok(false);
-    };
+    // Remove the connection (unless it's inferred, in which case there isn't one)
+    let mut did_something = false;
 
-    // Remove the connection
-    AttributePrototypeArgument::remove(ctx, explicit_connection_id).await?;
+    if let Some(explicit_connection_id) = explicit_connection_id {
+        AttributePrototypeArgument::remove(ctx, explicit_connection_id).await?;
 
-    // Send the WsEvent
-    if let &Some(SocketConnection {
-        from: (from_component_id, from_socket_id),
-        to: (to_component_id, to_socket_id),
-    }) = socket_connection
-    {
         // Send the WsEvent
-        WsEvent::connection_deleted(
-            ctx,
-            from_component_id,
-            to_component_id,
-            from_socket_id,
-            to_socket_id,
-        )
-        .await?
-        .publish_on_commit(ctx)
-        .await?;
+        if let &Some(SocketConnection {
+            from: (from_component_id, from_socket_id),
+            to: (to_component_id, to_socket_id),
+        }) = socket_connection
+        {
+            // Send the WsEvent
+            WsEvent::connection_deleted(
+                ctx,
+                from_component_id,
+                to_component_id,
+                from_socket_id,
+                to_socket_id,
+            )
+            .await?
+            .publish_on_commit(ctx)
+            .await?;
+        }
+
+        did_something = true;
     }
 
-    Ok(true)
+    Ok(did_something)
 }


### PR DESCRIPTION
This removes all remaining socket connections (if it can't migrate, it just sets its static value), as well as parents.

## How was it tested?

This is entirely local to the admin-only `/migrate_connections` endpoint, so it won't affect anything unless that's run. Plan currently is to test it in dry runs against workspaces that actually have parents and socket connections.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMW9hZWtjdWduZGR2dDZqMjBmeTFxMDR2Z2xpY2EwYTRidTZ2OTZoaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/UJikARnGkrxmUv5DHk/giphy-downsized-medium.gif"/>