### PR TITLE
fix(luminork): Allow a user to set a secret to a secret attribute

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -47,8 +47,6 @@ pub use components::{
     ComponentsResult,
     ConnectionViewV1,
     DomainPropPath,
-    SecretPropKey,
-    SecretPropPath,
     SourceViewV1,
     add_action::{
         ActionReference,
@@ -93,6 +91,8 @@ pub use components::{
         SearchComponentsV1Response,
     },
     update_component::{
+        SecretPropKey,
+        SecretPropPath,
         UpdateComponentV1Request,
         UpdateComponentV1Response,
     },


### PR DESCRIPTION
When a component is for a secret defining variant (i.e. AWS Credential) then we need to let a user to be able to easily set a secret directly on the secret Attribute Value. If we force a user to set that secret via the attributes API, then we would require a user to know the SecretId to use.

We will now allow a user to set a secret directly. This will not work for subscriptions and will NOT work for components that are not secret definiting. They will get a 422 if they try to do that.

this PR makes it way easier for a user to do this via the API:
```
response = requests.put(
        f'{API_URL}/v1/w/{WORKSPACE_ID}/change-sets/{change_set_id}/components/{component_id}',
        headers=headers,
        json='secrets': {
                        'AWS Credential': ‘si-tools-sandbox'
                    }
    )
```


That would set the AWS Credential Secret AV in the AWS Credential Component to point to the secret `si-tools-sandbox`