### PR TITLE
build(deps): bump `slab` to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8745,9 +8745,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "small_ctor"

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -7350,7 +7350,7 @@ cargo.rust_library(
         ":memchr-2.7.5",
         ":pin-project-lite-0.2.16",
         ":pin-utils-0.1.0",
-        ":slab-0.4.10",
+        ":slab-0.4.11",
     ],
 )
 
@@ -7629,7 +7629,7 @@ cargo.rust_library(
         ":futures-util-0.3.31",
         ":http-0.2.12",
         ":indexmap-2.10.0",
-        ":slab-0.4.10",
+        ":slab-0.4.11",
         ":tokio-1.46.1",
         ":tokio-util-0.7.15",
         ":tracing-0.1.41",
@@ -7659,7 +7659,7 @@ cargo.rust_library(
         ":futures-sink-0.3.31",
         ":http-1.3.1",
         ":indexmap-2.10.0",
-        ":slab-0.4.10",
+        ":slab-0.4.11",
         ":tokio-1.46.1",
         ":tokio-util-0.7.15",
         ":tracing-0.1.41",
@@ -17631,18 +17631,18 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "slab-0.4.10.crate",
-    sha256 = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d",
-    strip_prefix = "slab-0.4.10",
-    urls = ["https://static.crates.io/crates/slab/0.4.10/download"],
+    name = "slab-0.4.11.crate",
+    sha256 = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589",
+    strip_prefix = "slab-0.4.11",
+    urls = ["https://static.crates.io/crates/slab/0.4.11/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "slab-0.4.10",
-    srcs = [":slab-0.4.10.crate"],
+    name = "slab-0.4.11",
+    srcs = [":slab-0.4.11.crate"],
     crate = "slab",
-    crate_root = "slab-0.4.10.crate/src/lib.rs",
+    crate_root = "slab-0.4.11.crate/src/lib.rs",
     edition = "2018",
     features = [
         "default",
@@ -19831,7 +19831,7 @@ cargo.rust_library(
         ":pin-project-1.1.10",
         ":pin-project-lite-0.2.16",
         ":rand-0.8.5",
-        ":slab-0.4.10",
+        ":slab-0.4.11",
         ":tokio-1.46.1",
         ":tokio-util-0.7.15",
         ":tower-layer-0.3.3",

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -6648,9 +6648,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "small_ctor"


### PR DESCRIPTION
Updated with:

```sh
cargo update -p slab --precise 0.4.11
buck2 run support/buck2:sync-cargo-deps
```

References: https://github.com/systeminit/si/security/dependabot/428

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlajJ3cDVoMDhyNDlzODY4emYzNGtubXQ2N3E0YndtYWxxaDBrYTBpZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/XNTCXtlsRGkCY/giphy-downsized-medium.gif"/>