### PR TITLE
fix(split-graph): implement exclusive outgoing edge corrections for split graph

### DIFF
--- a/lib/dal/src/workspace_snapshot/node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight.rs
@@ -76,7 +76,11 @@ use crate::{
             },
             geometry_node_weight::GeometryNodeWeight,
             secret_node_weight::SecretNodeWeight,
-            traits::SiVersionedNodeWeight,
+            traits::{
+                ExclusiveOutgoingEdges,
+                SiVersionedNodeWeight,
+                SplitCorrectExclusiveOutgoingEdge,
+            },
             view_node_weight::ViewNodeWeight,
         },
     },
@@ -1324,8 +1328,9 @@ impl CorrectTransforms for NodeWeight {
         Ok(self.correct_exclusive_outgoing_edges(workspace_snapshot_graph, updates))
     }
 }
-
-impl CorrectExclusiveOutgoingEdge for NodeWeight {
+impl CorrectExclusiveOutgoingEdge for NodeWeight {}
+impl SplitCorrectExclusiveOutgoingEdge for NodeWeight {}
+impl ExclusiveOutgoingEdges for NodeWeight {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         match self {
             NodeWeight::Action(weight) => weight.exclusive_outgoing_edges(),

--- a/lib/dal/src/workspace_snapshot/node_weight/approval_requirement_definition_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/approval_requirement_definition_node_weight/v1.rs
@@ -17,6 +17,7 @@ use crate::{
         node_weight::traits::{
             CorrectExclusiveOutgoingEdge,
             CorrectTransforms,
+            ExclusiveOutgoingEdges,
             SiNodeWeight,
         },
     },
@@ -51,7 +52,9 @@ impl ApprovalRequirementDefinitionNodeWeightV1 {
 
 impl CorrectTransforms for ApprovalRequirementDefinitionNodeWeightV1 {}
 
-impl CorrectExclusiveOutgoingEdge for ApprovalRequirementDefinitionNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for ApprovalRequirementDefinitionNodeWeightV1 {}
+
+impl ExclusiveOutgoingEdges for ApprovalRequirementDefinitionNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[crate::EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/diagram_object_node_weight/v1.rs
@@ -32,6 +32,7 @@ use crate::{
                 CorrectTransforms,
                 CorrectTransformsError,
                 CorrectTransformsResult,
+                ExclusiveOutgoingEdges,
                 SiNodeWeight,
             },
         },
@@ -207,7 +208,9 @@ impl CorrectTransforms for DiagramObjectNodeWeightV1 {
     }
 }
 
-impl CorrectExclusiveOutgoingEdge for DiagramObjectNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for DiagramObjectNodeWeightV1 {}
+
+impl ExclusiveOutgoingEdges for DiagramObjectNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/geometry_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/geometry_node_weight/v1.rs
@@ -45,6 +45,7 @@ use crate::{
                 CorrectTransforms,
                 CorrectTransformsError,
                 CorrectTransformsResult,
+                ExclusiveOutgoingEdges,
                 SiNodeWeight,
             },
         },
@@ -280,7 +281,9 @@ impl CorrectTransforms for GeometryNodeWeightV1 {
     }
 }
 
-impl CorrectExclusiveOutgoingEdge for GeometryNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for GeometryNodeWeightV1 {}
+
+impl ExclusiveOutgoingEdges for GeometryNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[EdgeWeightKindDiscriminants::Represents]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/input_socket_node_weight/v1.rs
@@ -20,6 +20,7 @@ use crate::{
             traits::{
                 CorrectExclusiveOutgoingEdge,
                 CorrectTransforms,
+                ExclusiveOutgoingEdges,
                 SiNodeWeight,
             },
         },
@@ -62,7 +63,9 @@ impl InputSocketNodeWeightV1 {
 
 impl CorrectTransforms for InputSocketNodeWeightV1 {}
 
-impl CorrectExclusiveOutgoingEdge for InputSocketNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for InputSocketNodeWeightV1 {}
+
+impl ExclusiveOutgoingEdges for InputSocketNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/management_prototype_node_weight/v1.rs
@@ -17,6 +17,7 @@ use crate::{
         node_weight::traits::{
             CorrectExclusiveOutgoingEdge,
             CorrectTransforms,
+            ExclusiveOutgoingEdges,
             SiNodeWeight,
         },
     },
@@ -89,7 +90,8 @@ impl SiNodeWeight for ManagementPrototypeNodeWeightV1 {
 }
 
 impl CorrectTransforms for ManagementPrototypeNodeWeightV1 {}
-impl CorrectExclusiveOutgoingEdge for ManagementPrototypeNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for ManagementPrototypeNodeWeightV1 {}
+impl ExclusiveOutgoingEdges for ManagementPrototypeNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[crate::EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/reason_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/reason_node_weight/v1.rs
@@ -17,6 +17,7 @@ use crate::{
         node_weight::traits::{
             CorrectExclusiveOutgoingEdge,
             CorrectTransforms,
+            ExclusiveOutgoingEdges,
             SiNodeWeight,
         },
     },
@@ -45,8 +46,8 @@ impl ReasonNodeWeightV1 {
 }
 
 impl CorrectTransforms for ReasonNodeWeightV1 {}
-
-impl CorrectExclusiveOutgoingEdge for ReasonNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for ReasonNodeWeightV1 {}
+impl ExclusiveOutgoingEdges for ReasonNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[crate::EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/schema_variant_node_weight/v1.rs
@@ -53,6 +53,7 @@ use crate::{
             traits::{
                 CorrectExclusiveOutgoingEdge,
                 CorrectTransforms,
+                ExclusiveOutgoingEdges,
                 SiNodeWeight,
             },
         },
@@ -568,8 +569,8 @@ impl CorrectTransforms for SchemaVariantNodeWeightV1 {
         Ok(updates)
     }
 }
-
-impl CorrectExclusiveOutgoingEdge for SchemaVariantNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for SchemaVariantNodeWeightV1 {}
+impl ExclusiveOutgoingEdges for SchemaVariantNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/traits.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/traits.rs
@@ -23,7 +23,11 @@ use crate::{
 
 pub mod correct_exclusive_outgoing_edge;
 
-pub use correct_exclusive_outgoing_edge::CorrectExclusiveOutgoingEdge;
+pub use correct_exclusive_outgoing_edge::{
+    CorrectExclusiveOutgoingEdge,
+    ExclusiveOutgoingEdges,
+    SplitCorrectExclusiveOutgoingEdge,
+};
 
 #[remain::sorted]
 #[derive(Debug, Error)]
@@ -51,7 +55,9 @@ pub trait CorrectTransforms {
     }
 }
 
-pub trait SiNodeWeight: CorrectTransforms + CorrectExclusiveOutgoingEdge + Sized {
+pub trait SiNodeWeight:
+    CorrectTransforms + CorrectExclusiveOutgoingEdge + ExclusiveOutgoingEdges + Sized
+{
     fn content_hash(&self) -> ContentHash;
     fn id(&self) -> Ulid;
     fn lineage_id(&self) -> Ulid;
@@ -184,6 +190,12 @@ impl<T> CorrectExclusiveOutgoingEdge for T
 where
     T: SiVersionedNodeWeight,
     NodeInformation: for<'a> From<&'a T>,
+{
+}
+
+impl<T> ExclusiveOutgoingEdges for T
+where
+    T: SiVersionedNodeWeight,
 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         self.inner().exclusive_outgoing_edges()

--- a/lib/dal/src/workspace_snapshot/node_weight/traits/correct_exclusive_outgoing_edge.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/traits/correct_exclusive_outgoing_edge.rs
@@ -4,6 +4,7 @@ use std::collections::{
 };
 
 use petgraph::prelude::*;
+use si_split_graph::CustomNodeWeight;
 
 use crate::{
     WorkspaceSnapshotGraphVCurrent,
@@ -11,15 +12,100 @@ use crate::{
         NodeInformation,
         edge_weight::EdgeWeightKindDiscriminants,
         graph::detector::Update,
+        split_snapshot::{
+            SplitSnapshotGraphVCurrent,
+            UpdateVCurrent,
+        },
     },
 };
+
+pub trait ExclusiveOutgoingEdges {
+    fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants];
+}
+
+pub trait SplitCorrectExclusiveOutgoingEdge
+where
+    Self: CustomNodeWeight + ExclusiveOutgoingEdges,
+{
+    fn correct_exclusive_outgoing_edges_split(
+        &self,
+        graph: &SplitSnapshotGraphVCurrent,
+        mut updates: Vec<UpdateVCurrent>,
+    ) -> Vec<UpdateVCurrent> {
+        let exclusive_edge_kinds = self.exclusive_outgoing_edges();
+        if exclusive_edge_kinds.is_empty() {
+            return updates;
+        }
+        let source_id = self.id();
+
+        // A net new node should need no outgoing edge corrections
+        if !graph.node_exists(source_id) {
+            return updates;
+        }
+
+        let mut new_edge_map = HashMap::new();
+        let mut removal_set = HashSet::new();
+
+        for update in &updates {
+            if !update.source_has_id(source_id) {
+                continue;
+            }
+            let Some(dest_id) = update.destination_id() else {
+                continue;
+            };
+            let Some(kind) = update.edge_weight_kind() else {
+                continue;
+            };
+
+            match update {
+                si_split_graph::Update::NewEdge { .. } => {
+                    new_edge_map.insert(kind, dest_id);
+                    removal_set.remove(&(kind, dest_id));
+                }
+                si_split_graph::Update::RemoveEdge { .. } => {
+                    removal_set.insert((kind, dest_id));
+                }
+                _ => {}
+            }
+        }
+
+        let Some(outgoing_iterator) = graph.edges_directed(source_id, Outgoing).ok() else {
+            return updates;
+        };
+
+        for outgoing_edge_ref in outgoing_iterator {
+            let existing_dest_id = outgoing_edge_ref.target();
+            let kind: EdgeWeightKindDiscriminants = outgoing_edge_ref.weight().kind().into();
+
+            let Some(&new_edge_dest_id) = new_edge_map.get(&kind) else {
+                continue;
+            };
+
+            if new_edge_dest_id != existing_dest_id
+                && !removal_set.contains(&(kind, new_edge_dest_id))
+            {
+                removal_set.insert((kind, existing_dest_id));
+                let Some(removals) =
+                    UpdateVCurrent::remove_edge_updates(graph, source_id, kind, existing_dest_id)
+                        .ok()
+                else {
+                    continue;
+                };
+
+                updates.reserve(removals.len());
+                updates.extend(removals);
+            }
+        }
+
+        updates
+    }
+}
 
 pub trait CorrectExclusiveOutgoingEdge
 where
     NodeInformation: for<'a> From<&'a Self>,
+    Self: ExclusiveOutgoingEdges,
 {
-    fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants];
-
     /// If a set of updates will produce a new outgoing edge that a node weight
     /// considers "exclusive" (that is, there can only be one of these kinds of
     /// outgoing edges for this node), then we need to ensure we don't add that
@@ -37,12 +123,15 @@ where
         if exclusive_edge_kinds.is_empty() {
             return updates;
         }
+        let source_node_information: NodeInformation = self.into();
+        let source_id = source_node_information.id;
+
+        let Some(node_idx) = graph.get_node_index_by_id_opt(source_id) else {
+            return updates;
+        };
 
         let mut removal_set = HashSet::new();
         let mut new_edge_map = HashMap::new();
-
-        let source_node_information: NodeInformation = self.into();
-        let source_id = source_node_information.id;
 
         for update in &updates {
             match update {
@@ -69,42 +158,40 @@ where
             }
         }
 
-        if let Some(node_idx) = graph.get_node_index_by_id_opt(source_id) {
-            updates.extend(
-                graph
-                    .edges_directed(node_idx, Outgoing)
-                    .filter_map(|edge_ref| {
-                        let destination_weight = graph.get_node_weight_opt(edge_ref.target());
-                        let edge_kind = edge_ref.weight().kind().into();
+        updates.extend(
+            graph
+                .edges_directed(node_idx, Outgoing)
+                .filter_map(|edge_ref| {
+                    let existing_dest_weight = graph.get_node_weight_opt(edge_ref.target());
+                    let edge_kind = edge_ref.weight().kind().into();
 
-                        new_edge_map
-                            .get(&edge_kind)
-                            .and_then(|&new_edge_destination_id| {
-                                destination_weight.and_then(|weight| {
-                                    let destination: NodeInformation = weight.into();
+                    new_edge_map
+                        .get(&edge_kind)
+                        .and_then(|&new_edge_destination_id| {
+                            existing_dest_weight.and_then(|weight| {
+                                let existing_dest: NodeInformation = weight.into();
 
-                                    // If this is not the last NewEdge for this
-                                    // kind, and the edge will not already be
-                                    // removed, then we need to remove this edge
-                                    // since it will still be in the graph
-                                    // otherwise.
-                                    if destination.id != new_edge_destination_id
-                                        && !removal_set.contains(&(edge_kind, destination.id))
-                                    {
-                                        removal_set.insert((edge_kind, destination.id));
-                                        Some(Update::RemoveEdge {
-                                            source: source_node_information,
-                                            destination,
-                                            edge_kind,
-                                        })
-                                    } else {
-                                        None
-                                    }
-                                })
+                                // If this is not the last NewEdge for this
+                                // kind, and the edge will not already be
+                                // removed, then we need to remove this edge
+                                // since it will still be in the graph
+                                // otherwise.
+                                if existing_dest.id != new_edge_destination_id
+                                    && !removal_set.contains(&(edge_kind, existing_dest.id))
+                                {
+                                    removal_set.insert((edge_kind, existing_dest.id));
+                                    Some(Update::RemoveEdge {
+                                        source: source_node_information,
+                                        destination: existing_dest,
+                                        edge_kind,
+                                    })
+                                } else {
+                                    None
+                                }
                             })
-                    }),
-            );
-        }
+                        })
+                }),
+        );
 
         updates
     }

--- a/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/view_node_weight/v1.rs
@@ -36,6 +36,7 @@ use crate::{
             traits::{
                 CorrectExclusiveOutgoingEdge,
                 CorrectTransforms,
+                ExclusiveOutgoingEdges,
                 SiNodeWeight,
             },
         },
@@ -239,8 +240,8 @@ impl CorrectTransforms for ViewNodeWeightV1 {
         Ok(updates)
     }
 }
-
-impl CorrectExclusiveOutgoingEdge for ViewNodeWeightV1 {
+impl CorrectExclusiveOutgoingEdge for ViewNodeWeightV1 {}
+impl ExclusiveOutgoingEdges for ViewNodeWeightV1 {
     fn exclusive_outgoing_edges(&self) -> &[EdgeWeightKindDiscriminants] {
         &[]
     }

--- a/lib/si-split-graph/src/lib.rs
+++ b/lib/si-split-graph/src/lib.rs
@@ -765,7 +765,7 @@ where
         let subgraph_index = if let Some((index, _)) =
             self.subgraphs.iter().enumerate().find(|(_, sub)| {
                 // We add one to the max so that the root node is not part of the count
-                sub.node_index_by_id.len() < (self.supergraph.split_max + 1)
+                sub.node_index_by_id.len() < (self.supergraph.split_max.saturating_add(1))
             }) {
             index
         } else {


### PR DESCRIPTION
Exclusive edge corrections were missing from the Split graph. This fixes some failing tests.