### PR TITLE
feat: split generate template luminork changes

### DIFF
--- a/lib/luminork-server/src/service/v1/components/generate_template.rs
+++ b/lib/luminork-server/src/service/v1/components/generate_template.rs
@@ -2,6 +2,7 @@ use axum::response::Json;
 use dal::{
     ComponentId,
     FuncId,
+    SchemaId,
     SchemaVariantId,
 };
 use serde::{
@@ -45,15 +46,16 @@ pub async fn generate_template(
 ) -> Result<Json<GenerateTemplateV1Response>, ComponentsError> {
     let Json(payload) = payload?;
 
-    let (new_variant, _, func, prototype_id) = sdf_core::generate_template::prepare_and_generate(
-        ctx,
-        payload.component_ids,
-        payload.asset_name.clone(),
-        payload.func_name.clone(),
-        payload.category.unwrap_or("Templates".to_string()),
-        "#aaaaaa".to_string(),
-    )
-    .await?;
+    let (new_variant, schema_id, func, prototype_id) =
+        sdf_core::generate_template::prepare_and_generate(
+            ctx,
+            payload.component_ids,
+            payload.asset_name.clone(),
+            payload.func_name.clone(),
+            payload.category.unwrap_or("Templates".to_string()),
+            "#aaaaaa".to_string(),
+        )
+        .await?;
 
     tracker.track(
         ctx,
@@ -80,6 +82,7 @@ pub async fn generate_template(
     ctx.commit().await?;
 
     Ok(Json(GenerateTemplateV1Response {
+        schema_id,
         schema_variant_id: new_variant.id,
         func_id: func.id,
     }))
@@ -102,7 +105,9 @@ pub struct GenerateTemplateV1Request {
 #[serde(rename_all = "camelCase")]
 pub struct GenerateTemplateV1Response {
     #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79AA")]
-    pub schema_variant_id: SchemaVariantId,
+    pub schema_id: SchemaId,
     #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79BB")]
+    pub schema_variant_id: SchemaVariantId,
+    #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79CC")]
     pub func_id: FuncId,
 }

--- a/lib/luminork-server/src/service/v1/schemas/mod.rs
+++ b/lib/luminork-server/src/service/v1/schemas/mod.rs
@@ -79,10 +79,10 @@ pub enum SchemaError {
     Prop(#[from] Box<PropError>),
     #[error("schema error: {0}")]
     Schema(#[from] dal::SchemaError),
-    #[error("schema not found by name: {0}")]
-    SchemaNameNotFound(String),
     #[error("schema not found error: {0}")]
     SchemaNotFound(SchemaId),
+    #[error("schema not found by name: {0}")]
+    SchemaNotFoundByName(String),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] dal::SchemaVariantError),
     #[error("schema variant not found error: {0}")]
@@ -128,7 +128,7 @@ impl crate::service::v1::common::ErrorIntoResponse for SchemaError {
     fn status_and_message(&self) -> (StatusCode, String) {
         match self {
             SchemaError::SchemaNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
-            SchemaError::SchemaNameNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
+            SchemaError::SchemaNotFoundByName(_) => (StatusCode::NOT_FOUND, self.to_string()),
             SchemaError::SchemaVariantNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             SchemaError::SchemaVariantNotMemberOfSchema(_, _) => {
                 (StatusCode::PRECONDITION_REQUIRED, self.to_string())


### PR DESCRIPTION
Luminork changes split from pr nick/eng-3214

## How does this PR change the system?

- Return the schema ID in addition to the existing data in the luminork route for generating a template
- Try to find the schema on the graph first before going to cached modules when finding schemas in luminork

see - https://github.com/systeminit/si/pull/7212

## In short: [:link:](https://giphy.com/)

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2J0MmMxbXQwMGNtam8yamNhbXF5d2JkNXZkZGZzczhtbHBjd2J6ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kRXnZwKrPTwVq/giphy.gif)
