### PR TITLE
fix: ensure git is on path and we promote the correct images for innit

### DIFF
--- a/bin/innit/BUCK
+++ b/bin/innit/BUCK
@@ -27,4 +27,5 @@ docker_image(
         "BUILDKITE_BUILD_ID": ""
     },
     build_deps = ["//bin/innit:innit"],
+    promote_multi_arches = ["amd64"],
 )

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
           cargo
           cargo-sort
           deno
+          git
           makeWrapper
           nodePkgs.pnpm
           nodejs


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Ensure we only build x86 for innit. Add git back to the flake for sanity's sake.

