### PR TITLE
Chore: Increase timeouts for SDF API Tests and a few other fixes

### DIFF
--- a/bin/si-sdf-api-test/test_helpers.ts
+++ b/bin/si-sdf-api-test/test_helpers.ts
@@ -94,6 +94,9 @@ export async function runWithTemporaryChangeset(
     `Changeset name should be ${changeSetName}`,
   );
   const changeSetId = changeSet.id;
+  console.log(`Created temporary changeset ${changeSetId}`);
+  await sleepBetween(1000, 5000);
+  console.log("Fetching changeset index before running fn");
   // FETCH CHANGESET INDEX before running fn so we ensure the index has been built
   await sdf.fetchChangeSetIndex(changeSetId);
   // RUN FN
@@ -482,7 +485,7 @@ export async function eventualMVAssert(
   id: string,
   assertFn: (mv: any) => boolean,
   message: string,
-  timeoutMs: number = 60000, // 60 seconds
+  timeoutMs: number = 90000, // 90 seconds which should be plenty of time, but we're seeing some timing issues in crons so bumping it up dramatically
 ): Promise<void> {
   // update this to use sdf.mjolnir and retryUntil
   if (!sdf || !changeSetId || !kind || !id) {

--- a/bin/si-sdf-api-test/tests/3-create_and_use_variant.ts
+++ b/bin/si-sdf-api-test/tests/3-create_and_use_variant.ts
@@ -47,7 +47,7 @@ export async function create_variant_inner(
     schemaVariantId,
     (mv) => mv.id === schemaVariantId,
     "SchemaVariant MV should exist and have matching id",
-    90000, // give it 90 seconds to appear as we'll have to rebuild SchemaVariantCategories as well
+    180000, // give it 120 seconds to appear as we'll have to rebuild SchemaVariantCategories as well
   );
   // create new variant as a component
   let createInstancePayload = {

--- a/bin/si-sdf-api-test/tests/4-create_two_components_connect_and_propagate.ts
+++ b/bin/si-sdf-api-test/tests/4-create_two_components_connect_and_propagate.ts
@@ -39,13 +39,43 @@ async function create_two_components_connect_and_propagate_inner(
   const defaultView = views.find((v: any) => v.isDefault);
   assert(defaultView, "Expected to find a default view");
 
-  // Create two components, an EC2 Instance and a Region
-  let createEC2ComponentBody = createComponentPayload(schemaVariants, "AWS::EC2::Instance");
-  let createRegionComponentBody = createComponentPayload(schemaVariants, "Region");
-  const newEC2ComponentId = await createComponent(sdf, changeSetId, defaultView.id, createEC2ComponentBody);
+  // Create three components, an EC2 Instance, a Region, and a Credential
+  let createEC2ComponentBody = createComponentPayload(
+    schemaVariants,
+    "AWS::EC2::Instance",
+  );
+  let createRegionComponentBody = createComponentPayload(
+    schemaVariants,
+    "Region",
+  );
+  let createCredentialComponentBody = createComponentPayload(
+    schemaVariants,
+    "AWS Credential",
+  );
+  const newEC2ComponentId = await createComponent(
+    sdf,
+    changeSetId,
+    defaultView.id,
+    createEC2ComponentBody,
+  );
   assert(newEC2ComponentId, "Expected to get a component id after creation");
-  const newRegionComponentId = await createComponent(sdf, changeSetId, defaultView.id, createRegionComponentBody);
+  const newRegionComponentId = await createComponent(
+    sdf,
+    changeSetId,
+    defaultView.id,
+    createRegionComponentBody,
+  );
   assert(newRegionComponentId, "Expected to get a component id after creation");
+  const newCredentialComponentId = await createComponent(
+    sdf,
+    changeSetId,
+    defaultView.id,
+    createCredentialComponentBody,
+  );
+  assert(
+    newCredentialComponentId,
+    "Expected to get a component id after creation",
+  );
 
   // Subscribe EC2 Instance to Region
   const subResponse = await sdf.call({
@@ -57,14 +87,30 @@ async function create_two_components_connect_and_propagate_inner(
     },
     body: {
       "/domain/extra/Region": {
-        "$source": {
-          "component": newRegionComponentId,
-          "path": "/domain/region",
-        }
+        $source: {
+          component: newRegionComponentId,
+          path: "/domain/region",
+        },
       },
     },
   });
-
+  // Subscribe EC2 Instance to Credential
+  const subCredResponse = await sdf.call({
+    route: "attributes",
+    routeVars: {
+      workspaceId: sdf.workspaceId,
+      changeSetId,
+      componentId: newEC2ComponentId,
+    },
+    body: {
+      "/secrets/AWS Credential": {
+        $source: {
+          component: newCredentialComponentId,
+          path: "/secrets/AWS Credential",
+        },
+      },
+    },
+  });
 
   // Check that the subscription was successful
   await eventualMVAssert(
@@ -72,27 +118,39 @@ async function create_two_components_connect_and_propagate_inner(
     changeSetId,
     "AttributeTree",
     newEC2ComponentId,
-    (mv) => Object.values(mv.attributeValues).some(
-      (av: any) => av.path === "/domain/extra/Region" &&
-        av.externalSources.length === 1,
-    ),
-    "Expected EC2 Instance to be subscribed to Region",
+    (mv) =>
+      Object.values(mv.attributeValues).some(
+        (av: any) =>
+          av.path === "/domain/extra/Region" && av.externalSources.length === 1,
+      ) &&
+      Object.values(mv.attributeValues).some(
+        (av: any) =>
+          av.path === "/secrets/AWS Credential" &&
+          av.externalSources.length === 1,
+      ),
+    "Expected EC2 Instance to be subscribed to Region and Credential",
   );
 
   // Update Region value and check propagation
   const regionValue = "us-west-1";
-  const updateRegionResponse = await sdf.call({
-    route: "attributes",
-    routeVars: {
-      workspaceId: sdf.workspaceId,
-      changeSetId,
-      componentId: newRegionComponentId,
+  const updateRegionResponse = await sdf.call(
+    {
+      route: "attributes",
+      routeVars: {
+        workspaceId: sdf.workspaceId,
+        changeSetId,
+        componentId: newRegionComponentId,
+      },
+      body: {
+        "/domain/region": regionValue,
+      },
     },
-    body: {
-      "/domain/region": regionValue,
-    },
-  }, true);
-  assert(updateRegionResponse.status == 200, "Expected to update region value successfully");
+    true,
+  );
+  assert(
+    updateRegionResponse.status == 200,
+    "Expected to update region value successfully",
+  );
 
   // Check that the value was updated on the Region component
   await eventualMVAssert(
@@ -100,10 +158,10 @@ async function create_two_components_connect_and_propagate_inner(
     changeSetId,
     "AttributeTree",
     newRegionComponentId,
-    (mv) => Object.values(mv.attributeValues).some(
-      (av: any) => av.path === "/domain/region" &&
-        av.value === regionValue,
-    ),
+    (mv) =>
+      Object.values(mv.attributeValues).some(
+        (av: any) => av.path === "/domain/region" && av.value === regionValue,
+      ),
     "Expected Region to have a new value",
   );
 
@@ -115,12 +173,11 @@ async function create_two_components_connect_and_propagate_inner(
     newEC2ComponentId,
     (mv) =>
       Object.values(mv.attributeValues).some(
-        (av: any) => av.path === "/domain/extra/Region" &&
-          av.value === regionValue,
-      )
-    ,
+        (av: any) =>
+          av.path === "/domain/extra/Region" && av.value === regionValue,
+      ),
     "Expected propagated region value on EC2 Instance to match source",
-    90000, // give it 90 seconds to make it's way through dvu
+    120000, // give it 120 seconds to make it's way through dvu
   );
 
   // Now remove the subscription and verify the value is no longer propagated
@@ -132,7 +189,7 @@ async function create_two_components_connect_and_propagate_inner(
       componentId: newEC2ComponentId,
     },
     body: {
-      "/domain/extra/Region": { "$source": null },
+      "/domain/extra/Region": { $source: null },
     },
   });
   await eventualMVAssert(
@@ -142,16 +199,21 @@ async function create_two_components_connect_and_propagate_inner(
     newEC2ComponentId,
     (mv) =>
       Object.values(mv.attributeValues).some(
-        (av: any) => av.path === "/domain/extra/Region" &&
-          !av.value && (!av.externalSources || av.externalSources.length === 0),
-      )
-    ,
+        (av: any) =>
+          av.path === "/domain/extra/Region" &&
+          !av.value &&
+          (!av.externalSources || av.externalSources.length === 0),
+      ),
     "Expected region value to no longer be propagated to EC2 Instance",
   );
 
-  // lastly, delete both components
+  // lastly, delete all components
   const deleteComponentPayload = {
-    componentIds: [newEC2ComponentId, newRegionComponentId],
+    componentIds: [
+      newEC2ComponentId,
+      newRegionComponentId,
+      newCredentialComponentId,
+    ],
     forceErase: false,
   };
   await sdf.call({
@@ -168,7 +230,6 @@ async function create_two_components_connect_and_propagate_inner(
     "ComponentList",
     sdf.workspaceId,
     (mv) => mv.components.length === 0,
-    "Should be no components after deletion"
+    "Should be no components after deletion",
   );
-
 }


### PR DESCRIPTION
1. Increase timeouts basically across the board, as even if it takes a while, success is what we're looking for here
2. Add a credential and subscription to the create_two_components test 
3. Thread a helpful message when the timeout is due to the change set's index, `undefined`

Ran against prod and got consecutive passing runs! 

<div><img src="https://media2.giphy.com/media/I4Iv86mzxz4knUqiqo/giphy.gif?cid=5a38a5a2o9lefuplzjik483iohn57ubtbv6uko8uog2wxzj7&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/inkygirl/">Debbie Ridpath Ohi</a> on <a href="https://giphy.com/gifs/fingers-crossed-I4Iv86mzxz4knUqiqo">GIPHY</a></div>
