### PR TITLE
Fix issue with missing name on secret form

### DIFF
--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -258,6 +258,8 @@ const keyApi = useApi();
 
 const wForm = useWatchedForm<Record<string, string>>(
   `component.av.secret.${props.attributeTree.prop?.id}`,
+  false,
+  true,
 );
 const secretForm = wForm.newForm({
   data: secretFormData,

--- a/app/web/src/newhotness/logic_composables/watched_form.ts
+++ b/app/web/src/newhotness/logic_composables/watched_form.ts
@@ -37,7 +37,11 @@ const tracer = trace.getTracer("si-vue");
  * So the user know their form submission worked and we're waiting
  * for updated data
  */
-export const useWatchedForm = <Data>(label: string, resetBlank?: boolean) => {
+export const useWatchedForm = <Data>(
+  label: string,
+  resetBlank?: boolean,
+  disableResetWatcher?: boolean,
+) => {
   /**
    * Lifecycle of `bifrosting`
    *
@@ -138,12 +142,14 @@ export const useWatchedForm = <Data>(label: string, resetBlank?: boolean) => {
 
     // Update form data as data changes
     // im not 100% certain we always want this behavior
-    watch(
-      () => toValue(data),
-      (newData) => {
-        wForm.reset(newData);
-      },
-    );
+    if (!disableResetWatcher) {
+      watch(
+        () => toValue(data),
+        (newData) => {
+          wForm.reset(newData);
+        },
+      );
+    }
 
     return wForm;
   };


### PR DESCRIPTION
This change fixes an issue where the secret form is reset while the user is working within it. This solution is a bandage fix isolated to the secret form and not all forms.