### PR TITLE
added test logic to check if reached lobby OR app

### DIFF
--- a/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
+++ b/app/web/cypress/e2e/workspace-management/workspace-dashboard.cy.ts
@@ -35,6 +35,10 @@ Cypress._.times(SI_CYPRESS_MULTIPLIER, () => {
         return false;
       });
 
+      // check to confirm that we have reached either the lobby or the app itself
+      cy.get("#app-layout").should("exist", { timeout: 60000 });
+      cy.url().should("contain", SI_WORKSPACE_ID);
+
       // checks for the new hotness UI Explore page
       // cy.appModelPageLoaded();
     });

--- a/app/web/cypress/support/commands.ts
+++ b/app/web/cypress/support/commands.ts
@@ -119,6 +119,9 @@ Cypress.Commands.add('basicLogin', () => {
   cy.sendPosthogEvent(Cypress.currentTest.titlePath.join("/"), "test_uuid", UUID);
   // cy.appModelPageLoaded();
   cy.wait(5000);
+  // check to confirm that we have reached either the lobby or the app itself
+  cy.get("#app-layout").should("exist", { timeout: 60000 });
+  cy.url().should("contain", SI_WORKSPACE_ID);
 });
 
 Cypress.Commands.add('createChangeSet', (changeSetName: string, immediatelyAbandon = false) => {


### PR DESCRIPTION
While we are unable to use `appModelPageLoaded` due to dirty env issues, this PR adds test logic to confirm that the test has made it into the Workspace at all, whether on the `Lobby` or through to the app itself.