### PR TITLE
fix: luminork should should a binary

### DIFF
--- a/bin/luminork/BUCK
+++ b/bin/luminork/BUCK
@@ -1,7 +1,7 @@
 load(
     "@prelude-si//:macros.bzl",
-    "docker_image",
     "rust_binary",
+    "rust_binary_pkg",
 )
 
 rust_binary(
@@ -24,16 +24,7 @@ rust_binary(
     },
 )
 
-docker_image(
-    name = "image",
-    image_name = "luminork",
-    build_args = {
-        "BASE_VERSION": "bookworm",
-        "BIN": "luminork",
-        "SI_RBE_TOKEN": ""
-    },
-    build_deps = [
-        "//bin/luminork:luminork",
-        "//pkgs:pkgs",
-    ]
+rust_binary_pkg(
+    name = "luminork",
+    binary = ":luminork"
 )


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Luminork should be shipping a binary and not a container image.


## How was it tested?

A local build is successful
