### PR TITLE
fix: set docker images to use bookworm

### DIFF
--- a/bin/edda/Dockerfile
+++ b/bin/edda/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/forklift/Dockerfile
+++ b/bin/forklift/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/innit/BUCK
+++ b/bin/innit/BUCK
@@ -22,9 +22,9 @@ docker_image(
     name = "image",
     image_name = "innit",
     build_args = {
+        "BASE_VERSION": "bookworm",
         "BIN": "innit",
-        "SI_RBE_TOKEN": "",
-        "BUILDKITE_BUILD_ID": ""
+        "SI_RBE_TOKEN": ""
     },
     build_deps = ["//bin/innit:innit"],
     promote_multi_arches = ["amd64"],

--- a/bin/innit/Dockerfile
+++ b/bin/innit/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION=bookworm
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -15,8 +17,6 @@ RUN ARCH=$(uname -m); \
 FROM alpine:3 AS builder
 ARG BIN
 ARG SI_RBE_TOKEN
-ARG BUILDKITE_BUILD_ID
-ARG BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID}
 
 COPY . /workdir
 WORKDIR /workdir
@@ -26,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/innitctl/BUCK
+++ b/bin/innitctl/BUCK
@@ -22,9 +22,9 @@ docker_image(
     name = "image",
     image_name = "innitctl",
     build_args = {
+        "BASE_VERSION": "bookworm",
         "BIN": "innitctl",
-        "SI_RBE_TOKEN": "",
-        "BUILDKITE_BUILD_ID": ""
+        "SI_RBE_TOKEN": ""
     },
     build_deps = ["//bin/innitctl:innitctl"],
     srcs = {

--- a/bin/innitctl/Dockerfile
+++ b/bin/innitctl/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -15,8 +17,6 @@ RUN ARCH=$(uname -m); \
 FROM alpine:3 AS builder
 ARG BIN
 ARG SI_RBE_TOKEN
-ARG BUILDKITE_BUILD_ID
-ARG BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID}
 
 COPY . /workdir
 WORKDIR /workdir
@@ -26,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/luminork/BUCK
+++ b/bin/luminork/BUCK
@@ -28,6 +28,7 @@ docker_image(
     name = "image",
     image_name = "luminork",
     build_args = {
+        "BASE_VERSION": "bookworm",
         "BIN": "luminork",
         "SI_RBE_TOKEN": ""
     },

--- a/bin/luminork/Dockerfile
+++ b/bin/luminork/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/module-index/BUCK
+++ b/bin/module-index/BUCK
@@ -28,9 +28,9 @@ docker_image(
     name = "image",
     image_name = "module-index",
     build_args = {
+        "BASE_VERSION": "bookworm",
         "BIN": "module-index",
-        "SI_RBE_TOKEN": "",
-        "BUILDKITE_BUILD_ID": ""
+        "SI_RBE_TOKEN": ""
     },
     build_deps = ["//bin/module-index:module-index"],
     # TODO(fnichol): revisit post 2025-02-01

--- a/bin/module-index/Dockerfile
+++ b/bin/module-index/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -15,8 +17,6 @@ RUN ARCH=$(uname -m); \
 FROM alpine:3 AS builder
 ARG BIN
 ARG SI_RBE_TOKEN
-ARG BUILDKITE_BUILD_ID
-ARG BUILDKITE_BUILD_ID=${BUILDKITE_BUILD_ID}
 
 COPY . /workdir
 WORKDIR /workdir
@@ -26,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/pinga/Dockerfile
+++ b/bin/pinga/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/rebaser/Dockerfile
+++ b/bin/rebaser/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/sdf/Dockerfile
+++ b/bin/sdf/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 

--- a/bin/veritech/Dockerfile
+++ b/bin/veritech/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_VERSION
+
 FROM alpine:3 AS buck2
 
 RUN apk add --no-cache curl zstd libc6-compat
@@ -24,7 +26,7 @@ COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 RUN buck2 build bin/$BIN:$BIN \
     --out /tmp/local-bin/$BIN
 
-FROM debian:bullseye-slim AS final
+FROM debian:${BASE_VERSION} AS final
 ARG BIN
 ENV BIN=${BIN}
 


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Set the docker images to use bookworm to ensure we match glibc versions


## How was it tested?

CI and deploys will tests


