### PR TITLE
feat(si-mcp-server): Fixup MCP Server to capture shutdown events

### DIFF
--- a/bin/si-mcp-server/src/cli.ts
+++ b/bin/si-mcp-server/src/cli.ts
@@ -9,10 +9,7 @@ export async function run() {
     .name("si-mcp-server")
     .version("0.1.0")
     .description("MCP Server for System Initiative")
-    .globalEnv(
-      "SI_API_TOKEN=<string>",
-      "The System Initiative API Token",
-    )
+    .globalEnv("SI_API_TOKEN=<string>", "The System Initiative API Token")
     .globalEnv(
       "SI_WORKSPACE_ID=<string>",
       "The System Initiative Workspace to connect the MCP Server to",
@@ -25,15 +22,51 @@ export async function run() {
       command.showHelp();
       Deno.exit(1);
     })
-    .command(
-      "stdio",
-      "Start the SI MCP Server over the stdio transport",
-    )
+    .command("stdio", "Start the SI MCP Server over the stdio transport")
     .action(async () => {
       await analytics.trackServerStart();
       await setAiAgentUserFlag();
+
       const server = createServer();
-      await start_stdio(server);
+
+      let ended = false;
+      const shutdown = async (reason: string, exitCode: number | null = 0) => {
+        if (ended) return;
+        ended = true;
+        console.log("END EVENT:", reason);
+        try {
+          analytics.trackServerEnd();
+        } catch (_err) {
+          // ignore
+        }
+
+        // This is a sleep to let the events flush before we shut down the process
+        await new Promise((r) => setTimeout(r, 25));
+        if (exitCode !== null) Deno.exit(exitCode);
+      };
+
+      const onSigInt = () => {
+        shutdown("SIGINT", 0);
+      };
+      const onSigTerm = () => {
+        shutdown("SIGTERM", 0);
+      };
+      Deno.addSignalListener("SIGINT", onSigInt);
+      Deno.addSignalListener("SIGTERM", onSigTerm);
+
+      try {
+        await start_stdio(server);
+        await shutdown("transport_closed", null);
+      } catch (err: unknown) {
+        const name =
+          err instanceof Error
+            ? err.name
+            : ((err as { name?: string })?.name ?? "unknown");
+        await shutdown(`uncaught_error:${name}`, 1);
+      } finally {
+        Deno.removeSignalListener("SIGINT", onSigInt);
+        Deno.removeSignalListener("SIGTERM", onSigTerm);
+      }
     });
 
   await command.parse(Deno.args);

--- a/bin/si-mcp-server/src/stdio_transport.ts
+++ b/bin/si-mcp-server/src/stdio_transport.ts
@@ -2,11 +2,35 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logger } from "./logger.ts";
 
-export async function start_stdio(server: McpServer) {
+function deferred<T>() {
+  let resolve!: (v: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const p = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return Object.assign(p, { resolve, reject });
+}
+
+export async function start_stdio(server: McpServer): Promise<void> {
   const transport = new StdioServerTransport();
+
+  const closed = deferred<void>();
+  const realClose = transport.close.bind(transport);
+
+  transport.close = async () => {
+    try {
+      await realClose();
+    } finally {
+      closed.resolve();
+    }
+  };
+
   try {
     await server.connect(transport);
     logger.info("System Initiative MCP server started");
+
+    await closed;
   } catch (error) {
     logger.error(`Error starting mcp server: ${error}`);
     Deno.exit(2);


### PR DESCRIPTION
This allows us to send the correct shutdown events what we need to take care of

<img width="424" height="187" alt="Screenshot 2025-09-01 at 22 50 58" src="https://github.com/user-attachments/assets/94a1f027-c2fd-4893-86b4-5fffee84d0aa" />


This turns start_stdio into a long-running promise that only resolves when the stdio transport ends. It does this by hijacking the transport’s close() method to trigger a promise you’re awaiting. That’s what keeps the CLI loop alive until the server is truly shutting down.