### PR TITLE
re-enabling the e2e tests in tools crons only

### DIFF
--- a/.github/workflows/tools-test-cron.yml
+++ b/.github/workflows/tools-test-cron.yml
@@ -11,12 +11,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # e2e-validation:
-  #   uses: ./.github/workflows/e2e-validation.yml
-  #   with:
-  #     environment: tools
-  #     test_dir: cypress/e2e
-  #   secrets: inherit
+  e2e-validation:
+    uses: ./.github/workflows/e2e-validation.yml
+    with:
+      environment: tools
+      test_dir: cypress/e2e
+    secrets: inherit
   api-test:
     uses: ./.github/workflows/run-api-test.yml
     with:


### PR DESCRIPTION
Commenting back in the e2e tests for the tools crons