### PR TITLE
fix: extra space typo in final python code block

### DIFF
--- a/app/docs/src/how-tos/use-public-api.md
+++ b/app/docs/src/how-tos/use-public-api.md
@@ -562,7 +562,7 @@ def main():
                 }
             }
         }
-        template_component_data = create_component(change_set_id, "AWS  VPC Template", "demo-template", template_options)
+        template_component_data = create_component(change_set_id, "AWS VPC Template", "demo-template", template_options)
         template_component_id = template_component_data["component"]["id"]
         print(f'Template Component created with ID: {template_component_id}')
 


### PR DESCRIPTION
- Removed an extra space in the AWS VPC Template schema name in the full python code block.

## In short: [:link:](https://giphy.com/)

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3prb2J1YjV4OWZxMTU4cHFuemlnYng5eXFzbmJ6cGM4MjFyOTZ0cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xCyjMEYF9H2ZcLqf7t/giphy.gif)
