### PR TITLE
Add component-generate-template MCP tool

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -361,6 +361,13 @@ Here is an example:
 buck2 targets //lib/dal:
 ```
 
+You can do it locally within a package as well.
+
+```shell
+cd lib/dal
+buck2 targets :
+```
+
 ## Why isn't this new file I added available during builds?
 
 Expanding on the terminology section, "buildable" targets only use files that are explicitly provided.

--- a/bin/si-mcp-server/src/analytics.ts
+++ b/bin/si-mcp-server/src/analytics.ts
@@ -11,8 +11,7 @@ export class Analytics {
   }
 
   private initializePostHog() {
-    const apiKey =
-      Deno.env.get("POSTHOG_API_KEY") ||
+    const apiKey = Deno.env.get("POSTHOG_API_KEY") ||
       "phc_KpehlXOqtU44B2MeW6WjqR09NxRJCYEiUReA58QcAYK"; // Prod Posthog
     const host = Deno.env.get("POSTHOG_HOST") || "https://e.systeminit.com";
 

--- a/bin/si-mcp-server/src/cli.ts
+++ b/bin/si-mcp-server/src/cli.ts
@@ -58,10 +58,9 @@ export async function run() {
         await start_stdio(server);
         await shutdown("transport_closed", null);
       } catch (err: unknown) {
-        const name =
-          err instanceof Error
-            ? err.name
-            : ((err as { name?: string })?.name ?? "unknown");
+        const name = err instanceof Error
+          ? err.name
+          : ((err as { name?: string })?.name ?? "unknown");
         await shutdown(`uncaught_error:${name}`, 1);
       } finally {
         Deno.removeSignalListener("SIGINT", onSigInt);

--- a/bin/si-mcp-server/src/data/schemaAttributes.ts
+++ b/bin/si-mcp-server/src/data/schemaAttributes.ts
@@ -92,8 +92,8 @@ function collectFlatAttributes(
 
     switch (node.propType) {
       case "object": {
-        const hasChildren =
-          Array.isArray(node.children) && node.children.length > 0;
+        const hasChildren = Array.isArray(node.children) &&
+          node.children.length > 0;
         if (hasChildren) {
           collectFlatAttributes(node.children!, nodePath, outAttrs, outDocs);
         } else {
@@ -104,8 +104,8 @@ function collectFlatAttributes(
 
       case "array": {
         const arrayPath = `${nodePath}/[array]`;
-        const hasChildren =
-          Array.isArray(node.children) && node.children.length > 0;
+        const hasChildren = Array.isArray(node.children) &&
+          node.children.length > 0;
 
         if (!hasChildren) {
           addLeaf(outAttrs, outDocs, node, arrayPath);
@@ -114,8 +114,8 @@ function collectFlatAttributes(
 
         for (const item of node.children!) {
           if (item.propType === "object") {
-            const itemHasChildren =
-              Array.isArray(item.children) && item.children.length > 0;
+            const itemHasChildren = Array.isArray(item.children) &&
+              item.children.length > 0;
             if (itemHasChildren) {
               collectFlatAttributes(
                 item.children!,
@@ -139,7 +139,6 @@ function collectFlatAttributes(
     }
   }
 }
-
 
 export function buildAttributesStructure(
   input: GetSchemaVariantV1Response,
@@ -193,7 +192,6 @@ export function formatDocumentation(
   return parts.length > 0 ? parts.join("\n\n") : undefined;
 }
 
-
 export type SchemaAttributeDocumentation = {
   schemaAttributePath: string;
   documentation: string;
@@ -215,8 +213,7 @@ export function buildDocumentationForPaths(
 ): SchemaDocumentationData {
   const docsIndex = buildAttributeDocsIndex(variant);
   const attributes = schemaAttributePaths.map((p) => {
-    const documentation =
-      formatDocumentation(docsIndex, p) ??
+    const documentation = formatDocumentation(docsIndex, p) ??
       "There is no documentation for this attribute; if it is an AWS schema, consider looking up the data for the corresponding cloudformation resource";
     return { schemaAttributePath: p, documentation };
   });

--- a/bin/si-mcp-server/src/server.ts
+++ b/bin/si-mcp-server/src/server.ts
@@ -22,6 +22,7 @@ import { componentDeleteTool } from "./tools/componentDelete.ts";
 import { componentEraseTool } from "./tools/componentErase.ts";
 import { componentRestoreTool } from "./tools/componentRestore.ts";
 import { generateSiUrlTool } from "./tools/generateSiUrl.ts";
+import { componentGenerateTemplateTool } from "./tools/componentGenerateTemplate.ts";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -48,6 +49,7 @@ export function createServer(): McpServer {
   componentDeleteTool(server);
   componentEraseTool(server);
   componentRestoreTool(server);
+  componentGenerateTemplateTool(server);
   generateSiUrlTool(server);
   importPrompt(server);
   discoverPrompt(server);

--- a/bin/si-mcp-server/src/tools/actionUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/actionUpdateStatus.ts
@@ -55,58 +55,58 @@ export function actionUpdateTool(server: McpServer) {
     },
     async ({ changeSetId, newStatus, actionId }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      if (!changeSetId) {
-        return errorResponse({
-          message:
-            "Must provide a change set id; ensure you get one from the user!",
-        });
-      }
-      if (!newStatus) {
-        return errorResponse({
-          message:
-            "Must provide a new status for the action; ensure you get one from the user!",
-        });
-      }
-
-      const siApi = new ActionsApi(apiConfig);
-      try {
-        // Confirm the change set you want to manipulate isn't HEAD
-        if (newStatus == "on-hold") {
-          const response = await siApi.putOnHold({
-            workspaceId: WORKSPACE_ID,
-            changeSetId,
-            actionId,
-          });
-          return successResponse(
-            response.data,
-          );
-        } else if (newStatus == "off-hold" || newStatus == "retry") {
-          const response = await siApi.retryAction({
-            workspaceId: WORKSPACE_ID,
-            changeSetId,
-            actionId,
-          });
-          return successResponse(
-            response.data,
-          );
-        } else if (newStatus == "remove") {
-          const response = await siApi.cancelAction({
-            workspaceId: WORKSPACE_ID,
-            changeSetId,
-            actionId,
-          });
-          return successResponse(
-            response.data,
-          );
-        } else {
+        if (!changeSetId) {
           return errorResponse({
             message:
-              `Invalid status '${newStatus}'. Must be one of: on-hold, off-hold, retry, remove`,
+              "Must provide a change set id; ensure you get one from the user!",
           });
         }
-      } catch (error) {
-        return errorResponse(error);
-      }
+        if (!newStatus) {
+          return errorResponse({
+            message:
+              "Must provide a new status for the action; ensure you get one from the user!",
+          });
+        }
+
+        const siApi = new ActionsApi(apiConfig);
+        try {
+          // Confirm the change set you want to manipulate isn't HEAD
+          if (newStatus == "on-hold") {
+            const response = await siApi.putOnHold({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+              actionId,
+            });
+            return successResponse(
+              response.data,
+            );
+          } else if (newStatus == "off-hold" || newStatus == "retry") {
+            const response = await siApi.retryAction({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+              actionId,
+            });
+            return successResponse(
+              response.data,
+            );
+          } else if (newStatus == "remove") {
+            const response = await siApi.cancelAction({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+              actionId,
+            });
+            return successResponse(
+              response.data,
+            );
+          } else {
+            return errorResponse({
+              message:
+                `Invalid status '${newStatus}'. Must be one of: on-hold, off-hold, retry, remove`,
+            });
+          }
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/changeSetCreate.ts
+++ b/bin/si-mcp-server/src/tools/changeSetCreate.ts
@@ -48,24 +48,24 @@ export function changeSetCreateTool(server: McpServer) {
     },
     async ({ changeSetName }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      if (!changeSetName) {
-        return errorResponse({
-          message:
-            "Must provide a change set name; ensure you get one from the user!",
-        });
-      }
-      const siApi = new ChangeSetsApi(apiConfig);
-      try {
-        const response = await siApi.createChangeSet({
-          workspaceId: WORKSPACE_ID,
-          createChangeSetV1Request: { changeSetName },
-        });
-        return successResponse(
-          response.data.changeSet,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+        if (!changeSetName) {
+          return errorResponse({
+            message:
+              "Must provide a change set name; ensure you get one from the user!",
+          });
+        }
+        const siApi = new ChangeSetsApi(apiConfig);
+        try {
+          const response = await siApi.createChangeSet({
+            workspaceId: WORKSPACE_ID,
+            createChangeSetV1Request: { changeSetName },
+          });
+          return successResponse(
+            response.data.changeSet,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/changeSetList.ts
+++ b/bin/si-mcp-server/src/tools/changeSetList.ts
@@ -46,18 +46,18 @@ export function changeSetListTool(server: McpServer) {
     },
     async (): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ChangeSetsApi(apiConfig);
-      try {
-        const response = await siApi.listChangeSets({
-          workspaceId: WORKSPACE_ID,
-        });
-        return successResponse(
-          response.data.changeSets,
-          hints,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+        const siApi = new ChangeSetsApi(apiConfig);
+        try {
+          const response = await siApi.listChangeSets({
+            workspaceId: WORKSPACE_ID,
+          });
+          return successResponse(
+            response.data.changeSets,
+            hints,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
@@ -12,7 +12,8 @@ import {
 
 const name = "change-set-update-status";
 const title = "Update the status of a change set";
-const description = `<description>Update the status of a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon (or 'delete') a change set, Apply a change set, or Force Apply the change set (ignoring all approvals). You may *never* update the status of the HEAD change set.</usage>`;
+const description =
+  `<description>Update the status of a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon (or 'delete') a change set, Apply a change set, or Force Apply the change set (ignoring all approvals). You may *never* update the status of the HEAD change set.</usage>`;
 
 const UpdateChangeSetInputSchemaRaw = {
   newStatus: z
@@ -57,78 +58,79 @@ export function changeSetUpdateTool(server: McpServer) {
     },
     async ({ changeSetId, newStatus }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      if (!changeSetId) {
-        return errorResponse({
-          message:
-            "Must provide a change set id; ensure you get one from the user!",
-        });
-      }
-      if (!newStatus) {
-        return errorResponse({
-          message:
-            "Must provide a new status for the change set; ensure you get one from the user!",
-        });
-      }
-
-      const siApi = new ChangeSetsApi(apiConfig);
-      try {
-        const response = await siApi.getChangeSet({
-          workspaceId: WORKSPACE_ID,
-          changeSetId,
-        });
-        if (response.data.changeSet.isHead) {
+        if (!changeSetId) {
           return errorResponse({
             message:
-              "You may not change the status of the HEAD change set. Inform the user that HEAD is immutable, and they should not try and change its status. Call them a cheeky monkey.",
+              "Must provide a change set id; ensure you get one from the user!",
           });
         }
-      } catch (error) {
-        return errorResponse(error);
-      }
+        if (!newStatus) {
+          return errorResponse({
+            message:
+              "Must provide a new status for the change set; ensure you get one from the user!",
+          });
+        }
 
-      try {
-        // Confirm the change set you want to manipulate isn't HEAD
-        if (newStatus == "abandon") {
-          const response = await siApi.abandonChangeSet({
+        const siApi = new ChangeSetsApi(apiConfig);
+        try {
+          const response = await siApi.getChangeSet({
             workspaceId: WORKSPACE_ID,
             changeSetId,
           });
-          return successResponse(response.data);
-        } else if (newStatus == "apply") {
-          const response = await siApi.requestApproval({
-            workspaceId: WORKSPACE_ID,
-            changeSetId,
-          });
-          try {
-            const newResponse = await siApi.getChangeSet({
+          if (response.data.changeSet.isHead) {
+            return errorResponse({
+              message:
+                "You may not change the status of the HEAD change set. Inform the user that HEAD is immutable, and they should not try and change its status. Call them a cheeky monkey.",
+            });
+          }
+        } catch (error) {
+          return errorResponse(error);
+        }
+
+        try {
+          // Confirm the change set you want to manipulate isn't HEAD
+          if (newStatus == "abandon") {
+            const response = await siApi.abandonChangeSet({
               workspaceId: WORKSPACE_ID,
               changeSetId,
             });
-            if (newResponse.data.changeSet.status == "NeedsApproval") {
-              return successResponse(
-                response.data,
-                "Tell the user that while the request was successful, the Change Set requires review and explicit Approval.",
-              );
-            } else {
-              return successResponse(response.data);
+            return successResponse(response.data);
+          } else if (newStatus == "apply") {
+            const response = await siApi.requestApproval({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+            });
+            try {
+              const newResponse = await siApi.getChangeSet({
+                workspaceId: WORKSPACE_ID,
+                changeSetId,
+              });
+              if (newResponse.data.changeSet.status == "NeedsApproval") {
+                return successResponse(
+                  response.data,
+                  "Tell the user that while the request was successful, the Change Set requires review and explicit Approval.",
+                );
+              } else {
+                return successResponse(response.data);
+              }
+            } catch (error) {
+              return errorResponse(error);
             }
-          } catch (error) {
-            return errorResponse(error);
+          } else if (newStatus == "force-apply") {
+            const response = await siApi.forceApply({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
+            });
+            return successResponse(response.data);
+          } else {
+            return errorResponse({
+              message:
+                `Invalid status '${newStatus}'. Must be one of: abandon, apply or force-apply`,
+            });
           }
-        } else if (newStatus == "force-apply") {
-          const response = await siApi.forceApply({
-            workspaceId: WORKSPACE_ID,
-            changeSetId,
-          });
-          return successResponse(response.data);
-        } else {
-          return errorResponse({
-            message: `Invalid status '${newStatus}'. Must be one of: abandon, apply or force-apply`,
-          });
+        } catch (error) {
+          return errorResponse(error);
         }
-      } catch (error) {
-        return errorResponse(error);
-      }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/commonBehavior.ts
+++ b/bin/si-mcp-server/src/tools/commonBehavior.ts
@@ -5,7 +5,7 @@ import { analytics } from "../analytics.ts";
 
 export async function withAnalytics<T extends { isError?: boolean }>(
   toolName: string,
-  operation: () => Promise<T>
+  operation: () => Promise<T>,
 ): Promise<T> {
   const startTime = Date.now();
   const result = await operation();
@@ -13,9 +13,9 @@ export async function withAnalytics<T extends { isError?: boolean }>(
   if (result.isError) {
     // todo: track more interesting info
     await analytics.trackError(toolName);
-  } else { 
+  } else {
     // todo: consider otel for error tracking
-    await analytics.trackToolUsage(toolName, executionTime); 
+    await analytics.trackToolUsage(toolName, executionTime);
   }
   return result;
 }

--- a/bin/si-mcp-server/src/tools/componentCreate.ts
+++ b/bin/si-mcp-server/src/tools/componentCreate.ts
@@ -61,29 +61,29 @@ export function componentCreateTool(server: McpServer) {
       { changeSetId, componentName, schemaName, attributes },
     ): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        const response = await siApi.createComponent({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          createComponentV1Request: {
-            name: componentName,
-            schemaName,
-            attributes,
-          },
-        });
-        const result: CreateComponentResult = {
-          componentId: response.data.component.id,
-          componentName: response.data.component.name,
-          schemaName: schemaName,
-        };
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          const response = await siApi.createComponent({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            createComponentV1Request: {
+              name: componentName,
+              schemaName,
+              attributes,
+            },
+          });
+          const result: CreateComponentResult = {
+            componentId: response.data.component.id,
+            componentName: response.data.component.name,
+            schemaName: schemaName,
+          };
 
-        return successResponse(
-          result,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+          return successResponse(
+            result,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentDelete.ts
+++ b/bin/si-mcp-server/src/tools/componentDelete.ts
@@ -12,7 +12,8 @@ import {
 
 const name = "component-delete";
 const title = "Delete a component";
-const description = `<description>Delete a component and the resource for a given componentId. Returns the deletion status on successful deletion. On failure, returns error details.</description><usage>Use this tool to delete a component and its resource in a change set. The component and resource will be marked for deletion and the component removed from the workspace.</usage>`;
+const description =
+  `<description>Delete a component and the resource for a given componentId. Returns the deletion status on successful deletion. On failure, returns error details.</description><usage>Use this tool to delete a component and its resource in a change set. The component and resource will be marked for deletion and the component removed from the workspace.</usage>`;
 
 const DeleteComponentInputSchemaRaw = {
   changeSetId: z
@@ -60,21 +61,21 @@ export function componentDeleteTool(server: McpServer) {
     },
     async ({ changeSetId, componentId }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        await siApi.deleteComponent({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          componentId,
-        });
-        const result: DeleteComponentResult = {
-          success: true,
-        };
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          await siApi.deleteComponent({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            componentId,
+          });
+          const result: DeleteComponentResult = {
+            success: true,
+          };
 
-        return successResponse(result);
-      } catch (error) {
-        return errorResponse(error);
-      }
+          return successResponse(result);
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentDiscover.ts
+++ b/bin/si-mcp-server/src/tools/componentDiscover.ts
@@ -18,7 +18,8 @@ import { AttributesSchema } from "../data/components.ts";
 const name = "component-discover";
 const title =
   "Discover all the resources for a given schema, creating components for them all.";
-const description = `<description>Discover all the resources for a given schema name, and create components for them in a change set. This tool will delete any components it uses to be able to refine the requirements of the discover process.</description><usage>Use this tool to bring an all the existing resources for a given Schema into System Initiative. For example, if the user asks to discover AWS::EC2::VPC's, then this tool will find all of the AWS::EC2::VPC's in the given region and account. After discovering components, you should ask the user if they want you to update the attributes of the discovered components to use subscriptions to any existing components attributes - for example, a discovered AWS::EC2::Subnet would be updated to have a subscription to the /resource_value/VpcId of the AWS::EC2::VPC that matches the imported VpcId attribute of the subnet.</usage>`;
+const description =
+  `<description>Discover all the resources for a given schema name, and create components for them in a change set. This tool will delete any components it uses to be able to refine the requirements of the discover process.</description><usage>Use this tool to bring an all the existing resources for a given Schema into System Initiative. For example, if the user asks to discover AWS::EC2::VPC's, then this tool will find all of the AWS::EC2::VPC's in the given region and account. After discovering components, you should ask the user if they want you to update the attributes of the discovered components to use subscriptions to any existing components attributes - for example, a discovered AWS::EC2::Subnet would be updated to have a subscription to the /resource_value/VpcId of the AWS::EC2::VPC that matches the imported VpcId attribute of the subnet.</usage>`;
 
 const DiscoverComponentInputSchemaRaw = {
   changeSetId: z
@@ -84,131 +85,135 @@ export function componentDiscoverTool(server: McpServer) {
       attributes,
     }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      if (schemaName.startsWith("AWS")) {
-        let hasCredential = false;
-        let hasRegion = false;
-        for (const path of Object.keys(attributes)) {
-          if (path == "/domain/extra/Region") {
-            hasRegion = true;
+        if (schemaName.startsWith("AWS")) {
+          let hasCredential = false;
+          let hasRegion = false;
+          for (const path of Object.keys(attributes)) {
+            if (path == "/domain/extra/Region") {
+              hasRegion = true;
+            }
+            if (path == "/secrets/AWS Credential") {
+              hasCredential = true;
+            }
           }
-          if (path == "/secrets/AWS Credential") {
-            hasCredential = true;
+          if (!hasCredential || !hasRegion) {
+            return errorResponse({
+              response: { status: "bad prereq", data: {} },
+              message:
+                `This is an AWS resource, and to import it we must have /domain/extra/Region set to a valid value or subscription, and /secrets/AWS Credential set to a subscription.`,
+            });
           }
         }
-        if (!hasCredential || !hasRegion) {
-          return errorResponse({
-            response: { status: "bad prereq", data: {} },
-            message: `This is an AWS resource, and to import it we must have /domain/extra/Region set to a valid value or subscription, and /secrets/AWS Credential set to a subscription.`,
-          });
-        }
-      }
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        const discoverTemplateresponse = await siApi.createComponent({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          createComponentV1Request: {
-            name: `Discover ${schemaName} - Temporary`,
-            schemaName,
-            attributes,
-          },
-        });
-        const discoverTemplateResult: Record<string, string> = {
-          componentId: discoverTemplateresponse.data.component.id,
-          componentName: discoverTemplateresponse.data.component.name,
-          schemaName: schemaName,
-        };
-
-        // Lets dequeue any actions created for this component
-        const actionsApi = new ActionsApi(apiConfig);
-        const queuedDiscoveryComponentActions = await actionsApi.getActions({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-        });
-        for (const action of queuedDiscoveryComponentActions.data.actions) {
-          await actionsApi.cancelAction({
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          const discoverTemplateresponse = await siApi.createComponent({
             workspaceId: WORKSPACE_ID,
             changeSetId: changeSetId,
-            actionId: action.id,
-          });
-        }
-
-        try {
-          const discoverResponse = await siApi.executeManagementFunction({
-            workspaceId: WORKSPACE_ID,
-            changeSetId,
-            componentId: discoverTemplateResult["componentId"],
-            executeManagementFunctionV1Request: {
-              managementFunction: { function: "Discover on AWS" },
+            createComponentV1Request: {
+              name: `Discover ${schemaName} - Temporary`,
+              schemaName,
+              attributes,
             },
           });
+          const discoverTemplateResult: Record<string, string> = {
+            componentId: discoverTemplateresponse.data.component.id,
+            componentName: discoverTemplateresponse.data.component.name,
+            schemaName: schemaName,
+          };
 
-          let discoverState = "Pending";
-          const retrySleepInMs = 1000;
-          const retryMaxCount = 260;
-          let currentCount = 0;
-
-          const mgmtApi = new ManagementFuncsApi(apiConfig);
-          while (
-            (discoverState == "Pending" ||
-              discoverState == "Executing" ||
-              discoverState == "Operating") &&
-            currentCount <= retryMaxCount
-          ) {
-            if (currentCount != 0) {
-              sleep(retrySleepInMs);
-            }
-            try {
-              const status = await mgmtApi.getManagementFuncRunState({
-                workspaceId: WORKSPACE_ID,
-                changeSetId,
-                managementFuncJobStateId:
-                  discoverResponse.data.managementFuncJobStateId,
-              });
-              discoverState = status.data.state;
-              discoverTemplateResult["funcRunId"] = status.data.funcRunId;
-              currentCount += 1;
-            } catch (error) {
-              return errorResponse({
-                message: `error fetching management function state: ${JSON.stringify(
-                  error,
-                  null,
-                  2,
-                )}`,
-              });
-            }
-          }
-          if (currentCount > retryMaxCount) {
-            return successResponse(
-              discoverTemplateResult,
-              "The discover function is still in progress; use the funcRunId to find out more",
-            );
-          } else if (discoverState == "Failure") {
-            return errorResponse({
-              response: {
-                status: "failed",
-                data: discoverTemplateResult,
-              },
-              message: `failed to discover ${schemaName} resources; see funcRunId ${
-                discoverTemplateResult["funcRunId"]
-              } with the func-run-get tool for more information`,
-            });
-          } else {
-            // Let's cleanup the discovery component now that the management function is successful
-            await siApi.deleteComponent({
+          // Lets dequeue any actions created for this component
+          const actionsApi = new ActionsApi(apiConfig);
+          const queuedDiscoveryComponentActions = await actionsApi.getActions({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+          });
+          for (const action of queuedDiscoveryComponentActions.data.actions) {
+            await actionsApi.cancelAction({
               workspaceId: WORKSPACE_ID,
               changeSetId: changeSetId,
+              actionId: action.id,
+            });
+          }
+
+          try {
+            const discoverResponse = await siApi.executeManagementFunction({
+              workspaceId: WORKSPACE_ID,
+              changeSetId,
               componentId: discoverTemplateResult["componentId"],
+              executeManagementFunctionV1Request: {
+                managementFunction: { function: "Discover on AWS" },
+              },
             });
 
-            return successResponse(discoverTemplateResult);
+            let discoverState = "Pending";
+            const retrySleepInMs = 1000;
+            const retryMaxCount = 260;
+            let currentCount = 0;
+
+            const mgmtApi = new ManagementFuncsApi(apiConfig);
+            while (
+              (discoverState == "Pending" ||
+                discoverState == "Executing" ||
+                discoverState == "Operating") &&
+              currentCount <= retryMaxCount
+            ) {
+              if (currentCount != 0) {
+                sleep(retrySleepInMs);
+              }
+              try {
+                const status = await mgmtApi.getManagementFuncRunState({
+                  workspaceId: WORKSPACE_ID,
+                  changeSetId,
+                  managementFuncJobStateId:
+                    discoverResponse.data.managementFuncJobStateId,
+                });
+                discoverState = status.data.state;
+                discoverTemplateResult["funcRunId"] = status.data.funcRunId;
+                currentCount += 1;
+              } catch (error) {
+                return errorResponse({
+                  message: `error fetching management function state: ${
+                    JSON.stringify(
+                      error,
+                      null,
+                      2,
+                    )
+                  }`,
+                });
+              }
+            }
+            if (currentCount > retryMaxCount) {
+              return successResponse(
+                discoverTemplateResult,
+                "The discover function is still in progress; use the funcRunId to find out more",
+              );
+            } else if (discoverState == "Failure") {
+              return errorResponse({
+                response: {
+                  status: "failed",
+                  data: discoverTemplateResult,
+                },
+                message:
+                  `failed to discover ${schemaName} resources; see funcRunId ${
+                    discoverTemplateResult["funcRunId"]
+                  } with the func-run-get tool for more information`,
+              });
+            } else {
+              // Let's cleanup the discovery component now that the management function is successful
+              await siApi.deleteComponent({
+                workspaceId: WORKSPACE_ID,
+                changeSetId: changeSetId,
+                componentId: discoverTemplateResult["componentId"],
+              });
+
+              return successResponse(discoverTemplateResult);
+            }
+          } catch (error) {
+            return errorResponse(error);
           }
         } catch (error) {
           return errorResponse(error);
         }
-      } catch (error) {
-        return errorResponse(error);
-      }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentEnqueueAction.ts
+++ b/bin/si-mcp-server/src/tools/componentEnqueueAction.ts
@@ -58,24 +58,24 @@ export function componentEnqueueActionTool(server: McpServer) {
       { changeSetId, componentId, actionName },
     ): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        const response = await siApi.addAction({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          componentId,
-          addActionV1Request: {
-            action: {
-              function: actionName,
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          const response = await siApi.addAction({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            componentId,
+            addActionV1Request: {
+              action: {
+                function: actionName,
+              },
             },
-          },
-        });
-        return successResponse(
-          response.data,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+          });
+          return successResponse(
+            response.data,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentErase.ts
+++ b/bin/si-mcp-server/src/tools/componentErase.ts
@@ -12,7 +12,8 @@ import {
 
 const name = "component-erase";
 const title = "Erase a component";
-const description = `<description>Erase a component, removing it completely from System Initiative without enqueuing a delete action or ensuring that downstream components aren't impacted by the removal. This can leave upstream provider resources orphaned (no longer managed by System Initiative) and can negatively impact downstream components if not used carefully. Returns true when successfully erased. On failure, returns error details. This cannot be undone within the change set!</description><usage>Use this tool to remove a component from System Initiative in a change set. You can use this tool to immediately cleanup any components from the model without needing to enqueue a delete action. The component will be immediately removed from the change set and the real world resource will be left intact. If you erase a component that has subscriptions to downstream components, the subscriptions will be removed and the values will no longer be propagated. Only use this tool if it's acceptable to sever the connection with the real world resource, or you no longer need data to propagate to downstream components, otherwise you should prefer to use Delete. This cannot be undone within this change set!</usage>`;
+const description =
+  `<description>Erase a component, removing it completely from System Initiative without enqueuing a delete action or ensuring that downstream components aren't impacted by the removal. This can leave upstream provider resources orphaned (no longer managed by System Initiative) and can negatively impact downstream components if not used carefully. Returns true when successfully erased. On failure, returns error details. This cannot be undone within the change set!</description><usage>Use this tool to remove a component from System Initiative in a change set. You can use this tool to immediately cleanup any components from the model without needing to enqueue a delete action. The component will be immediately removed from the change set and the real world resource will be left intact. If you erase a component that has subscriptions to downstream components, the subscriptions will be removed and the values will no longer be propagated. Only use this tool if it's acceptable to sever the connection with the real world resource, or you no longer need data to propagate to downstream components, otherwise you should prefer to use Delete. This cannot be undone within this change set!</usage>`;
 
 const EraseComponentInputSchemaRaw = {
   changeSetId: z
@@ -58,21 +59,21 @@ export function componentEraseTool(server: McpServer) {
     },
     async ({ changeSetId, componentId }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        await siApi.eraseComponent({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          componentId,
-        });
-        const result: EraseComponentResult = {
-          success: true,
-        };
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          await siApi.eraseComponent({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            componentId,
+          });
+          const result: EraseComponentResult = {
+            success: true,
+          };
 
-        return successResponse(result);
-      } catch (error) {
-        return errorResponse(error);
-      }
+          return successResponse(result);
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentGenerateTemplate.ts
+++ b/bin/si-mcp-server/src/tools/componentGenerateTemplate.ts
@@ -1,0 +1,141 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ComponentsApi, SchemasApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+  withAnalytics,
+} from "./commonBehavior.ts";
+
+const name = "component-generate-template";
+const title = "Generate a template from a list a components";
+const description =
+  `<description>Generate a template for a given list of componentIds and a name for the template. If the list is empty, do not use this tool. Only include componentIds explicitly listed. The name can either be explicitly given or generated based on the names of the components themselves. The name must be relevant to the components chosen. Returns the 'success' on successful creation of a template. On failure, returns error details.</description><usage>Use this tool to generate a template from at least one component in a change set. Use only the component-list tool to understand the components that are available to be included in a template. For the template name, generate it based on the component names, schema names, and their conceptual relevancy to one another. To see all of its information after the template has been generated, use the schema-find tool.</usage>`;
+
+const ComponentGenerateTemplateInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to generate a template in; templates cannot be generated on the HEAD change set",
+  ),
+  componentIds: z.array(
+    z.string().describe(
+      "the component id to be included in the generated template",
+    ),
+  ).describe(
+    "the list of component ids to be included in the generated template",
+  ),
+  templateName: z.string().describe(
+    "the name of the template that will be generated",
+  ),
+  secrets: z.boolean().optional().describe(
+    "include secret-defining components in the template to be generated; useful for excluding common base components and not tying in credential setup into templates; the user may want to make this decision themselves",
+  ),
+  region: z.boolean().optional().describe(
+    "include components that define the region for your infrastructure in the template to be generated; useful for excluding common base components; the user may want to make this decision themselves",
+  ),
+};
+
+const ComponentGenerateTemplateOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({
+    schemaId: z.string().describe("the schema id of the generated template"),
+    schemaVariantId: z.string().describe(
+      "the schema variant id of the generated template",
+    ),
+    funcId: z.string().describe(
+      "the func id for running the generated template",
+    ),
+    schema: z.object({
+      // FIXME(nick,aaron): re-use this type from the "find-schema" tool rather than hard copy/paste.
+      schemaId: z.string().describe("the schema id for the generated template"),
+      schemaName: z.string().describe(
+        "the name of the schema for the generated template",
+      ),
+      description: z
+        .string()
+        .optional()
+        .describe(
+          "a description of the schema for the generated template, frequently containing documentation",
+        ),
+      link: z
+        .string()
+        .url()
+        .optional()
+        .describe(
+          "an external URL that contains documentation about what this schema for the generated template is modeling; this will likely be null because we just generated it",
+        ),
+    })
+      .optional()
+      .describe("the information for the schema for the generated template"),
+  }).describe(
+    "the information for the generated template including all ids relevant for future tasks; the ids are not as important to the user, but there is not need to obfuscate them either",
+  ),
+};
+
+const ComponentGenerateTemplateOutputSchema = z.object(
+  ComponentGenerateTemplateOutputSchemaRaw,
+);
+
+type ComponentGenerateTemplateResult = z.infer<
+  typeof ComponentGenerateTemplateOutputSchema
+>["data"];
+
+export function componentGenerateTemplateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "componentGenerateTemplate",
+        ComponentGenerateTemplateOutputSchema,
+      ),
+      inputSchema: ComponentGenerateTemplateInputSchemaRaw,
+      outputSchema: ComponentGenerateTemplateOutputSchemaRaw,
+    },
+    async (
+      { changeSetId, componentIds, templateName },
+    ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
+        const siComponentsApi = new ComponentsApi(apiConfig);
+        const siSchemasApi = new SchemasApi(apiConfig);
+
+        try {
+          const response = await siComponentsApi.generateTemplate({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            generateTemplateV1Request: {
+              componentIds,
+              assetName: templateName,
+              funcName: `Generate ${templateName}`,
+            },
+          });
+
+          const schemaResponse = await siSchemasApi.findSchema({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            schemaId: response.data.schemaId,
+          });
+
+          const result: ComponentGenerateTemplateResult = {
+            schemaId: response.data.schemaId,
+            schemaVariantId: response.data.schemaVariantId,
+            funcId: response.data.funcId,
+            schema: schemaResponse.data,
+          };
+
+          return successResponse(
+            result,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
+      });
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/componentGet.ts
+++ b/bin/si-mcp-server/src/tools/componentGet.ts
@@ -111,113 +111,114 @@ export function componentGetTool(server: McpServer) {
       { changeSetId, componentId, code, qualifications },
     ): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        const response = await siApi.getComponent({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          componentId,
-        });
-        // _.pickBy(response.data.component.attributes, (_value, key) => key.includes('/code'))
-        const attributes = _.pickBy(
-          response.data.component.attributes,
-          (_value: unknown, key: string) =>
-            key.startsWith("/domain") || key.startsWith("/si/name") ||
-            key.startsWith("/resource_value") || key.startsWith("/secrets"),
-        );
-        const result: GetComponentResult = {
-          componentId: response.data.component.id,
-          componentName: response.data.component.name,
-          resourceId: response.data.component.resourceId,
-          attributes: attributes as GetComponentResult["attributes"],
-          actions: response.data.actionFunctions.map((af) => {
-            return { actionName: af.funcName };
-          }),
-          management: response.data.managementFunctions.map((mf) => {
-            return { managementName: mf.funcName };
-          }),
-        };
-        if (code) {
-          const codeAttributes = _.pickBy(
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          const response = await siApi.getComponent({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            componentId,
+          });
+          // _.pickBy(response.data.component.attributes, (_value, key) => key.includes('/code'))
+          const attributes = _.pickBy(
             response.data.component.attributes,
-            (_value: unknown, key: string) => key.startsWith("/code"),
+            (_value: unknown, key: string) =>
+              key.startsWith("/domain") || key.startsWith("/si/name") ||
+              key.startsWith("/resource_value") || key.startsWith("/secrets"),
           );
-          const code: NonNullable<GetComponentResult["code"]> = {};
-          for (const [path, codeValue] of Object.entries(codeAttributes)) {
-            const match = path.match(/^\/code\/([^\/]+)\/([^\/]+)/);
-            if (match) {
-              if (!code[match[1]]) {
-                code[match[1]] = { code: "", format: "" };
-              }
-              if (match[2] === "code" || match[2] === "format") {
-                code[match[1]][match[2] as "code" | "format"] =
-                  codeValue as string;
-              }
-            }
-          }
-          result["code"] = code;
-        }
-        if (qualifications) {
-          const qualAttributes = _.pickBy(
-            response.data.component.attributes,
-            (_value: unknown, key: string) => key.startsWith("/qualification"),
-          );
-          const qualifications: NonNullable<
-            GetComponentResult["qualifications"]
-          > = {};
-          for (const [path, qualValue] of Object.entries(qualAttributes)) {
-            const match = path.match(/^\/qualification\/([^\/]+)\/([^\/]+)/);
-            if (match) {
-              if (!qualifications[match[1]]) {
-                qualifications[match[1]] = { result: "unknown", message: "" };
-              }
-              if (match[2] === "result") {
-                qualifications[match[1]]["result"] = qualValue as
-                  | "failure"
-                  | "success"
-                  | "unknown"
-                  | "warning";
-              } else if (match[2] === "message") {
-                qualifications[match[1]]["message"] = qualValue as string;
-              }
-            }
-          }
-          result["qualifications"] = qualifications;
-        }
-        const resourceAttributes = _.pickBy(
-          response.data.component.attributes,
-          (_value: unknown, key: string) => key.startsWith("/resource/"),
-        );
-        const resource: {
-          status?: "ok" | "error" | "warning";
-          resourceData?: unknown;
-          lastSynced?: string;
-        } = {};
-        for (
-          const [path, resourceValue] of Object.entries(resourceAttributes)
-        ) {
-          if (path == "/resource/status") {
-            resource["status"] = resourceValue as "ok" | "error" | "warning";
-          } else if (path == "/resource/payload") {
-            resource["resourceData"] = resourceValue;
-          } else if (path == "/resource/last_synced") {
-            resource["lastSynced"] = resourceValue as string;
-          }
-        }
-        if (!_.isEmpty(resource) && resource.status && resource.lastSynced) {
-          result["resource"] = resource as {
-            status: "ok" | "error" | "warning";
-            lastSynced: string;
-            resourceData?: unknown;
+          const result: GetComponentResult = {
+            componentId: response.data.component.id,
+            componentName: response.data.component.name,
+            resourceId: response.data.component.resourceId,
+            attributes: attributes as GetComponentResult["attributes"],
+            actions: response.data.actionFunctions.map((af) => {
+              return { actionName: af.funcName };
+            }),
+            management: response.data.managementFunctions.map((mf) => {
+              return { managementName: mf.funcName };
+            }),
           };
-        }
+          if (code) {
+            const codeAttributes = _.pickBy(
+              response.data.component.attributes,
+              (_value: unknown, key: string) => key.startsWith("/code"),
+            );
+            const code: NonNullable<GetComponentResult["code"]> = {};
+            for (const [path, codeValue] of Object.entries(codeAttributes)) {
+              const match = path.match(/^\/code\/([^\/]+)\/([^\/]+)/);
+              if (match) {
+                if (!code[match[1]]) {
+                  code[match[1]] = { code: "", format: "" };
+                }
+                if (match[2] === "code" || match[2] === "format") {
+                  code[match[1]][match[2] as "code" | "format"] =
+                    codeValue as string;
+                }
+              }
+            }
+            result["code"] = code;
+          }
+          if (qualifications) {
+            const qualAttributes = _.pickBy(
+              response.data.component.attributes,
+              (_value: unknown, key: string) =>
+                key.startsWith("/qualification"),
+            );
+            const qualifications: NonNullable<
+              GetComponentResult["qualifications"]
+            > = {};
+            for (const [path, qualValue] of Object.entries(qualAttributes)) {
+              const match = path.match(/^\/qualification\/([^\/]+)\/([^\/]+)/);
+              if (match) {
+                if (!qualifications[match[1]]) {
+                  qualifications[match[1]] = { result: "unknown", message: "" };
+                }
+                if (match[2] === "result") {
+                  qualifications[match[1]]["result"] = qualValue as
+                    | "failure"
+                    | "success"
+                    | "unknown"
+                    | "warning";
+                } else if (match[2] === "message") {
+                  qualifications[match[1]]["message"] = qualValue as string;
+                }
+              }
+            }
+            result["qualifications"] = qualifications;
+          }
+          const resourceAttributes = _.pickBy(
+            response.data.component.attributes,
+            (_value: unknown, key: string) => key.startsWith("/resource/"),
+          );
+          const resource: {
+            status?: "ok" | "error" | "warning";
+            resourceData?: unknown;
+            lastSynced?: string;
+          } = {};
+          for (
+            const [path, resourceValue] of Object.entries(resourceAttributes)
+          ) {
+            if (path == "/resource/status") {
+              resource["status"] = resourceValue as "ok" | "error" | "warning";
+            } else if (path == "/resource/payload") {
+              resource["resourceData"] = resourceValue;
+            } else if (path == "/resource/last_synced") {
+              resource["lastSynced"] = resourceValue as string;
+            }
+          }
+          if (!_.isEmpty(resource) && resource.status && resource.lastSynced) {
+            result["resource"] = resource as {
+              status: "ok" | "error" | "warning";
+              lastSynced: string;
+              resourceData?: unknown;
+            };
+          }
 
-        return successResponse(
-          result,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+          return successResponse(
+            result,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentList.ts
+++ b/bin/si-mcp-server/src/tools/componentList.ts
@@ -88,37 +88,37 @@ export function componentListTool(server: McpServer) {
     async ({ changeSetId, filters }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
         if (!changeSetId) {
-        const changeSetsApi = new ChangeSetsApi(apiConfig);
-        try {
-          const changeSetList = await changeSetsApi.listChangeSets({
-            workspaceId: WORKSPACE_ID,
-          });
-          const changeSets = changeSetList.data.changeSets as ChangeSet[];
-          const head = changeSets.find((cs) => cs.isHead);
-          if (!head) {
+          const changeSetsApi = new ChangeSetsApi(apiConfig);
+          try {
+            const changeSetList = await changeSetsApi.listChangeSets({
+              workspaceId: WORKSPACE_ID,
+            });
+            const changeSets = changeSetList.data.changeSets as ChangeSet[];
+            const head = changeSets.find((cs) => cs.isHead);
+            if (!head) {
+              return errorResponse({
+                message: "Could not find HEAD change set",
+              });
+            }
+            changeSetId = head.id;
+          } catch (error) {
             return errorResponse({
-              message: "Could not find HEAD change set",
+              message:
+                `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
             });
           }
