### PR TITLE
fix: allow migration to migrate subscriptions with wrong types (part deux)

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2157,7 +2157,7 @@ impl AttributeValue {
     /// This overwrites or overrides any existing value; if your intent is to append
     /// subscriptions, you should first call AttributeValue::subscriptions() and append to that
     /// list.
-    pub(crate) async fn set_to_subscription_unchecked(
+    pub async fn set_to_subscription_unchecked(
         ctx: &DalContext,
         subscriber_av_id: AttributeValueId,
         subscription: ValueSubscription,

--- a/lib/sdf-server/src/service/v2/admin/migrate_connections.rs
+++ b/lib/sdf-server/src/service/v2/admin/migrate_connections.rs
@@ -312,7 +312,7 @@ async fn add_prop_connection(
     // Create the subscription
     let from_root_av_id = Component::root_attribute_value_id(ctx, from_component_id).await?;
     let from_path = AttributePath::from_json_pointer(from_path.to_string());
-    AttributeValue::set_to_subscription(
+    AttributeValue::set_to_subscription_unchecked(
         ctx,
         to_av_id,
         ValueSubscription {


### PR DESCRIPTION
The [previous PR](https://github.com/systeminit/si/pull/7192) was missing something important: that PR added the new method to avoid subscription typechecking, but this causes migration to actually *use* it.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMHpxbm9sMXpqbnM5aHlyMW5wbDFobWw2b2FhNzhyYmY2cmF2dTBlbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QAcSylF6vYV4UD4O23/giphy.gif"/>