### PR TITLE
fix: innitctl container permissions incorrect

### DIFF
--- a/bin/innitctl/Dockerfile
+++ b/bin/innitctl/Dockerfile
@@ -48,5 +48,8 @@ WORKDIR /run/$BIN
 COPY --from=builder /tmp/local-bin/* /usr/local/bin/
 COPY --chown=app:app ./configs /configs
 
-USER app
-ENTRYPOINT "/usr/local/bin/$BIN"
+RUN mkdir -p /output && \
+    chown -R app:app /output && \
+    chmod -R 775 /output
+
+ENTRYPOINT ["sh", "-c", "chown -R app:app /output; exec runuser -u app -- /usr/local/bin/innitctl \"$@\"", "--"]


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Innitctl needs permissions on the volumes it interacts with to create config files for other apps.


## How was it tested?

Pushed and manually tested on a tools instance
