### PR TITLE
no more IconButton in the new UI

### DIFF
--- a/app/web/src/newhotness/ActionCard.vue
+++ b/app/web/src/newhotness/ActionCard.vue
@@ -110,7 +110,8 @@
       </DropdownMenu>
       <DetailsPanelMenuIcon
         v-if="!noInteraction"
-        @click.stop="(e) => contextMenuRef?.open(e, false)"
+        :selected="contextMenuRef?.isOpen"
+        @click.stop="(e: MouseEvent) => contextMenuRef?.open(e, false)"
       />
     </template>
   </ActionCardLayout>

--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -96,14 +96,17 @@
             )
           "
         >
-          <IconButton
+          <NewButton
             tooltip="Close (Esc)"
             tooltipPlacement="top"
-            class="border-0 mr-2em"
             icon="x"
-            size="sm"
-            iconIdleTone="shade"
-            iconTone="shade"
+            tone="empty"
+            :class="
+              clsx(
+                'active:bg-white active:text-black',
+                themeClasses('hover:bg-neutral-400', 'hover:bg-neutral-500'),
+              )
+            "
             @click="close"
           />
           <TruncateWithTooltip class="py-xs text-sm">
@@ -126,14 +129,17 @@
           )
         "
       >
-        <IconButton
+        <NewButton
           tooltip="Close (Esc)"
           tooltipPlacement="top"
-          class="border-0 mr-2em"
           icon="x"
-          size="sm"
-          iconIdleTone="shade"
-          iconTone="shade"
+          tone="empty"
+          :class="
+            clsx(
+              'active:bg-white active:text-black',
+              themeClasses('hover:bg-neutral-200', 'hover:bg-neutral-600'),
+            )
+          "
           @click="close"
         />
         <div class="flex-none text-sm">{{ component.schemaVariantName }}</div>
@@ -408,7 +414,6 @@ import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import {
   Icon,
   themeClasses,
-  IconButton,
   TruncateWithTooltip,
   NewButton,
 } from "@si/vue-lib/design-system";

--- a/app/web/src/newhotness/DocumentationPanel.vue
+++ b/app/web/src/newhotness/DocumentationPanel.vue
@@ -48,13 +48,17 @@
               {{ component.schemaVariantName }}
             </a>
           </div>
-          <IconButton
-            class="ml-auto"
-            icon="x"
+          <NewButton
             tooltip="Close"
             tooltipPlacement="top"
-            size="sm"
-            iconTone="shade"
+            icon="x"
+            tone="empty"
+            :class="
+              clsx(
+                'ml-auto active:bg-white active:text-black',
+                themeClasses('hover:bg-neutral-200', 'hover:bg-neutral-600'),
+              )
+            "
             @click="emit('cleardocs')"
           />
         </div>
@@ -65,7 +69,7 @@
 </template>
 
 <script lang="ts" setup>
-import { themeClasses, IconButton } from "@si/vue-lib/design-system";
+import { themeClasses, NewButton } from "@si/vue-lib/design-system";
 import { PropType } from "vue";
 import clsx from "clsx";
 import { BifrostComponent } from "@/workers/types/entity_kind_types";

--- a/app/web/src/newhotness/Review.vue
+++ b/app/web/src/newhotness/Review.vue
@@ -11,14 +11,17 @@
         )
       "
     >
-      <IconButton
+      <NewButton
         tooltip="Close (Esc)"
         tooltipPlacement="top"
-        class="border-0 mr-2em"
         icon="x"
-        size="sm"
-        iconIdleTone="shade"
-        iconTone="shade"
+        tone="empty"
+        :class="
+          clsx(
+            'active:bg-white active:text-black',
+            themeClasses('hover:bg-neutral-200', 'hover:bg-neutral-600'),
+          )
+        "
         @click="exitReview"
       />
       <div class="flex-1 text-sm font-medium">Review Changes</div>
@@ -393,7 +396,6 @@ import {
   Icon,
   SiSearch,
   themeClasses,
-  IconButton,
   TruncateWithTooltip,
   NewButton,
 } from "@si/vue-lib/design-system";

--- a/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
+++ b/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
@@ -10,14 +10,17 @@
         )
       "
     >
-      <IconButton
+      <NewButton
         tooltip="Close (Esc)"
         tooltipPlacement="top"
-        class="border-0 mr-2em"
         icon="x"
