### PR TITLE
fix: Allow migration to migrate connections with incompatible types

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2145,6 +2145,25 @@ impl AttributeValue {
             });
         }
 
+        Self::set_to_subscription_unchecked(ctx, subscriber_av_id, subscription, func_id, reason)
+            .await
+    }
+
+    /// Set the source of this attribute value to one or more subscriptions.
+    ///
+    /// Does NOT check if the subscription has the right type. This should only be used
+    /// for migration, and removed after it is no longer used there.
+    ///
+    /// This overwrites or overrides any existing value; if your intent is to append
+    /// subscriptions, you should first call AttributeValue::subscriptions() and append to that
+    /// list.
+    pub(crate) async fn set_to_subscription_unchecked(
+        ctx: &DalContext,
+        subscriber_av_id: AttributeValueId,
+        subscription: ValueSubscription,
+        func_id: Option<FuncId>,
+        reason: Reason,
+    ) -> AttributeValueResult<()> {
         let func_id = match func_id {
             Some(func_id) => func_id,
             None => Func::find_intrinsic(ctx, IntrinsicFunc::Identity).await?,


### PR DESCRIPTION
There are a few bad, unmigrated socket connections in some existing graphs, which connect string props to object props. (Ancient keebsdoublers, mostly :) Migration fails on these, because we (correctly) prevent you from making a prop subscription of the wrong type.

This PR migrates these connections anyway, leaving them just as incorrect as before and allowing us to complete the migration from sockets. The values flow the same, so the system should be no worse or better than before.

## How was it tested?

- [X] Integration tests pass<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdldDdxcnNtY2Z1aGp6cjM4YzVsMmE1ZzVzdzZ1ZGJ4czE5ZncwNG90OCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2OP9jbHFlFPW/giphy.gif"/>
