### PR TITLE
Grab bag of changes to api tests

### DIFF
--- a/bin/si-luminork-api-tests/tests/schemas.test.ts
+++ b/bin/si-luminork-api-tests/tests/schemas.test.ts
@@ -1,110 +1,173 @@
 /**
  * Schemas Tests
- * 
+ *
  * Tests for the schemas API endpoints.
  */
 
-import { assertEquals, assertExists } from 'https://deno.land/std@0.220.1/assert/mod.ts';
-import { createTestClient, cleanupTestResources, ConfigError } from '../src/test-utils.ts';
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.220.1/assert/mod.ts";
+import {
+  createTestClient,
+  cleanupTestResources,
+  ConfigError,
+} from "../src/test-utils.ts";
 
 Deno.test("Schemas API - List and Find Schemas", async () => {
   try {
     const { api, config } = await createTestClient();
-    
+
     const createdChangeSetIds: string[] = [];
-    
+
     try {
       // Create a change set for testing
-      const createChangeSetResponse = await api.changeSets.createChangeSet(config.workspaceId, {
-        changeSetName: 'schema_test_changeset',
-      });
-      
+      const createChangeSetResponse = await api.changeSets.createChangeSet(
+        config.workspaceId,
+        {
+          changeSetName: "schema_test_changeset",
+        },
+      );
+
       assertEquals(createChangeSetResponse.status, 200);
       assertExists(createChangeSetResponse.data.changeSet);
       const changeSetId = createChangeSetResponse.data.changeSet.id;
       createdChangeSetIds.push(changeSetId);
-      
+
       console.log(`Created change set with ID: ${changeSetId}`);
-      
+
+      // Find some schemas to ensure we have uninstalled variants
+      const findEc2Response = await api.schemas.findSchema(
+        config.workspaceId,
+        { name: "AWS::EC2::Instance" },
+        changeSetId,
+      );
+
+      assertEquals(findEc2Response.status, 200);
+      assertExists(findEc2Response.data.schemas);
+
+      const findRegionResponse = await api.schemas.findSchema(
+        config.workspaceId,
+        { name: "Region" },
+        changeSetId,
+      );
+
+      assertEquals(findRegionResponse.status, 200);
+      assertExists(findRegionResponse.data.schemas);
+
+      const findVpcResponse = await api.schemas.findSchema(
+        config.workspaceId,
+        { name: "AWS::EC2::VPC" },
+        changeSetId,
+      );
+      assertEquals(findVpcResponse.status, 200);
+      assertExists(findVpcResponse.data.schemas);
+
+      const findCredentialResponse = await api.schemas.findSchema(
+        config.workspaceId,
+        { name: "AWS Credential" },
+        changeSetId,
+      );
+      assertEquals(findCredentialResponse.status, 200);
+      assertExists(findCredentialResponse.data.schemas);
+
       // List all schemas
-      const listSchemasResponse = await api.schemas.listSchemas(config.workspaceId, changeSetId);
-      
+      const listSchemasResponse = await api.schemas.listSchemas(
+        config.workspaceId,
+        changeSetId,
+      );
+
       assertEquals(listSchemasResponse.status, 200);
       assertExists(listSchemasResponse.data.schemas);
-      
+
       if (listSchemasResponse.data.schemas.length === 0) {
-        console.warn('No schemas found in workspace, test is limited');
+        console.warn("No schemas found in workspace, test is limited");
         return;
       }
-      
+
       // Get the first schema for further testing
       const firstSchema = listSchemasResponse.data.schemas[0];
       assertExists(firstSchema.schemaId);
       assertExists(firstSchema.schemaName);
-      
-      console.log(`Found schema with ID: ${firstSchema.schemaId} and name: ${firstSchema.schemaName}`);
+
+      console.log(
+        `Found schema with ID: ${firstSchema.schemaId} and name: ${firstSchema.schemaName}`,
+      );
       console.log(`Testing find schema by name: ${firstSchema.schemaName}`);
-      
+
       const findSchemaResponse = await api.schemas.findSchema(
         config.workspaceId,
         { name: firstSchema.schemaName },
-        changeSetId
+        changeSetId,
       );
-      
-      assertEquals(findSchemaResponse.status, 200, "Find schema response status should be 200");
-      assertExists(findSchemaResponse.data.schemas, "Find schema response should contain schemas array");
-      
+
+      assertEquals(
+        findSchemaResponse.status,
+        200,
+        "Find schema response status should be 200",
+      );
+      assertExists(
+        findSchemaResponse.data.schemas,
+        "Find schema response should contain schemas array",
+      );
+
       // Check if our schema is in the results
       const schemaFound = findSchemaResponse.data.schemas.some(
-        (schema) => schema.schemaId === firstSchema.schemaId
+        (schema) => schema.schemaId === firstSchema.schemaId,
       );
-      
-      assertEquals(schemaFound, true, `Schema ${firstSchema.schemaId} not found in search results`);
-      
+
+      assertEquals(
+        schemaFound,
+        true,
+        `Schema ${firstSchema.schemaId} not found in search results`,
+      );
+
       // Ensure we install the schema if it doesn't exist so we can guarantee we can get the schema details
-      await api.components.createComponent(
-        config.workspaceId, 
-        changeSetId, 
-        {
-          name: "Ensuring Schema Installed",
-          schemaName: firstSchema.schemaName
-        }
-      );
-      
+      await api.components.createComponent(config.workspaceId, changeSetId, {
+        name: "Ensuring Schema Installed",
+        schemaName: firstSchema.schemaName,
+      });
+
       // Get specific schema
       const getSchemaResponse = await api.schemas.getSchema(
         config.workspaceId,
         changeSetId,
-        firstSchema.schemaId
+        firstSchema.schemaId,
       );
       assertEquals(getSchemaResponse.status, 200);
       assertEquals(getSchemaResponse.data.name, firstSchema.schemaName); // May need to adjust this based on actual response
-      
+
       // Test getting schema variant if available
-      if (getSchemaResponse.data.variants && getSchemaResponse.data.variants.length > 0) {
+      if (
+        getSchemaResponse.data.variants &&
+        getSchemaResponse.data.variants.length > 0
+      ) {
         const variant = getSchemaResponse.data.variants[0];
-        
+
         const getVariantResponse = await api.schemas.getSchemaVariant(
           config.workspaceId,
           changeSetId,
           firstSchema.schemaId,
-          variant.id
+          variant.id,
         );
-        
+
         assertEquals(getVariantResponse.status, 200);
         assertEquals(getVariantResponse.data.id, variant.id);
         assertEquals(getVariantResponse.data.schema_id, firstSchema.schemaId);
-        
-        console.log(`Successfully retrieved schema variant with ID: ${variant.id}`);
+
+        console.log(
+          `Successfully retrieved schema variant with ID: ${variant.id}`,
+        );
       }
-      
     } finally {
       // Clean up any change sets
       await cleanupTestResources(api, config.workspaceId, createdChangeSetIds);
     }
   } catch (error: unknown) {
     if (error instanceof ConfigError) {
-      console.warn(`Skipping test due to configuration error: ${error.message}`);
+      console.warn(
+        `Skipping test due to configuration error: ${error.message}`,
+      );
       return;
     }
     throw error;

--- a/bin/si-sdf-api-test/sdf_api_client.ts
+++ b/bin/si-sdf-api-test/sdf_api_client.ts
@@ -1,6 +1,11 @@
 // sdf_client.ts
 import JWT from "npm:jsonwebtoken";
-import { retryUntil, retryWithBackoff, sleep, sleepBetween } from "./test_helpers.ts";
+import {
+  retryUntil,
+  retryWithBackoff,
+  sleep,
+  sleepBetween,
+} from "./test_helpers.ts";
 
 type HTTP_METHOD = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 type ROUTE_VARS = Record<string, string>;
@@ -24,7 +29,8 @@ export const ROUTES = {
     method: "POST",
   },
   apply: {
-    path: (vars: ROUTE_VARS) => `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/apply`,
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/apply`,
     method: "POST",
   },
   create_change_set: {
@@ -40,22 +46,25 @@ export const ROUTES = {
 
   // Component Management -------------------------------------------------------
   create_component_v2: {
-    path: (vars: ROUTE_VARS) => `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/views/${vars.viewId}/component`,
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/views/${vars.viewId}/component`,
     method: "POST",
   },
   delete_components_v2: {
-    path: (vars: ROUTE_VARS) => `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/components/delete`,
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/components/delete`,
     method: "DELETE",
   },
   attributes: {
-    path: (vars: ROUTE_VARS) => `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/components/${vars.componentId}/attributes`,
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/components/${vars.componentId}/attributes`,
     method: "PUT",
   },
   upgrade: {
-    path: (vars: ROUTE_VARS) => `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/components/upgrade`,
+    path: (vars: ROUTE_VARS) =>
+      `/v2/workspaces/${vars.workspaceId}/change-sets/${vars.changeSetId}/components/upgrade`,
     method: "POST",
   },
-
 
   // Variant Management -----------------------------------------------------------
   create_variant: {
@@ -207,7 +216,10 @@ export class SdfApiClient {
     return new SdfApiClient(token, baseUrl, workspaceId);
   }
 
-  public async call({ route, routeVars, params, body }: API_CALL, noThrow?: boolean) {
+  public async call(
+    { route, routeVars, params, body }: API_CALL,
+    noThrow?: boolean,
+  ) {
     const { path, method, headers } = ROUTES[route] as API_DESCRIPTION;
 
     // Ensure routeVars is always defined and contains workspaceId
@@ -315,13 +327,21 @@ export class SdfApiClient {
   ): Promise<void> {
     console.log(`Waiting on DVUs for ${this.workspaceId}...`);
 
-    await retryUntil(async () => {
-      const dvuRoots = await this.mjolnir(changeSetId, "DependentValueComponentList", this.workspaceId);
-      if (dvuRoots.components && dvuRoots.components.length !== 0) {
-        throw new Error("DVU is still being processed");
-      }
-    }, timeout_ms, "Timeout waiting for dvu roots to clear", interval_ms);
-
+    await retryUntil(
+      async () => {
+        const dvuRoots = await this.mjolnir(
+          changeSetId,
+          "DependentValueComponentList",
+          this.workspaceId,
+        );
+        if (dvuRoots.components && dvuRoots.components.length !== 0) {
+          throw new Error("DVU is still being processed");
+        }
+      },
+      timeout_ms,
+      "Timeout waiting for dvu roots to clear",
+      interval_ms,
+    );
   }
 
   public async waitForDVUs(
@@ -356,18 +376,19 @@ export class SdfApiClient {
     return Promise.race([dvuPromise, timeoutPromise]);
   }
 
-
   // Helper functions for interacting with MVs
   public async mjolnir(
     changeSetId: string,
     kind: string,
     id: string,
   ): Promise<any | null> {
-
-    const response = await this.call({
-      route: "mjolnir",
-      routeVars: { changeSetId, materializedViewId: id, referenceKind: kind },
-    }, true);
+    const response = await this.call(
+      {
+        route: "mjolnir",
+        routeVars: { changeSetId, materializedViewId: id, referenceKind: kind },
+      },
+      true,
+    );
     if (response?.status === 200) {
       try {
         const json = await response.json();
@@ -375,71 +396,103 @@ export class SdfApiClient {
       } catch (err) {
         console.error("Error trying to parse response body as JSON", err);
       }
-
     } else if (response?.status === 404) {
-      console.warn(`Materialized view for ${kind} with ID ${id} not (yet?) found`);
-      throw new Error("Materialized view not (yet?) found for kind: " + kind + ", id: " + id);
+      console.warn(
+        `Materialized view for ${kind} with ID ${id} not (yet?) found`,
+      );
+      throw new Error(
+        "Materialized view not (yet?) found for kind: " + kind + ", id: " + id,
+      );
     } else {
       // Fail on non-200 and non-404 errors
-      console.error(`Error ${response.status}: Unable to fetch MV for ${kind} with ID ${id}:`, await response.text());
+      console.error(
+        `Error ${response.status}: Unable to fetch MV for ${kind} with ID ${id}:`,
+        await response.text(),
+      );
       throw new Error(`Error ${response.status}: ${await response.text()}`);
     }
     return null;
   }
 
-  public async multiMjolnir(changeSetId: string, mvs: { kind: string; id: string }[]) {
-    const response = await this.call({
-      route: "multi_mjolnir",
-      routeVars: { changeSetId },
-      body: { requests: mvs },
-    }, true);
+  public async multiMjolnir(
+    changeSetId: string,
+    mvs: { kind: string; id: string }[],
+  ) {
+    const response = await this.call(
+      {
+        route: "multi_mjolnir",
+        routeVars: { changeSetId },
+        body: { requests: mvs },
+      },
+      true,
+    );
 
     if (response?.status === 200) {
       try {
         const json = await response.json();
         if (json.failed && json.failed.length > 0) {
-          console.warn("Some MVs were not found during multi mjolnir:", json.failed);
+          console.warn(
+            "Some MVs were not found during multi mjolnir:",
+            json.failed,
+          );
         }
         return json.successful.map((v: any) => v.frontEndObject.data);
       } catch (err) {
         console.error("Error trying to parse response body as JSON", err);
+        throw new Error(`Error trying to parse response body as JSON: ${err}`);
       }
     } else {
       // Fail on non-200 errors
-      console.error(`Error ${response.status}: Unable to fetch MVs:`, await response.text());
+      console.error(
+        `Error ${response.status}: Unable to fetch MVs:`,
+        await response.text(),
+      );
       throw new Error(`Error ${response.status}: ${await response.text()}`);
     }
   }
 
-  public async fetchChangeSetIndex(changeSetId: string, timeout_ms: number = 30000): Promise<any> {
+  public async fetchChangeSetIndex(
+    changeSetId: string,
+    timeout_ms: number = 120000, // default 2 minutes
+  ): Promise<any> {
     await retryUntil(
       async () => {
         // your operation that might fail
-        const response = await this.call({
-          route: "index",
-          routeVars: { changeSetId },
-        }, true);
+        const response = await this.call(
+          {
+            route: "index",
+            routeVars: { changeSetId },
+          },
+          true,
+        );
         if (response?.status === 200) {
           const json = await response.json();
           return json;
         } else if (response?.status === 404) {
-          console.warn(`ChangeSet index for ID ${changeSetId} not (yet?) found`);
+          console.warn(
+            `ChangeSet index for ID ${changeSetId} not (yet?) found`,
+          );
           throw new Error("Index not found yet for changeset: " + changeSetId);
-        }
-        else if (response?.status === 202) {
-          console.log(`ChangeSet index for ID ${changeSetId} is still being built (status 202)`);
-          throw new Error("Index still being built for changeset: " + changeSetId);
-        }
-        else {
+        } else if (response?.status === 202) {
+          console.log(
+            `ChangeSet index for ID ${changeSetId} is still being built (status 202)`,
+          );
+          throw new Error(
+            "Index still being built for changeset: " + changeSetId,
+          );
+        } else {
           // Fail on non-200 and non-404 errors
-          console.error(`Error ${response.status}: Unable to fetch ChangeSet index for ID ${changeSetId}:`, await response.text());
+          console.error(
+            `Error ${response.status}: Unable to fetch ChangeSet index for ID ${changeSetId}:`,
+            await response.text(),
+          );
           throw new Error(`Error ${response.status}: ${await response.text()}`);
         }
       },
       timeout_ms,
+      `Timeout waiting for change set index to be built ${timeout_ms}`,
     );
   }
-
 }
 
 // Helper functions for JWT generation and fetching


### PR DESCRIPTION
1. Expand sdf api test to also create and connect to an AWS Credential - action item from previous regression (note: I did not go as far as setting the secret, but we can consider this in a follow up)
2. Increase time out when fetching new change set index and add a helpful message if that’s what fails (we see this occasionally take 2 minutes) 
3. Add luminork coverage for finding an uninstalled schema variant, to help catch regressions in the deployment build pipeline

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

Ran tests in Tools - mostly passed but let's ship this to stop the bleed. 

## In short: [:link:](https://giphy.com/)

![](put .gif link here - click the :link: besides the gif on giphy to copy it)
