### PR TITLE
fix: incorrect sha for mac rust_dist

### DIFF
--- a/prelude-si/toolchains/rust_distribution.bzl
+++ b/prelude-si/toolchains/rust_distribution.bzl
@@ -17,7 +17,7 @@ _RUST_S3_CHECKSUMS = {
         },
         "darwin": {
             "x86_64": "847e986ec6a9f11c1c48b1e2bd4e623ea92e1a2fd552d43456c8c64d189eaac0",
-            "aarch64": "825a4f3843d6b30b0f1fa875b78e58505f461ddf3ba556b61ba3eb28056870f7",
+            "aarch64": "e04e944504c9bfcd4ff0c1cf52550cce7dace373da130f9a8fef5dbe4e99f334",
         },
     },
     "nightly-2025-04-17": {


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

The incorrect sha was set for mac builds, so the rust toolchain will not download.


## How was it tested?

Verified on my mac.

## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdleXQxZnJ3amd6MzBlMnhpbjIyMjdtbHR4a3EwMXFhMzBiczRsMHR5ZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GDnomdqpSHlIs/giphy.gif"/>