-          changeSetId = head.id;
-        } catch (error) {
-          return errorResponse({
-            message:
-              `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-          });
         }
-      }
-      try {
-        const response = await listAllComponents(apiConfig, changeSetId);
-        const filteredResponse = applyFilters(response, filters);
-        return successResponse(
-          filteredResponse,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+        try {
+          const response = await listAllComponents(apiConfig, changeSetId);
+          const filteredResponse = applyFilters(response, filters);
+          return successResponse(
+            filteredResponse,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/componentRestore.ts
+++ b/bin/si-mcp-server/src/tools/componentRestore.ts
@@ -11,7 +11,8 @@ import {
 
 const name = "component-restore";
 const title = "Restore a component that is marked for deletion";
-const description = `<description>Restores a component that is marked for deletion in a change set. Returns success if the component is restored. On failure, returns error details</description><usage>Use this tool when the user wants to restore a component that they marked for deletion. You can use the component-get tool to check if a component is set toDelete. A component will only be set toDelete if it exists on the HEAD change set and has an associated resource or has a dependent component. This will restore the component immediately and all of it's data and subscriptions. This will not work if the component has been erased!</usage>`;
+const description =
+  `<description>Restores a component that is marked for deletion in a change set. Returns success if the component is restored. On failure, returns error details</description><usage>Use this tool when the user wants to restore a component that they marked for deletion. You can use the component-get tool to check if a component is set toDelete. A component will only be set toDelete if it exists on the HEAD change set and has an associated resource or has a dependent component. This will restore the component immediately and all of it's data and subscriptions. This will not work if the component has been erased!</usage>`;
 
 const RestoreComponentInputSchemaRaw = {
   changeSetId: z

--- a/bin/si-mcp-server/src/tools/componentUpdate.ts
+++ b/bin/si-mcp-server/src/tools/componentUpdate.ts
@@ -58,26 +58,26 @@ export function componentUpdateTool(server: McpServer) {
       { changeSetId, attributes, componentId },
     ): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new ComponentsApi(apiConfig);
-      try {
-        await siApi.updateComponent({
-          workspaceId: WORKSPACE_ID,
-          changeSetId: changeSetId,
-          componentId,
-          updateComponentV1Request: {
-            attributes,
-          },
-        });
-        const result: UpdateComponentResult = {
-          success: true,
-        };
+        const siApi = new ComponentsApi(apiConfig);
+        try {
+          await siApi.updateComponent({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            componentId,
+            updateComponentV1Request: {
+              attributes,
+            },
+          });
+          const result: UpdateComponentResult = {
+            success: true,
+          };
 
-        return successResponse(
-          result,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+          return successResponse(
+            result,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/tools/funcRunGet.ts
+++ b/bin/si-mcp-server/src/tools/funcRunGet.ts
@@ -14,7 +14,8 @@ import { decodeBase64 } from "@std/encoding/base64";
 
 const name = "func-run-get";
 const title = "Get a function run information";
-const description = `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
+const description =
+  `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
 
 const GetFuncRunInputSchemaRaw = {
   changeSetId: z
@@ -172,10 +173,12 @@ export function funcRunGetTool(server: McpServer) {
             }
             changeSetId = head.id;
           } catch (error) {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
+            const errorMessage = error instanceof Error
+              ? error.message
+              : String(error);
             return errorResponse({
-              message: `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+              message:
+                `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
             });
           }
         }
@@ -194,8 +197,7 @@ export function funcRunGetTool(server: McpServer) {
             componentId: response.data.funcRun.componentId,
             componentName: response.data.funcRun.componentName,
             schemaName: response.data.funcRun.schemaName,
-            functionName:
-              response.data.funcRun.functionDisplayName ||
+            functionName: response.data.funcRun.functionDisplayName ||
               response.data.funcRun.functionName,
             functionKind: response.data.funcRun
               .functionKind as FuncRunResult["functionKind"],

--- a/bin/si-mcp-server/src/tools/generateSiUrl.ts
+++ b/bin/si-mcp-server/src/tools/generateSiUrl.ts
@@ -11,7 +11,8 @@ import {
 } from "./commonBehavior.ts";
 import { ChangeSet } from "../data/changeSets.ts";
 
-const description = `<description>Generates a URL for a component details page, the change set review screen, the change set map view or the default link for the workspace.</description><usage>Use this tool to generate a url to a component details page, change set review screen, the change set map view or the default change set page in the System Initiative web application. You should never try and create a component to match the users request. You should never offer to link the user to another component and you should never try and find a matching component in a different change set once a change set has been specified.</usage>`;
+const description =
+  `<description>Generates a URL for a component details page, the change set review screen, the change set map view or the default link for the workspace.</description><usage>Use this tool to generate a url to a component details page, change set review screen, the change set map view or the default change set page in the System Initiative web application. You should never try and create a component to match the users request. You should never offer to link the user to another component and you should never try and find a matching component in a different change set once a change set has been specified.</usage>`;
 
 const GenerateSiUrlInputSchemaRaw = {
   changeSetId: z
@@ -95,9 +96,10 @@ export function generateSiUrlTool(server: McpServer) {
           changeSetId = head.id;
         } catch (error) {
           return errorResponse({
-            message: `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
+            message:
+              `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
           });
         }
       }
@@ -136,7 +138,8 @@ export function generateSiUrlTool(server: McpServer) {
           result.url = generateComponentLink(changeSetId, componentId);
         } catch {
           return errorResponse({
-            message: `No component found in that change set. Tell the user to ensure they are using the correct change set.`,
+            message:
+              `No component found in that change set. Tell the user to ensure they are using the correct change set.`,
           });
         }
       }

--- a/bin/si-mcp-server/src/tools/schemaAttributesDocumentation.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesDocumentation.ts
@@ -17,7 +17,8 @@ import {
 
 const name = "schema-attributes-documentation";
 const title = "Schema Attributes Documentation";
-const description = `<description>Look up the documentation for Schema Attributes - you can look up many at once for a single schema. Returns an object with the schemaName and an array of documentation and path attribute objects. (if any). On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to understand how to use a particular attribute, or what values it accepts. Use attribute paths that mirror those returned from the schema-attributes-list tool. In addition, you can ask for the documentation for paths *earlier* than those returned by the attributes-list tool - for example, the tool might return '/domain/Tags/[array]/Key', but the user wants documentation for '/domain/Tags' - both are valid.</usage>`;
+const description =
+  `<description>Look up the documentation for Schema Attributes - you can look up many at once for a single schema. Returns an object with the schemaName and an array of documentation and path attribute objects. (if any). On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to understand how to use a particular attribute, or what values it accepts. Use attribute paths that mirror those returned from the schema-attributes-list tool. In addition, you can ask for the documentation for paths *earlier* than those returned by the attributes-list tool - for example, the tool might return '/domain/Tags/[array]/Key', but the user wants documentation for '/domain/Tags' - both are valid.</usage>`;
 
 const DocumentSchemaAttributesInputSchemaRaw = {
   schemaName: z
@@ -112,10 +113,12 @@ export function schemaAttributesDocumentationTool(server: McpServer) {
           }
           changeSetId = head.id;
         } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
+          const errorMessage = error instanceof Error
+            ? error.message
+            : String(error);
           return errorResponse({
-            message: `We could not find the HEAD change set; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+            message:
+              `We could not find the HEAD change set; this is a bug! Tell the user we are sorry: ${errorMessage}`,
           });
         }
 
@@ -148,10 +151,12 @@ export function schemaAttributesDocumentationTool(server: McpServer) {
             });
             schemaId = response.data.schemaId;
           } catch (error) {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
+            const errorMessage = error instanceof Error
+              ? error.message
+              : String(error);
             return errorResponse({
-              message: `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
+              message:
+                `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
             });
           }
 
@@ -178,7 +183,7 @@ export function schemaAttributesDocumentationTool(server: McpServer) {
             (schemaAttributePath: string) => {
               const documentation =
                 formatDocumentation(docsIndex, schemaAttributePath) ??
-                "There is no documentation for this attribute; if it is an AWS schema, consider looking up the data for the corresponding cloudformation resource";
+                  "There is no documentation for this attribute; if it is an AWS schema, consider looking up the data for the corresponding cloudformation resource";
 
               return { schemaAttributePath, documentation };
             },

--- a/bin/si-mcp-server/src/tools/schemaAttributesList.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesList.ts
@@ -14,7 +14,8 @@ import { buildAttributesStructure } from "../data/schemaAttributes.ts";
 
 const name = "schema-attributes-list";
 const title = "List all the attributes of a schema";
-const description = `<description>Lists all the attributes of a schema. Returns the schema name and an array of attribute objects that contain the Attribute Name, Path, and if it is Required. On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to discover what attributes (sometimes called properties) are available for a schema.</usage>`;
+const description =
+  `<description>Lists all the attributes of a schema. Returns the schema name and an array of attribute objects that contain the Attribute Name, Path, and if it is Required. On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to discover what attributes (sometimes called properties) are available for a schema.</usage>`;
 
 const ListSchemaAttributesInputSchemaRaw = {
   schemaName: z
@@ -96,10 +97,12 @@ export function schemaAttributesListTool(server: McpServer) {
           }
           changeSetId = head.id;
         } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
+          const errorMessage = error instanceof Error
+            ? error.message
+            : String(error);
           return errorResponse({
-            message: `We could not find the HEAD change set; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+            message:
+              `We could not find the HEAD change set; this is a bug! Tell the user we are sorry: ${errorMessage}`,
           });
         }
 
@@ -132,10 +135,12 @@ export function schemaAttributesListTool(server: McpServer) {
             });
             schemaId = response.data.schemaId;
           } catch (error) {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
+            const errorMessage = error instanceof Error
+              ? error.message
+              : String(error);
             return errorResponse({
-              message: `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
+              message:
+                `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
             });
           }
 

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -14,7 +14,8 @@ import { isValid } from "ulid";
 
 const name = "schema-find";
 const title = "Find component schemas";
-const description = `<description>Finds component schemas by name or Schema ID. Returns the Schema ID, Name, Description, and external documentation Link. On failure, returns error details. When looking for AWS Schemas, you can use the AWS Cloudformation Resource name (examples: AWS::EC2::Instance, AWS::Bedrock::Agent, or AWS::ControlTower::EnabledBaseline)</description><usage>Use this tool to find if a schema exists in System Initiative, to look up the Schema Name or Schema ID if you need it, or to display high level information about the schema.</usage>`;
+const description =
+  `<description>Finds component schemas by name or Schema ID. Returns the Schema ID, Name, Description, and external documentation Link. On failure, returns error details. When looking for AWS Schemas, you can use the AWS Cloudformation Resource name (examples: AWS::EC2::Instance, AWS::Bedrock::Agent, or AWS::ControlTower::EnabledBaseline)</description><usage>Use this tool to find if a schema exists in System Initiative, to look up the Schema Name or Schema ID if you need it, or to display high level information about the schema.</usage>`;
 
 const FindSchemaInputSchemaRaw = {
   changeSetId: z
@@ -38,6 +39,7 @@ const FindSchemaOutputSchemaRaw = {
     ),
   data: z
     .object({
+      // FIXME(nick,aaron): allow this type to be used in "component-generate-template".
       schemaId: z.string().describe("the schema id"),
       schemaName: z.string().describe("the name of the schema"),
       description: z
@@ -95,10 +97,12 @@ export function schemaFindTool(server: McpServer) {
             }
             changeSetId = head.id;
           } catch (error) {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
+            const errorMessage = error instanceof Error
+              ? error.message
+              : String(error);
             return errorResponse({
-              message: `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+              message:
+                `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
             });
           }
         }
@@ -132,10 +136,12 @@ export function schemaFindTool(server: McpServer) {
               });
               schemaId = response.data.schemaId;
             } catch (error) {
-              const errorMessage =
-                error instanceof Error ? error.message : String(error);
+              const errorMessage = error instanceof Error
+                ? error.message
+                : String(error);
               return errorResponse({
-                message: `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
+                message:
+                  `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
               });
             }
           } else {

--- a/bin/si-mcp-server/src/tools/validateCredentials.ts
+++ b/bin/si-mcp-server/src/tools/validateCredentials.ts
@@ -64,15 +64,15 @@ export function validateCredentialsTool(server: McpServer) {
     },
     async (): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
-      const siApi = new WhoamiApi(apiConfig);
-      try {
-        const response = await siApi.whoami();
-        return successResponse(
-          response.data,
-        );
-      } catch (error) {
-        return errorResponse(error);
-      }
+        const siApi = new WhoamiApi(apiConfig);
+        try {
+          const response = await siApi.whoami();
+          return successResponse(
+            response.data,
+          );
+        } catch (error) {
+          return errorResponse(error);
+        }
       });
     },
   );

