### PR TITLE
unified new and old navbar

### DIFF
--- a/app/web/src/components/layout/navbar/ChangeSetPanel.vue
+++ b/app/web/src/components/layout/navbar/ChangeSetPanel.vue
@@ -42,22 +42,22 @@
       </DropdownMenuButton>
     </label>
 
-    <VButton
+    <NewButton
       v-tooltip="{
         content: 'Create Change Set',
       }"
+      data-testid="create-change-set-button"
       icon="git-branch-plus"
-      size="sm"
       tone="action"
-      variant="ghost"
       class="flex-none"
       @click="openCreateModal"
     />
 
-    <VButton
+    <NewButton
       v-tooltip="{
         content: 'Abandon Change Set',
       }"
+      data-testid="abandon-change-set-button"
       :disabled="
         !selectedChangeSetName ||
         changeSetsStore.headSelected ||
@@ -66,9 +66,7 @@
           ChangeSetStatus.NeedsApproval
       "
       icon="trash"
-      size="sm"
-      tone="action"
-      variant="ghost"
+      tone="destructive"
       class="flex-none"
       @click="openAbandonConfirmationModal"
     />
@@ -128,6 +126,7 @@ import {
   DropdownMenuButton,
   DropdownMenuItem,
   DEFAULT_DROPDOWN_SEARCH_THRESHOLD,
+  NewButton,
 } from "@si/vue-lib/design-system";
 import { tw } from "@si/vue-lib";
 import { useChangeSetsStore } from "@/store/change_sets.store";

--- a/app/web/src/components/layout/navbar/Navbar.vue
+++ b/app/web/src/components/layout/navbar/Navbar.vue
@@ -9,23 +9,34 @@
     "
   >
     <!-- Left side -->
-    <NavbarPanelLeft />
+    <NavbarPanelLeft :invalidWorkspace="invalidWorkspace" />
 
     <!-- Center -->
-    <NavbarPanelCenter />
+    <NavbarPanelCenter v-if="!invalidWorkspace" />
 
     <!-- Right -->
-    <NavbarPanelRight />
+    <NavbarPanelRight :invalidWorkspace="invalidWorkspace" />
   </nav>
 </template>
 
 <script setup lang="ts">
 import { useThemeContainer } from "@si/vue-lib/design-system";
 import clsx from "clsx";
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { useWorkspacesStore } from "@/store/workspaces.store";
 import NavbarPanelCenter from "./NavbarPanelCenter.vue";
 import NavbarPanelRight from "./NavbarPanelRight.vue";
 import NavbarPanelLeft from "./NavbarPanelLeft.vue";
+
+const workspacesStore = useWorkspacesStore();
+
+const invalidWorkspace = computed(
+  () =>
+    !!(
+      workspacesStore.urlSelectedWorkspaceId &&
+      !workspacesStore.selectedWorkspace
+    ),
+);
 
 // top bar is always dark, so this keeps the workspace and change set dropdowns looking correct
 useThemeContainer("dark");

--- a/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelLeft.vue
@@ -30,14 +30,16 @@
       </DropdownMenuButton>
     </label>
 
-    <Icon
-      name="chevron--right"
-      size="xs"
-      tone="neutral"
-      class="mt-[14px] flex-none"
-    />
+    <template v-if="!invalidWorkspace">
+      <Icon
+        name="chevron--right"
+        size="xs"
+        tone="neutral"
+        class="mt-[14px] flex-none"
+      />
 
-    <ChangeSetPanel ref="changeSetPanelRef" />
+      <ChangeSetPanel ref="changeSetPanelRef" />
+    </template>
 
     <StatusPanel v-if="useNewUI" />
   </div>
@@ -57,6 +59,10 @@ import { useRoute } from "vue-router";
 import { useWorkspacesStore } from "@/store/workspaces.store";
 import StatusPanel from "@/newhotness/StatusPanel.vue";
 import ChangeSetPanel from "./ChangeSetPanel.vue";
+
+defineProps({
+  invalidWorkspace: { type: Boolean },
+});
 
 // Determine if we're in the new experience
 const route = useRoute();

--- a/app/web/src/components/layout/navbar/NavbarPanelRight.vue
+++ b/app/web/src/components/layout/navbar/NavbarPanelRight.vue
@@ -2,8 +2,10 @@
   <div
     class="flex flex-row flex-1 basis-1/2 items-center min-w-0 h-full justify-end"
   >
-    <Collaborators />
-    <Notifications />
+    <template v-if="!invalidWorkspace">
+      <Collaborators />
+      <Notifications />
+    </template>
 
     <template v-if="!collapse">
       <NavbarButton
@@ -32,6 +34,10 @@ import Collaborators from "./Collaborators.vue";
 import Notifications from "./Notifications.vue";
 import WorkspaceSettingsMenu from "./WorkspaceSettingsMenu.vue";
 import ProfileButton from "./ProfileButton.vue";
+
+defineProps({
+  invalidWorkspace: { type: Boolean },
+});
 
 const windowWidth = ref(window.innerWidth);
 const collapse = computed(() => windowWidth.value < 1200);


### PR DESCRIPTION
## How does this PR change the system?

Changes to the new navbar need to be ported to the old navbar until we are ready to remove all uses of stores from the old navbar. This PR unifies the designs between the two so that they look the same for now while we are using both.

#### Screenshots:

<img width="1911" height="192" alt="Screenshot 2025-09-05 at 1 32 10 PM" src="https://github.com/user-attachments/assets/8915d031-f5b3-41a4-a711-cd5094a61c32" />

#### Out of Scope:

Eventually we will want to remove the old navbar entirely and replace it with the new navbar.