### PR TITLE
feat(clover): Adding an action we can use to trigger an instance refresh

### DIFF
--- a/bin/clover/src/cloud-control-funcs/overrides/AWS::AutoScaling::AutoScalingGroup/actions/instanceRefresh.ts
+++ b/bin/clover/src/cloud-control-funcs/overrides/AWS::AutoScaling::AutoScalingGroup/actions/instanceRefresh.ts
@@ -1,0 +1,61 @@
+async function main(component: Input): Promise<Output> {
+  const resource = component.properties.resource?.payload;
+  if (!resource) {
+    return {
+      status: component.properties.resource?.status ?? "ok",
+      message: component.properties.resource?.message,
+    };
+  }
+
+  if (!resource.AutoScalingGroupName) {
+    return {
+      status: "error",
+      payload: resource,
+      message: "No AutoScaling Group name found",
+    };
+  }
+
+  const minHealthyPercentage =
+    component.properties.domain?.InstanceMaintenancePolicy
+      ?.MinHealthyPercentage;
+
+  const defaultInstanceWarmup =
+    component.properties.domain?.DefaultInstanceWarmup;
+
+  if (!minHealthyPercentage || !defaultInstanceWarmup) {
+    return {
+      status: "error",
+      payload: resource,
+      message:
+        "Recycling an AutoScaling Group instances requires a MinHealthyPercentage and DefaultInstanceWarmup. Please ensure you set these before re-trying the action",
+    };
+  }
+
+  const child = await siExec.waitUntilEnd("aws", [
+    "autoscaling",
+    "start-instance-refresh",
+    "--auto-scaling-group-name",
+    resource.AutoScalingGroupName,
+    "--strategy",
+    "Rolling",
+    "--preferences",
+    `{"MinHealthyPercentage":${minHealthyPercentage},"InstanceWarmup":${defaultInstanceWarmup}}`,
+    "--region",
+    component.properties.domain?.extra.Region,
+  ]);
+
+  if (child.exitCode !== 0) {
+    console.log(`AutoScaling group: ${resource.AutoScalingGroupName}`);
+    console.error(child.stderr);
+    return {
+      payload: resource,
+      status: "error",
+      message: `AWS CLI 2 "aws autoscaling refresh-instances" returned non zero exit code (${child.exitCode})`,
+    };
+  }
+
+  return {
+    payload: resource,
+    status: "ok",
+  };
+}

--- a/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipeline-steps/assetSpecificOverrides.ts
@@ -388,7 +388,7 @@ const overrides = new Map<string, OverrideFn>([
     "AWS::AutoScaling::AutoScalingGroup",
     (spec: ExpandedPkgSpec) => {
       // TODO prop suggestions
-      // const variant = spec.schemas[0].variants[0];
+      const variant = spec.schemas[0].variants[0];
       // const launchTemplateVersionSocket = variant.sockets.find(
       //   (s: ExpandedSocketSpec) =>
       //     s.name === "Launch Template Version" && s.data.kind === "input",
@@ -412,6 +412,18 @@ const overrides = new Map<string, OverrideFn>([
       const updatePath =
         "./src/cloud-control-funcs/overrides/AWS::AutoScaling::AutoScalingGroup/actions/awsCloudControlUpdate.ts";
       modifyFunc(spec, updateTargetId, newUpdateId, updatePath);
+
+      const {
+        func: refreshInstancesFunc,
+        actionFuncSpec: refreshInstancesFuncSpec,
+      } = attachExtraActionFunction(
+        "./src/cloud-control-funcs/overrides/AWS::AutoScaling::AutoScalingGroup/actions/instanceRefresh.ts",
+        "Refresh Autoscaling Group Instances",
+        "other",
+        "300d62f40cb1268e6f4cd2320be8c373da7f148d0d9e6e69d1b2879202794b5f",
+      );
+      spec.funcs.push(refreshInstancesFunc);
+      variant.actionFuncs.push(refreshInstancesFuncSpec);
     },
   ],
   // TODO prop suggestions


### PR DESCRIPTION
We often have to rotate nodes in an AutoScaling group - this is the best way to do that as we have autoscaling groups we can ask to do it for us

HOLD BACK ON MERGING THIS! I WANT TO TEST A FEW MORE SCENARIOS!