-        size="sm"
-        iconIdleTone="shade"
-        iconTone="shade"
+        tone="empty"
+        :class="
+          clsx(
+            'active:bg-white active:text-black',
+            themeClasses('hover:bg-neutral-200', 'hover:bg-neutral-600'),
+          )
+        "
         @click="() => emit('close')"
       />
       <div class="flex-none text-sm">Edit selected components</div>
@@ -279,9 +282,9 @@ import {
 } from "vue";
 import {
   themeClasses,
-  IconButton,
   TruncateWithTooltip,
   TextPill,
+  NewButton,
 } from "@si/vue-lib/design-system";
 import { bifrost, useMakeArgs, useMakeKey } from "@/store/realtime/heimdall";
 import {

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -36,17 +36,28 @@
             :showAsterisk="validationStatus === 'missingRequiredValue'"
           />
           <div class="flex flex-row items-center ml-auto gap-2xs">
-            <IconButton
+            <NewButton
               v-if="canDelete && !component.toDelete"
+              ref="deleteButtonRef"
               tooltip="Delete"
               tooltipPlacement="top"
               icon="trash"
-              iconTone="destructive"
-              iconIdleTone="shade"
-              size="sm"
+              tone="destructive"
               loadingIcon="loader"
               :loading="bifrostingTrash"
+              loadingText=""
+              :tabIndex="0"
+              :class="
+                clsx(
+                  'focus:outline',
+                  themeClasses(
+                    'focus:outline-action-500',
+                    'focus:outline-action-300',
+                  ),
+                )
+              "
               @click.left="remove"
+              @keydown.tab.stop.prevent="onDeleteButtonTab"
             />
           </div>
         </div>
@@ -268,17 +279,25 @@
                 :text="displayName"
                 :showAsterisk="validationStatus === 'missingRequiredValue'"
               />
-              <IconButton
+              <NewButton
                 v-if="canDelete && !component.toDelete"
                 tooltip="Delete (⌘⌫)"
                 tooltipPlacement="top"
                 icon="trash"
-                iconTone="destructive"
-                iconIdleTone="shade"
-                size="sm"
-                class="ml-auto"
+                tone="destructive"
                 loadingIcon="loader"
                 :loading="bifrostingTrash"
+                loadingText=""
+                :tabIndex="-1"
+                :class="
+                  clsx(
+                    'ml-auto focus:outline',
+                    themeClasses(
+                      'focus:outline-action-500',
+                      'focus:outline-action-300',
+                    ),
+                  )
+                "
                 @click.left="remove"
               />
             </div>
@@ -737,10 +756,10 @@ import { debounce } from "lodash-es";
 import clsx from "clsx";
 import {
   Icon,
-  IconButton,
   themeClasses,
   TruncateWithTooltip,
   TextPill,
+  NewButton,
 } from "@si/vue-lib/design-system";
 import { Fzf } from "fzf";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
@@ -1192,6 +1211,7 @@ const emit = defineEmits<{
   (e: "add", key?: string): void;
   (e: "selected"): void;
   (e: "close"): void;
+  (e: "handleTab", event: KeyboardEvent, currentFocus?: HTMLElement): void;
 }>();
 
 // INPUT WINDOW LOGIC
@@ -1704,6 +1724,12 @@ const discardString = computed(() => {
 
   return "Discard edits";
 });
+
+const deleteButtonRef = ref<InstanceType<typeof NewButton>>();
+
+const onDeleteButtonTab = (e: KeyboardEvent) => {
+  emit("handleTab", e, deleteButtonRef.value?.mainElRef);
+};
 
 defineExpose({
   openInput,

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -46,13 +46,19 @@
       <slot name="header" />
       <div v-if="$slots.headerIcons || showExpandButton" class="ml-auto" />
       <slot name="headerIcons" />
-      <IconButton
+      <NewButton
         v-if="showExpandButton"
         tooltip="Expand"
         tooltipPlacement="top"
-        size="xs"
         icon="maximize"
-        iconTone="shade"
+        tone="empty"
+        size="xs"
+        :class="
+          clsx(
+            'active:bg-white active:text-black',
+            themeClasses('hover:bg-neutral-200', 'hover:bg-neutral-600'),
+          )
+        "
         @click.prevent.stop="expand"
       />
     </h3>
@@ -78,10 +84,10 @@
 <script lang="ts" setup>
 import {
   themeClasses,
-  IconButton,
   Modal,
   Icon,
   SpacingSizes,
+  NewButton,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed, onMounted, ref } from "vue";

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -19,6 +19,7 @@
     :hasSocketConnection="hasSocketConnections"
     @close="closeSubscriptionInput"
     @save="(...args) => emit('save', ...args)"
+    @handleTab="handleTab"
   />
   <li
     v-else-if="showingChildren || !attributeTree.prop?.hidden"
@@ -88,13 +89,20 @@
                   attributeTree.attributeValue.externalSources[0]?.path
                 }}</span
               >
-
-              <IconButton
-                v-tooltip="'Remove subscription'"
+              <NewButton
+                tooltip="Remove subscription"
+                tooltipPlacement="top"
                 icon="x"
-                size="sm"
-                iconTone="destructive"
-                iconIdleTone="shade"
+                tone="empty"
+                :class="
+                  clsx(
+                    'active:bg-white active:text-black',
+                    themeClasses(
+                      'hover:bg-neutral-200',
+                      'hover:bg-neutral-600',
+                    ),
+                  )
+                "
                 @click="removeSubscription"
               />
             </div>
@@ -108,7 +116,7 @@
                 !attributeTree.attributeValue.externalSources?.length
               "
               ref="connectButtonRef"
-              v-tooltip="'Create subscription'"
+              tooltip="Create subscription"
               :tabIndex="
                 attributeTree.isBuildable && !component.toDelete ? 0 : undefined
               "
@@ -125,7 +133,7 @@
               @click.stop.prevent="createSubscription"
               @keydown.tab.stop.prevent="onConnectButtonTab"
             />
-            <IconButton
+            <NewButton
               v-if="
                 attributeTree.isBuildable &&
                 !component.toDelete &&
@@ -134,15 +142,15 @@
                 !attributeTree.attributeValue.externalSources?.length
               "
               ref="deleteButtonRef"
-              v-tooltip="'Delete'"
+              tooltip="Delete"
+              tooltipPlacement="top"
               :tabIndex="
                 attributeTree.isBuildable && !component.toDelete ? 0 : undefined
               "
               icon="trash"
-              size="sm"
-              iconTone="destructive"
-              iconIdleTone="shade"
+              tone="destructive"
               loadingIcon="loader"
+              loadingText=""
               :loading="bifrostingTrash"
               class="focus:outline focus:outline-action-500"
               @click="remove"
@@ -232,7 +240,7 @@
               :loading="addButtonBifrosting"
               :disabled="addButtonBifrosting"
               loadingIcon="loader"
-              :tabindex="0"
+              :tabIndex="0"
               @click="add"
               @keydown.tab.stop.prevent="onAddButtonTab"
             >
@@ -270,6 +278,7 @@
         "
         @remove-subscription="(...args) => emit('removeSubscription', ...args)"
         @add="(...args) => add(...args)"
+        @handleTab="handleTab"
       />
     </template>
   </li>
@@ -277,7 +286,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, ref } from "vue";
-import { IconButton, themeClasses, NewButton } from "@si/vue-lib/design-system";
+import { themeClasses, NewButton } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useQuery } from "@tanstack/vue-query";
 import {
@@ -527,7 +536,7 @@ const showingChildren = computed(
 const headerRef = ref<HTMLDivElement>();
 const addButtonRef = ref<InstanceType<typeof NewButton>>();
 const connectButtonRef = ref<InstanceType<typeof NewButton>>();
-const deleteButtonRef = ref<InstanceType<typeof IconButton>>();
+const deleteButtonRef = ref<InstanceType<typeof NewButton>>();
 
 const handleTab = (e: KeyboardEvent, currentFocus?: HTMLElement) => {
   const focusable = Array.from(
@@ -571,6 +580,6 @@ const onConnectButtonTab = (e: KeyboardEvent) => {
   handleTab(e, connectButtonRef.value?.$el);
 };
 const onDeleteButtonTab = (e: KeyboardEvent) => {
-  handleTab(e, deleteButtonRef.value?.mainDivRef);
+  handleTab(e, deleteButtonRef.value?.mainElRef);
 };
 </script>

--- a/app/web/src/newhotness/layout_components/DetailsPanelMenuIcon.vue
+++ b/app/web/src/newhotness/layout_components/DetailsPanelMenuIcon.vue
@@ -1,14 +1,21 @@
 <template>
-  <IconButton
+  <NewButton
     icon="dots-vertical"
-    iconIdleTone="neutral"
-    :selected="selected"
     :disabled="disabled"
+    tone="empty"
+    :class="
+      selected
+        ? themeClasses('bg-action-500', 'bg-action-300')
+        : themeClasses(
+            'hover:bg-neutral-200 active:bg-action-500',
+            'hover:bg-neutral-600 active:bg-action-300',
+          )
+    "
   />
 </template>
 
 <script lang="ts" setup>
-import { IconButton } from "@si/vue-lib/design-system";
+import { NewButton, themeClasses } from "@si/vue-lib/design-system";
 
 defineProps({
   selected: { type: Boolean },

--- a/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
@@ -18,14 +18,17 @@
         )
       "
     >
-      <IconButton
+      <NewButton
         tooltip="Close (Esc)"
         tooltipPlacement="top"
-        class="border-0 mr-2em"
         icon="x"
-        size="sm"
-        iconIdleTone="shade"
-        iconTone="shade"
+        tone="empty"
+        :class="
+          clsx(
+            'active:bg-white active:text-black',
+            themeClasses('hover:bg-neutral-200', 'hover:bg-neutral-600'),
+          )
+        "
         @click="navigateBack"
       />
 
@@ -147,7 +150,7 @@
 
 <script lang="ts" setup>
 import { computed, ref, watch } from "vue";
-import { Icon, themeClasses, IconButton } from "@si/vue-lib/design-system";
+import { Icon, themeClasses, NewButton } from "@si/vue-lib/design-system";
 import { useRoute, useRouter } from "vue-router";
 import clsx from "clsx";
 import CodeViewer from "@/components/CodeViewer.vue";

--- a/app/web/src/newhotness/nav/ChangeSetPanel.vue
+++ b/app/web/src/newhotness/nav/ChangeSetPanel.vue
@@ -66,7 +66,7 @@
         changeSet.status === ChangeSetStatus.NeedsApproval
       "
       icon="trash"
-      tone="action"
+      tone="destructive"
       class="flex-none"
       @click="openAbandonConfirmationModal"
     />

--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -51,7 +51,7 @@ export const getAssetIcon = (name: string) => {
  * When its open use the fractional unit so it grows to the available size, sharing the remaining space with other open grid items
  */
 export const gridCollapseStyle = (open: boolean | Ref<boolean, boolean>) =>
-  unref(open) ? "1fr" : "1.75em";
+  unref(open) ? "1fr" : "2.5em";
 
 /**
  * Generates the styles for a vertical grid of collapsing panels

--- a/app/web/src/pages/auth/LogoutPage.vue
+++ b/app/web/src/pages/auth/LogoutPage.vue
@@ -2,7 +2,6 @@
   <AppLayout pageMode="modal" class="font-medium">
     <Stack spacing="lg" class="max-w-md">
       <AuthPageHeader title="Logging out"></AuthPageHeader>
-
       <Card rounded> See ya later!</Card>
     </Stack>
   </AppLayout>

--- a/lib/vue-lib/src/design-system/general/IconButton.vue
+++ b/lib/vue-lib/src/design-system/general/IconButton.vue
@@ -1,5 +1,6 @@
+<!-- THIS COMPONENT IS DEPRECATED, DO NOT USE IT ANYMORE!-->
+
 <template>
-  <!-- TODO(Wendy) - probably at some point IconButton should be merged with VButton -->
   <div
     ref="mainDivRef"
     v-tooltip="{


### PR DESCRIPTION
## How does this PR change the system?

This PR replaces all instances of `IconButton` in the new UI with `NewButton`. From now on, we will only use the `NewButton` component for all buttons to ensure design consistency.

#### Screenshots:

<img width="151" height="76" alt="Screenshot 2025-09-03 at 5 36 50 PM" src="https://github.com/user-attachments/assets/138f997d-4779-40ab-8499-e0f80029ede1" />

#### Out of Scope:

This PR does not remove `IconButton` from the auth-portal or the old UI. We will follow up to remove IconButton from the auth-portal in the future, and there's no reason to update the old UI when it will soon be gone!

## How was it tested?

Each button replaced was individually tested to ensure it works properly. Testing included confirming that keyboard controls still work properly when applicable.