### PR TITLE
fix: Return to ye olde rust to avoid clippy warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756780571,
-        "narHash": "sha256-xX0B7Sgx3OQvf6anaNW0vXyYDXbchSx2mnT8rqAPbWA=",
+        "lastModified": 1752720268,
+        "narHash": "sha256-XCiJdtXIN09Iv0i1gs5ajJ9CVHk537Gy1iG/4nIdpVI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c18db2acc837a71146ed2d6dae27bf03e3b7a4b",
+        "rev": "dc221f842e9ddc8c0416beae8d77f2ea356b91ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
VS Code is showing clippy warnings from Rust 1.86, but no lint issues in RBE (because it uses a different Rust version). This fixes that by returning to pre-RBE rust in the nix flake. Thanks @sprutton1 for spoonfeeding me the exact lines to put in flake.lock :)