### PR TITLE
fix: Actually remove parents during migration

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -861,7 +861,6 @@ const wForm = useWatchedForm<AttrData>(
   `component.av.prop.${props.component.id}.${props.path}`,
   attributeInputContext?.blankInput,
 );
-
 // this gets used by the watcher to ensure that data has propagated
 const rawAttrData = computed<AttrData>(() => {
   return { value: props.value };


### PR DESCRIPTION
Turns out the migration code for parents ran *after* the commit() :)

I also switched it out to explicitly iterate FrameContains edges, since removing all of those is one of the primary goals. Affects only migration.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdldHczMjk1b2o1ZXRldDNnbGc1aDFqaW5yZGI4bGx0dm8wenpmY3RzdSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GBSj8zQtylzOgzkfw9/giphy.gif"/>

## How was it tested?

- [X] Manual test: inferred connections are replaced and then parents removed
