### PR TITLE
Fail the entire deployment MV update if any of the individual MVs fails to build

### DIFF
--- a/lib/edda-server/src/materialized_view.rs
+++ b/lib/edda-server/src/materialized_view.rs
@@ -1164,7 +1164,8 @@ async fn build_deployment_mv_inner(
                     build_total_elapsed += build_duration;
                 }
                 Err(err) => {
-                    warn!(name = "deployment_mv_build_error", si.error.message = err.to_string(), kind = %kind, id = %mv_id);
+                    error!(name = "deployment_mv_build_error", si.error.message = err.to_string(), kind = %kind, id = %mv_id);
+                    return Err(err);
                 }
             }
         }


### PR DESCRIPTION
Rather than potentially forgetting that there are any deployment-level MVs if there is something like a database connection problem while building MVs, we now treat any MV build errors as reason to not update the MV index at all.

This also means that we will short-circuit the build loop if we see an MV fail and exit early without attempting to build any further deployment-level MVs.