--- a/bin/si-mcp-server/src/user_state.ts
+++ b/bin/si-mcp-server/src/user_state.ts
@@ -2,11 +2,12 @@ import axios from "npm:axios";
 import { apiConfig, WORKSPACE_ID } from "./si_client.ts";
 import { logger } from "./logger.ts";
 
-export async function setAiAgentUserFlag(){
-  const url = `${apiConfig.basePath}/v1/w/${WORKSPACE_ID}/user/set_ai_agent_executed`;
+export async function setAiAgentUserFlag() {
+  const url =
+    `${apiConfig.basePath}/v1/w/${WORKSPACE_ID}/user/set_ai_agent_executed`;
 
   try {
-    await axios.post(url, {}, apiConfig.baseOptions)
+    await axios.post(url, {}, apiConfig.baseOptions);
   } catch (error) {
     logger.error("Error setting AI agent flag:", error);
   }


### PR DESCRIPTION
## Description

This change adds a tool for generating templates from components. The tool not only generates the template, but it also finds the resulting schema. Along the way to making this change, the following was also changed:

- Format all "si-mcp-server" files using the buck2 target "fix-format" (side note: we should be checking for this in CI)
- Add an additional example finding buck2 targets locally to the dev docs (this was used to find the "fix-format" command)
- Return the schema ID in addition to the existing data in the luminork route for generating a template
- Try to find the schema on the graph first before going to cached modules when finding schemas in luminork

The primary change was tested by creating a VPC with two subnets and then generating a template from it. The template was then ran to confirm that it worked.

## Screenshot

<img width="1850" height="877" alt="Screenshot 2025-09-04 at 4 59 37 PM" src="https://github.com/user-attachments/assets/7522eea3-f51e-4aa5-807a-ea8ee7df7b5c" />