### PR TITLE
fix: add health_check back to otelcol config

### DIFF
--- a/bin/innitctl/configs/config.yaml.template
+++ b/bin/innitctl/configs/config.yaml.template
@@ -20,6 +20,7 @@ exporters:
 
 extensions:
   zpages:
+  health_check:
 
 service:
   pipelines:
@@ -31,4 +32,4 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [prometheus]
-  extensions: [zpages]
+  extensions: [zpages, health_check]


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

I am not sure how this got missed, but the timeout on the health_check here is adding like 90 seconds to our deploy times :(


## How was it tested?

Caught this when verifying log shipping in tools, made the change manually, and verified it

```
7b3ba1c89b1a   systeminit/otelcol:stable       "/app/docker-entrypo…"   13 minutes ago   Up 47 seconds (healthy)   0.0.0.0:4317->4317/tcp, :::4317->4317/tcp, 0.0.0.0:9090->9090/tcp, :::9090->9090/tcp, 0.0.0.0:55679->55679/tcp, :::55679->55679/tcp   otelcol
```
