### PR TITLE
fix: remove frame options and hardcode component type to component

### DIFF
--- a/app/web/src/components/AssetDetailsPanel.vue
+++ b/app/web/src/components/AssetDetailsPanel.vue
@@ -97,14 +97,11 @@
         />
         <VormInput
           id="componentType"
-          v-model="editingAsset.componentType"
-          :disabled="editingAsset.isLocked"
-          :options="componentTypeOptions"
+          disabled
           compact
           label="Component Type"
-          type="dropdown"
-          @change="updateAsset"
-          @focus="focus"
+          type="text"
+          :modelValue="'Component'"
         />
         <VormInput
           id="description"
@@ -282,7 +279,6 @@ import {
 } from "@/api/sdf/dal/func";
 import { useAssetStore } from "@/store/asset.store";
 import {
-  ComponentType,
   InputSocketId,
   SchemaVariant,
   SchemaVariantId,
@@ -629,18 +625,6 @@ const openAttachModal = (warning: { kind?: FuncKind; funcId?: FuncId }) => {
   if (!warning.kind) return;
   attachModalRef.value?.open(true, warning.kind, warning.funcId);
 };
-
-const componentTypeOptions = [
-  { label: "Component", value: ComponentType.Component },
-  {
-    label: "Configuration Frame (down)",
-    value: ComponentType.ConfigurationFrameDown,
-  },
-  {
-    label: "Configuration Frame (up)",
-    value: ComponentType.ConfigurationFrameUp,
-  },
-];
 
 const attachModalRef = ref<InstanceType<typeof AssetFuncAttachModal>>();
 


### PR DESCRIPTION
## How does this PR change the system?

This PR removes the options for Configuration Frame (down) and (up) from the Customize screen under 'Component Type' when creating a new Component, and hard codes the value to Component.

#### Screenshots:
**Before**:
<img width="539" height="440" alt="Screenshot 2025-09-03 at 23 53 34" src="https://github.com/user-attachments/assets/221cfa4f-aa08-4508-bc8b-badc865c71b9" />

**After**:
<img width="986" height="794" alt="Screenshot 2025-09-03 at 23 37 40" src="https://github.com/user-attachments/assets/1ae6a2cc-eb7c-43b0-8048-fe43ef0f0082" />

## How was it tested?

- [X] Hit Regenerate Asset without error
- [X] Added Component to the Grid
- [X] Added prop to the Component and tested entering a value
- [X] Merged change set

## In short: [:link:](https://giphy.com/)

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3prb2J1YjV4OWZxMTU4cHFuemlnYng5eXFzbmJ6cGM4MjFyOTZ0cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xCyjMEYF9H2ZcLqf7t/giphy.gif)
