### PR TITLE
feat(luminork): adding the authoring endpoints for Luminork

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -108,6 +108,10 @@ pub use funcs::{
     FuncsResult,
     get_func::GetFuncV1Response,
     get_func_run::GetFuncRunV1Response,
+    update_func::{
+        UpdateFuncV1Request,
+        UpdateFuncV1Response,
+    },
 };
 pub use management_funcs::{
     ManagementFuncJobStateV1RequestPath,
@@ -122,11 +126,38 @@ pub use schemas::{
     SchemaError,
     SchemaV1RequestPath,
     SchemaVariantV1RequestPath,
+    create_action::{
+        CreateVariantActionFuncV1Request,
+        CreateVariantActionFuncV1Response,
+    },
+    // create_attribute::{
+    //     CreateVariantAttributeFuncV1Request,
+    //     CreateVariantAttributeFuncV1Response,
+    // },
+    create_authentication::{
+        CreateVariantAuthenticationFuncV1Request,
+        CreateVariantAuthenticationFuncV1Response,
+    },
+    create_codegen::{
+        CreateVariantCodegenFuncV1Request,
+        CreateVariantCodegenFuncV1Response,
+    },
+    create_management::{
+        CreateVariantManagementFuncV1Request,
+        CreateVariantManagementFuncV1Response,
+    },
+    create_qualification::{
+        CreateVariantQualificationFuncV1Request,
+        CreateVariantQualificationFuncV1Response,
+    },
+    create_schema::CreateSchemaV1Request,
     find_schema::{
         FindSchemaV1Params,
         FindSchemaV1Response,
     },
     list_schemas::ListSchemaV1Response,
+    unlock_schema::UnlockedSchemaV1Response,
+    // update_schema_variant::UpdateSchemaVariantV1Request,
 };
 pub use workspaces::WorkspaceError;
 
@@ -176,8 +207,18 @@ pub use crate::api_types::func_run::v1::{
         schemas::get_schema::get_schema,
         schemas::get_variant::get_variant,
         schemas::get_default_variant::get_default_variant,
+        schemas::create_schema::create_schema,
+        schemas::unlock_schema::unlock_schema,
+        schemas::create_action::create_variant_action,
+        // schemas::create_attribute::create_variant_attribute,
+        schemas::create_authentication::create_variant_authentication,
+        schemas::create_qualification::create_variant_qualification,
+        schemas::create_codegen::create_variant_codegen,
+        schemas::create_management::create_variant_management,
+        // schemas::update_schema_variant::update_schema_variant,
         funcs::get_func_run::get_func_run,
         funcs::get_func::get_func,
+        funcs::update_func::update_func,
         management_funcs::get_management_func_run_state::get_management_func_run_state,
         actions::cancel_action::cancel_action,
         actions::retry_action::retry_action,
@@ -248,6 +289,8 @@ pub use crate::api_types::func_run::v1::{
             OutputLineViewV1,
             GetFuncV1Response,
             GetFuncRunV1Response,
+            UpdateFuncV1Request,
+            UpdateFuncV1Response,
             PropSchemaV1,
             CancelActionV1Response,
             RetryActionV1Response,
@@ -258,6 +301,21 @@ pub use crate::api_types::func_run::v1::{
             FindSchemaV1Response,
             GetManagementFuncJobStateV1Response,
             ManagementFuncJobStateV1RequestPath,
+            CreateVariantActionFuncV1Request,
+            CreateVariantActionFuncV1Response,
+            // CreateVariantAttributeFuncV1Request,
+            // CreateVariantActionFuncV1Response,
+            CreateVariantAuthenticationFuncV1Request,
+            CreateVariantAuthenticationFuncV1Response,
+            CreateVariantQualificationFuncV1Request,
+            CreateVariantQualificationFuncV1Response,
+            CreateSchemaV1Request,
+            UnlockedSchemaV1Response,
+            CreateVariantCodegenFuncV1Request,
+            CreateVariantCodegenFuncV1Response,
+            CreateVariantManagementFuncV1Request,
+            CreateVariantManagementFuncV1Response,
+            // UpdateSchemaVariantV1Request,
         )
     ),
     tags(

--- a/lib/luminork-server/src/service/v1/funcs/update_func.rs
+++ b/lib/luminork-server/src/service/v1/funcs/update_func.rs
@@ -1,0 +1,130 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    Func,
+    func::authoring::FuncAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    FuncV1RequestPath,
+    FuncsError,
+    FuncsResult,
+};
+
+#[utoipa::path(
+    put,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/funcs/{func_id}",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("func_id" = String, Path, description = "Func identifier"),
+    ),
+    summary = "Update a func",
+    tag = "funcs",
+    request_body = UpdateFuncV1Request,
+    responses(
+        (status = 200, description = "Function successfully updated", body = UpdateFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Function not found"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn update_func(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(FuncV1RequestPath { func_id }): Path<FuncV1RequestPath>,
+    payload: Result<Json<UpdateFuncV1Request>, axum::extract::rejection::JsonRejection>,
+) -> FuncsResult<Json<UpdateFuncV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(FuncsError::NotPermittedOnHead);
+    }
+
+    let func = Func::get_by_id(ctx, func_id).await?;
+
+    if func.is_locked {
+        return Err(FuncsError::LockedFunc(func_id));
+    }
+
+    if payload.display_name.clone() != func.display_name || payload.description != func.description
+    {
+        let updated_func = FuncAuthoringClient::update_func(
+            ctx,
+            func_id,
+            payload.display_name.clone(),
+            payload.description,
+        )
+        .await?;
+
+        ctx.write_audit_log(
+            AuditLogKind::UpdateFuncMetadata {
+                func_id,
+                old_display_name: func.display_name,
+                new_display_name: updated_func.display_name.clone(),
+                old_description: func.description,
+                new_description: updated_func.description.clone(),
+            },
+            updated_func.name.clone(),
+        )
+        .await?;
+
+        tracker.track(
+            ctx,
+            "api_update_func",
+            serde_json::json!({
+                "func_id": func_id,
+                "func_name": updated_func.name.clone(),
+                "func_kind": updated_func.kind.clone(),
+            }),
+        );
+    }
+
+    FuncAuthoringClient::save_code(ctx, func_id, payload.code).await?;
+    tracker.track(
+        ctx,
+        "api_save_func_code",
+        serde_json::json!({
+            "func_id": func_id,
+            "func_name": payload.display_name.clone(),
+            "func_kind": func.kind.clone(),
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(UpdateFuncV1Response { success: true }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateFuncV1Request {
+    #[schema(value_type = String, example = "Updated Display Name")]
+    pub display_name: Option<String>,
+    #[schema(value_type = String, example = "Updated Description")]
+    pub description: Option<String>,
+    #[schema(value_type = String, example = "<!-- String escaped Typescript code here -->")]
+    pub code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateFuncV1Response {
+    #[schema(value_type = bool)]
+    pub success: bool,
+}

--- a/lib/luminork-server/src/service/v1/schemas/create_action.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_action.rs
@@ -1,0 +1,142 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    FuncId,
+    SchemaVariant,
+    action::prototype::ActionKind,
+    func::authoring::FuncAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+    SchemaVariantV1RequestPath,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}/funcs/action",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Create an action function and attach to a schema variant",
+    tag = "schemas",
+    request_body = CreateVariantActionFuncV1Request,
+    responses(
+        (status = 200, description = "Action function successfully created and attached to the variant", body = CreateVariantActionFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_variant_action(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaVariantV1RequestPath {
+        schema_id: _,
+        schema_variant_id,
+    }): Path<SchemaVariantV1RequestPath>,
+    payload: Result<
+        Json<CreateVariantActionFuncV1Request>,
+        axum::extract::rejection::JsonRejection,
+    >,
+) -> SchemaResult<Json<CreateVariantActionFuncV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+    if schema_variant.is_locked() {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    let func = FuncAuthoringClient::create_new_action_func(
+        ctx,
+        Some(payload.name),
+        payload.kind,
+        schema_variant_id,
+    )
+    .await?;
+
+    FuncAuthoringClient::update_func(ctx, func.id, payload.display_name, payload.description)
+        .await?;
+
+    FuncAuthoringClient::save_code(ctx, func.id, payload.code).await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateFunc {
+            func_display_name: func.display_name.clone(),
+            func_kind: func.kind.into(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+    ctx.write_audit_log(
+        AuditLogKind::AttachActionFunc {
+            func_id: func.id,
+            func_display_name: func.display_name.clone(),
+            schema_variant_id: Some(schema_variant_id),
+            component_id: None,
+            action_kind: Some(payload.kind.into()),
+        },
+        func.name.clone(),
+    )
+    .await?;
+
+    tracker.track(
+        ctx,
+        "api_create_action_func",
+        serde_json::json!({
+            "func_id": func.id,
+            "func_name": func.name.to_owned(),
+            "schema_variant_id": schema_variant_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(CreateVariantActionFuncV1Response { func_id: func.id }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantActionFuncV1Request {
+    #[schema(value_type = String, example = "awsEC2InstanceCreate")]
+    pub name: String,
+    #[schema(value_type = String, example = "Create EC2 Instance")]
+    pub display_name: Option<String>,
+    #[schema(value_type = String, example = "Creates an EC2 Instance")]
+    pub description: Option<String>,
+    #[schema(value_type = String, example = "Create", pattern = "^(Create|Destroy|Manual|Refresh|Update)$")]
+    pub kind: ActionKind,
+    #[schema(value_type = String, example = "<!-- String escaped Typescript code here -->")]
+    pub code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantActionFuncV1Response {
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
+    pub func_id: FuncId,
+}

--- a/lib/luminork-server/src/service/v1/schemas/create_attribute.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_attribute.rs
@@ -1,0 +1,60 @@
+use axum::response::Json;
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}/funcs/attribute",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Create an attribute function and attach to a schema variant",
+    tag = "schemas",
+    request_body = CreateVariantAttributeFuncV1Request,
+    responses(
+        (status = 200, description = "Attribute function successfully created and attached to the variant", body = CreateVariantAttributeFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_variant_attribute(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    _tracker: PosthogEventTracker,
+    _payload: Result<
+        Json<CreateVariantAttributeFuncV1Response>,
+        axum::extract::rejection::JsonRejection,
+    >,
+) -> SchemaResult<Json<CreateVariantAttributeFuncV1Response>> {
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+    Ok(Json(CreateVariantAttributeFuncV1Response {}))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantAttributeFuncV1Request {}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantAttributeFuncV1Response {}

--- a/lib/luminork-server/src/service/v1/schemas/create_authentication.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_authentication.rs
@@ -1,0 +1,135 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    FuncId,
+    SchemaVariant,
+    func::authoring::FuncAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+    SchemaVariantV1RequestPath,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}/funcs/authentication",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Create an authentication function and attach to a schema variant",
+    tag = "schemas",
+    request_body = CreateVariantAuthenticationFuncV1Request,
+    responses(
+        (status = 200, description = "Authentication function successfully created and attached to the variant", body = CreateVariantAuthenticationFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_variant_authentication(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaVariantV1RequestPath {
+        schema_id: _,
+        schema_variant_id,
+    }): Path<SchemaVariantV1RequestPath>,
+    payload: Result<
+        Json<CreateVariantAuthenticationFuncV1Request>,
+        axum::extract::rejection::JsonRejection,
+    >,
+) -> SchemaResult<Json<CreateVariantAuthenticationFuncV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+    if schema_variant.is_locked() {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    let func =
+        FuncAuthoringClient::create_new_management_func(ctx, Some(payload.name), schema_variant_id)
+            .await?;
+
+    FuncAuthoringClient::update_func(ctx, func.id, payload.display_name, payload.description)
+        .await?;
+
+    FuncAuthoringClient::save_code(ctx, func.id, payload.code).await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateFunc {
+            func_display_name: func.display_name.clone(),
+            func_kind: func.kind.into(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+    ctx.write_audit_log(
+        AuditLogKind::AttachAuthFunc {
+            func_id: func.id,
+            func_display_name: func.display_name.clone(),
+            schema_variant_id: Some(schema_variant_id),
+        },
+        func.name.clone(),
+    )
+    .await?;
+
+    tracker.track(
+        ctx,
+        "api_create_authentication_func",
+        serde_json::json!({
+            "func_id": func.id,
+            "func_name": func.name.to_owned(),
+            "schema_variant_id": schema_variant_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(CreateVariantAuthenticationFuncV1Response {
+        func_id: func.id,
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantAuthenticationFuncV1Request {
+    #[schema(value_type = String, example = "awsSetCredentials")]
+    pub name: String,
+    #[schema(value_type = String, example = "Set AWS credentials")]
+    pub display_name: Option<String>,
+    #[schema(value_type = String, example = "Function to manage AWS Credentials")]
+    pub description: Option<String>,
+    #[schema(value_type = String, example = "<!-- String escaped Typescript code here -->")]
+    pub code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantAuthenticationFuncV1Response {
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
+    pub func_id: FuncId,
+}

--- a/lib/luminork-server/src/service/v1/schemas/create_codegen.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_codegen.rs
@@ -1,0 +1,160 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    FuncId,
+    SchemaVariant,
+    func::{
+        authoring::FuncAuthoringClient,
+        binding::EventualParent,
+    },
+    schema::variant::leaves::{
+        LeafInputLocation,
+        LeafKind,
+    },
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+    SchemaVariantV1RequestPath,
+    leaf_input_locations_schema,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}/funcs/codegen",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Create a codegen function and attach to a schema variant",
+    tag = "schemas",
+    request_body = CreateVariantCodegenFuncV1Request,
+    responses(
+        (status = 200, description = "Codegen function successfully created and attached to the variant", body = CreateVariantCodegenFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_variant_codegen(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaVariantV1RequestPath {
+        schema_id: _,
+        schema_variant_id,
+    }): Path<SchemaVariantV1RequestPath>,
+    payload: Result<
+        Json<CreateVariantCodegenFuncV1Request>,
+        axum::extract::rejection::JsonRejection,
+    >,
+) -> SchemaResult<Json<CreateVariantCodegenFuncV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+    if schema_variant.is_locked() {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    let mut locations = payload.locations;
+    if locations.is_empty() {
+        locations.push(LeafInputLocation::Domain);
+    }
+
+    let func = FuncAuthoringClient::create_new_leaf_func(
+        ctx,
+        Some(payload.name),
+        LeafKind::CodeGeneration,
+        EventualParent::SchemaVariant(schema_variant_id),
+        &locations,
+    )
+    .await?;
+
+    FuncAuthoringClient::update_func(ctx, func.id, payload.display_name, payload.description)
+        .await?;
+
+    FuncAuthoringClient::save_code(ctx, func.id, payload.code).await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateFunc {
+            func_display_name: func.display_name.clone(),
+            func_kind: func.kind.into(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+    ctx.write_audit_log(
+        AuditLogKind::AttachCodeGenFunc {
+            func_id: func.id,
+            func_display_name: func.display_name.clone(),
+            schema_variant_id: Some(schema_variant_id),
+            component_id: None,
+            subject_name: schema_variant.display_name().to_string(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+
+    tracker.track(
+        ctx,
+        "api_create_codegen_func",
+        serde_json::json!({
+            "func_id": func.id,
+            "func_name": func.name.to_owned(),
+            "schema_variant_id": schema_variant_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(CreateVariantCodegenFuncV1Response {
+        func_id: func.id,
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantCodegenFuncV1Request {
+    #[schema(value_type = String, example = "awsEC2InstanceGenerateCode")]
+    pub name: String,
+    #[schema(value_type = String, example = "Generate EC2 Instance Create Payload")]
+    pub display_name: Option<String>,
+    #[schema(value_type = String, example = "Generates the payload required for creating an EC2 instance")]
+    pub description: Option<String>,
+    #[schema(
+            example = json!(["code", "resource"]),
+            schema_with = leaf_input_locations_schema
+        )]
+    pub locations: Vec<LeafInputLocation>,
+    #[schema(value_type = String, example = "<!-- String escaped Typescript code here -->")]
+    pub code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantCodegenFuncV1Response {
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
+    pub func_id: FuncId,
+}

--- a/lib/luminork-server/src/service/v1/schemas/create_management.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_management.rs
@@ -1,0 +1,138 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    FuncId,
+    SchemaVariant,
+    func::authoring::FuncAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+    SchemaVariantV1RequestPath,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}/funcs/management",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Create a management function and attach to a schema variant",
+    tag = "schemas",
+    request_body = CreateVariantManagementFuncV1Request,
+    responses(
+        (status = 200, description = "Management function successfully created and attached to the variant", body = CreateVariantManagementFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_variant_management(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaVariantV1RequestPath {
+        schema_id: _,
+        schema_variant_id,
+    }): Path<SchemaVariantV1RequestPath>,
+    payload: Result<
+        Json<CreateVariantManagementFuncV1Request>,
+        axum::extract::rejection::JsonRejection,
+    >,
+) -> SchemaResult<Json<CreateVariantManagementFuncV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+    if schema_variant.is_locked() {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    let func =
+        FuncAuthoringClient::create_new_management_func(ctx, Some(payload.name), schema_variant_id)
+            .await?;
+
+    FuncAuthoringClient::update_func(ctx, func.id, payload.display_name, payload.description)
+        .await?;
+
+    FuncAuthoringClient::save_code(ctx, func.id, payload.code).await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateFunc {
+            func_display_name: func.display_name.clone(),
+            func_kind: func.kind.into(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::AttachManagementFunc {
+            func_id: func.id,
+            func_display_name: func.display_name.clone(),
+            schema_variant_id: Some(schema_variant_id),
+            component_id: None,
+            subject_name: schema_variant.display_name().to_string(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+
+    tracker.track(
+        ctx,
+        "api_create_management_func",
+        serde_json::json!({
+            "func_id": func.id,
+            "func_name": func.name.to_owned(),
+            "schema_variant_id": schema_variant_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(CreateVariantManagementFuncV1Response {
+        func_id: func.id,
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantManagementFuncV1Request {
+    #[schema(value_type = String, example = "awsCreateMyVpc")]
+    pub name: String,
+    #[schema(value_type = String, example = "Manage my VPC Components")]
+    pub display_name: Option<String>,
+    #[schema(value_type = String, example = "Manages a collection of VPC components and their relationships")]
+    pub description: Option<String>,
+    #[schema(value_type = String, example = "<!-- String escaped Typescript code here -->")]
+    pub code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantManagementFuncV1Response {
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
+    pub func_id: FuncId,
+}

--- a/lib/luminork-server/src/service/v1/schemas/create_qualification.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_qualification.rs
@@ -1,0 +1,161 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    FuncId,
+    SchemaVariant,
+    func::{
+        authoring::FuncAuthoringClient,
+        binding::EventualParent,
+    },
+    schema::variant::leaves::{
+        LeafInputLocation,
+        LeafKind,
+    },
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+    SchemaVariantV1RequestPath,
+    leaf_input_locations_schema,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}/funcs/qualification",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Create a qualification and attach to a schema variant",
+    tag = "schemas",
+    request_body = CreateVariantQualificationFuncV1Request,
+    responses(
+        (status = 200, description = "Qualification successfully created and attached to the variant", body = CreateVariantQualificationFuncV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_variant_qualification(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaVariantV1RequestPath {
+        schema_id: _,
+        schema_variant_id,
+    }): Path<SchemaVariantV1RequestPath>,
+    payload: Result<
+        Json<CreateVariantQualificationFuncV1Request>,
+        axum::extract::rejection::JsonRejection,
+    >,
+) -> SchemaResult<Json<CreateVariantQualificationFuncV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+    if schema_variant.is_locked() {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    let mut locations = payload.locations;
+    if locations.is_empty() {
+        locations.push(LeafInputLocation::Domain);
+        locations.push(LeafInputLocation::Code);
+    }
+
+    let func = FuncAuthoringClient::create_new_leaf_func(
+        ctx,
+        Some(payload.name),
+        LeafKind::Qualification,
+        EventualParent::SchemaVariant(schema_variant_id),
+        &locations,
+    )
+    .await?;
+
+    FuncAuthoringClient::update_func(ctx, func.id, payload.display_name, payload.description)
+        .await?;
+
+    FuncAuthoringClient::save_code(ctx, func.id, payload.code).await?;
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateFunc {
+            func_display_name: func.display_name.clone(),
+            func_kind: func.kind.into(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+    ctx.write_audit_log(
+        AuditLogKind::AttachQualificationFunc {
+            func_id: func.id,
+            func_display_name: func.display_name.clone(),
+            schema_variant_id: Some(schema_variant_id),
+            component_id: None,
+            subject_name: schema_variant.display_name().to_string(),
+        },
+        func.name.clone(),
+    )
+    .await?;
+
+    tracker.track(
+        ctx,
+        "api_create_qualification_func",
+        serde_json::json!({
+            "func_id": func.id,
+            "func_name": func.name.to_owned(),
+            "schema_variant_id": schema_variant_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(CreateVariantQualificationFuncV1Response {
+        func_id: func.id,
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantQualificationFuncV1Request {
+    #[schema(value_type = String, example = "awsEC2InstanceCreate")]
+    pub name: String,
+    #[schema(value_type = String, example = "Create EC2 Instance")]
+    pub display_name: Option<String>,
+    #[schema(value_type = String, example = "Creates an EC2 Instance")]
+    pub description: Option<String>,
+    #[schema(
+            example = json!(["code", "resource"]),
+            schema_with = leaf_input_locations_schema
+        )]
+    pub locations: Vec<LeafInputLocation>,
+    #[schema(value_type = String, example = "<!-- String escaped Typescript code here -->")]
+    pub code: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVariantQualificationFuncV1Response {
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
+    pub func_id: FuncId,
+}

--- a/lib/luminork-server/src/service/v1/schemas/create_schema.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_schema.rs
@@ -1,0 +1,107 @@
+use axum::response::Json;
+use dal::{
+    SchemaVariant,
+    schema::variant::authoring::VariantAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    GetSchemaV1Response,
+    SchemaError,
+    SchemaResult,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+    ),
+    tag = "schemas",
+    request_body = CreateSchemaV1Request,
+    summary = "Create a schema and it's default variant",
+    responses(
+        (status = 200, description = "Schema created successfully", body = GetSchemaV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 422, description = "Validation error - Invalid request data", body = crate::service::v1::common::ApiError),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn create_schema(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    payload: Result<Json<CreateSchemaV1Request>, axum::extract::rejection::JsonRejection>,
+) -> SchemaResult<Json<GetSchemaV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let created_schema_variant = VariantAuthoringClient::create_schema_and_variant_from_code(
+        ctx,
+        payload.name.clone(),
+        payload.description,
+        payload.link,
+        payload.category.unwrap_or("Custom".to_string()),
+        payload.color.unwrap_or("#000000".to_string()),
+        payload.code.clone(),
+    )
+    .await?;
+
+    let schema = created_schema_variant.schema(ctx).await?;
+    let variants = SchemaVariant::list_for_schema(ctx, schema.id()).await?;
+
+    tracker.track(
+        ctx,
+        "api_create_schema",
+        json!({
+            "schema_id": schema.id(),
+            "schema_variant_id": created_schema_variant.id,
+            "display_name": created_schema_variant.display_name(),
+            "category": created_schema_variant.category(),
+        }),
+    );
+
+    ctx.write_audit_log(
+        AuditLogKind::CreateSchemaVariant {
+            schema_id: schema.id(),
+            schema_variant_id: created_schema_variant.id,
+        },
+        created_schema_variant.display_name().to_string(),
+    )
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(GetSchemaV1Response {
+        name: payload.name,
+        default_variant_id: created_schema_variant.id,
+        variant_ids: variants.into_iter().map(|v| v.id).collect(),
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSchemaV1Request {
+    pub name: String,
+    pub description: Option<String>,
+    pub link: Option<String>,
+    pub category: Option<String>,
+    pub color: Option<String>,
+    pub code: String,
+}

--- a/lib/luminork-server/src/service/v1/schemas/unlock_schema.rs
+++ b/lib/luminork-server/src/service/v1/schemas/unlock_schema.rs
@@ -1,0 +1,109 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    Schema,
+    SchemaId,
+    SchemaVariant,
+    SchemaVariantId,
+    schema::variant::authoring::VariantAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    SchemaError,
+    SchemaResult,
+    SchemaV1RequestPath,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/unlock",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+    ),
+    tag = "schemas",
+    summary = "Unlocks a schema - if there's already an unlocked variant, then we return that",
+    responses(
+        (status = 200, description = "Schema unlocked successfully", body = UnlockedSchemaV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 422, description = "Validation error - Invalid request data", body = crate::service::v1::common::ApiError),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn unlock_schema(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaV1RequestPath { schema_id }): Path<SchemaV1RequestPath>,
+) -> SchemaResult<Json<UnlockedSchemaV1Response>> {
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema = Schema::get_by_id_opt(ctx, schema_id)
+        .await?
+        .ok_or(SchemaError::SchemaNotFound(schema_id))?;
+
+    let default_variant_id = Schema::default_variant_id(ctx, schema_id).await?;
+    let variants = SchemaVariant::list_for_schema(ctx, schema_id).await?;
+
+    let unlocked_variant_id = match variants.iter().find(|v| !v.is_locked()) {
+        Some(v) => v.id(), // already have one so we will return that unlocked variant id
+        None => {
+            // Otherwise lets create one!
+            let unlocked =
+                VariantAuthoringClient::create_unlocked_variant_copy(ctx, default_variant_id)
+                    .await?;
+            ctx.write_audit_log(
+                AuditLogKind::UnlockSchemaVariant {
+                    schema_variant_id: unlocked.id(),
+                    schema_variant_display_name: unlocked.display_name().to_owned(),
+                },
+                schema.name().to_owned(),
+            )
+            .await?;
+            unlocked.id()
+        }
+    };
+
+    tracker.track(
+        ctx,
+        "api_unlock_schema",
+        json!({
+            "schema_id": schema.id(),
+            "unlocked_variant_id": unlocked_variant_id,
+        }),
+    );
+
+    ctx.commit().await?;
+
+    Ok(Json(UnlockedSchemaV1Response {
+        schema_id,
+        unlocked_variant_id,
+    }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlockedSchemaV1Response {
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
+    pub schema_id: SchemaId,
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q75XY")]
+    pub unlocked_variant_id: SchemaVariantId,
+}

--- a/lib/luminork-server/src/service/v1/schemas/update_schema_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/update_schema_variant.rs
@@ -1,0 +1,169 @@
+use axum::{
+    extract::Path,
+    response::Json,
+};
+use dal::{
+    Schema,
+    SchemaVariant,
+    schema::variant::authoring::VariantAuthoringClient,
+};
+use sdf_extract::{
+    PosthogEventTracker,
+    change_set::ChangeSetDalContext,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use si_events::audit_log::AuditLogKind;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::{
+    GetSchemaVariantV1Response,
+    SchemaError,
+    SchemaResult,
+    SchemaVariantV1RequestPath,
+};
+
+#[utoipa::path(
+    put,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/schemas/{schema_id}/variant/{schema_variant_id}",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("schema_id" = String, Path, description = "Schema identifier"),
+        ("schema_variant_id" = String, Path, description = "Schema variant identifier"),
+    ),
+    summary = "Update the schema variant and regenerate",
+    tag = "schemas",
+    request_body = UpdateSchemaVariantV1Request,
+    responses(
+        (status = 200, description = "Schema variant successfully updated", body = GetSchemaVariantV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Schema variant not found"),
+        (status = 412, description = "Schema variant not found for schema"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn update_schema_variant(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    tracker: PosthogEventTracker,
+    Path(SchemaVariantV1RequestPath {
+        schema_id,
+        schema_variant_id,
+    }): Path<SchemaVariantV1RequestPath>,
+    payload: Result<Json<UpdateSchemaVariantV1Request>, axum::extract::rejection::JsonRejection>,
+) -> SchemaResult<Json<GetSchemaVariantV1Response>> {
+    let Json(payload) = payload?;
+
+    if ctx.change_set_id() == ctx.get_workspace_default_change_set_id().await? {
+        return Err(SchemaError::NotPermittedOnHead);
+    }
+
+    let schema_variants = Schema::list_schema_variant_ids(ctx, schema_id).await?;
+    if !schema_variants.contains(&schema_variant_id) {
+        return Err(SchemaError::SchemaVariantNotMemberOfSchema(
+            schema_id,
+            schema_variant_id,
+        ));
+    }
+
+    let variant = SchemaVariant::get_by_id_opt(ctx, schema_variant_id)
+        .await?
+        .ok_or(SchemaError::SchemaVariantNotFound(schema_variant_id))?;
+
+    if variant.is_locked() {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    let schema = Schema::get_by_id(ctx, schema_id).await?;
+
+    let color = payload.color.unwrap_or_else(|| variant.color().to_string());
+
+    VariantAuthoringClient::save_variant_content(
+        ctx,
+        schema_variant_id,
+        schema.name(),
+        payload.name,
+        payload.category,
+        payload.description,
+        payload.link,
+        color,
+        variant.component_type(),
+        Some(payload.code),
+    )
+    .await?;
+
+    let updated_schema_variant_id =
+        VariantAuthoringClient::regenerate_variant(ctx, schema_variant_id).await?;
+
+    // Final check that we updated the correct variant!!
+    if updated_schema_variant_id != schema_variant_id {
+        return Err(SchemaError::LockedVariant(schema_variant_id));
+    }
+
+    tracker.track(
+        ctx,
+        "api_update_variant",
+        json!({
+            "schema_variant_id": schema_variant_id,
+        }),
+    );
+
+    let variant_func_ids: Vec<_> = SchemaVariant::all_func_ids(ctx, default_variant_id)
+        .await?
+        .into_iter()
+        .collect();
+
+    let domain =
+        Prop::find_prop_by_path(ctx, default_variant_id, &RootPropChild::Domain.prop_path())
+            .await
+            .map_err(Box::new)?;
+    let domain_prop_schema = build_prop_schema_tree(ctx, domain.id).await?;
+
+    let response = GetSchemaVariantV1Response {
+        variant_id: variant.id(),
+        display_name: variant.display_name().to_owned(),
+        category: variant.category().to_owned(),
+        color: variant.color().to_owned(),
+        is_locked: variant.is_locked(),
+        description: variant.description(),
+        link: variant.link(),
+        is_default_variant: variant.is_default(ctx).await?,
+    };
+
+    ctx.write_audit_log(
+        AuditLogKind::RegenerateSchemaVariant { schema_variant_id },
+        variant.display_name().to_string(),
+    )
+    .await?;
+
+    ctx.commit().await?;
+
+    Ok(Json(
+        GetSchemaVariantV1Response::assemble(ctx, variant.clone()).await?,
+    ))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateSchemaVariantV1Request {
+    #[schema(value_type = String, example = "AWS Region Validator")]
+    pub name: String,
+    #[schema(value_type = String, example = "Validates if an AWS region exists and is available for use")]
+    pub description: Option<String>,
+    #[schema(value_type = String, example = "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html")]
+    pub link: Option<String>,
+    #[schema(value_type = String, example = "AWS::EC2")]
+    pub category: String,
+    #[schema(value_type = String, example = "#FF5733")]
+    pub color: Option<String>,
+    #[schema(
+        example = "async function main(input: Input): Promise < Output > {\n    if (!input.domain?.region) {\n        return {\n            result: \"failure\",\n            message: \"No Region Name to validate\",\n        };\n    }\n\n    const child = await siExec.waitUntilEnd(\"aws\", [\n        \"ec2\",\n        \"describe-regions\",\n        \"--region-names\",\n        input.domain?.region!,\n        \"--region\",\n        \"us-east-1\",\n    ]);\n\n    if (child.exitCode !== 0) {\n        console.error(child.stderr);\n        return {\n            result: \"failure\",\n            message: \"Error from API\"\n        }\n    }\n\n    const regionDetails = JSON.parse(child.stdout).Regions;\n    if (regionDetails.length === 0 || regionDetails.length > 1) {\n        return {\n            result: \"failure\",\n            message: \"Unable to find Region\"\n        }\n    }\n\n    if (regionDetails[0].OptInStatus === \"not-opted-in\") {\n        return {\n            result: \"failure\",\n            message: \"Region not-opted-in for use\"\n        }\n    }\n\n    return {\n        result: \"success\",\n        message: \"Region is available to use\",\n    };\n}"
+    )]
+    pub code: String,
+}


### PR DESCRIPTION
The following endpoints are available:

* POST /schemas to create a schema and it's variant
* POST /schemas/{schema_id}/unlock
* POST /schemas/{schema_id}/variant/{schema_variant_id}/funcs/action
* POST /schemas/{schema_id}/variant/{schema_variant_id}/funcs/authentication
* POST /schemas/{schema_id}/variant/{schema_variant_id}/funcs/codegen
* POST /schemas/{schema_id}/variant/{schema_variant_id}/funcs/qualification 
* POST /schemas/{schema_id}/variant/{schema_variant_id}/funcs/management
* PUT /funcs/{func_id} to update a func contents