### PR TITLE
fix: use isOriginSecret for subscription

### DIFF
--- a/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentSecretAttribute.vue
@@ -347,7 +347,10 @@ const secretFormOpen = ref(false);
 const interstitialSpinner = computed(
   () =>
     !props.attributeTree.secret &&
-    props.attributeTree.attributeValue.isControlledByDynamicFunc,
+    props.attributeTree.attributeValue.isControlledByDynamicFunc &&
+    (props.attributeTree.prop?.isOriginSecret ||
+      (props.attributeTree.attributeValue.externalSources &&
+        props.attributeTree.attributeValue.externalSources.length > 0)),
 );
 const showSecretForm = computed(
   () =>


### PR DESCRIPTION
FIXES: BUG-1010

Only show subscribing when theres an active subscription, not just when isControlledByDynamicFunc is true. Hopefully fixes issue where new components incorrectly displayed subscribing... on creation.

## How does this PR change the system?

I think this preserves the original intent of https://github.com/systeminit/si/pull/7184 but uses isOriginSecret to determine the correct behaviour when not an AWS Credential.

#### Screenshots:

JAM - https://jam.dev/c/1af78257-9c84-4049-a00c-3cc5f9492882

## How was it tested?

- [X] Manual test: (regression check) creating a component still works
- [X] Creating a new component in the UI no longer shows 'subscribing...' dy default

## In short: [:link:](https://giphy.com/)

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHpnc3RqdDN0MGZoZGpseWF1djJnamhxcTA1cjIyenJ6bGw2aTJkYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/o3XuiZ4h81IPvVfyJZ/giphy.gif)
