### PR TITLE
feat(si-mcp-server): Teach the MCP server how to upgrade components

### DIFF
--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -11,7 +11,7 @@
     "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
     "@std/assert": "jsr:@std/assert@1",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.0.8",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.1.2",
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",

--- a/bin/si-mcp-server/src/server.ts
+++ b/bin/si-mcp-server/src/server.ts
@@ -23,6 +23,7 @@ import { componentEraseTool } from "./tools/componentErase.ts";
 import { componentRestoreTool } from "./tools/componentRestore.ts";
 import { generateSiUrlTool } from "./tools/generateSiUrl.ts";
 import { componentGenerateTemplateTool } from "./tools/componentGenerateTemplate.ts";
+import { upgradeComponentsTool } from "./tools/upgradeComponents.ts";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -51,6 +52,7 @@ export function createServer(): McpServer {
   componentRestoreTool(server);
   componentGenerateTemplateTool(server);
   generateSiUrlTool(server);
+  upgradeComponentsTool(server);
   importPrompt(server);
   discoverPrompt(server);
 

--- a/bin/si-mcp-server/src/tools/upgradeComponents.ts
+++ b/bin/si-mcp-server/src/tools/upgradeComponents.ts
@@ -1,0 +1,106 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ComponentsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+  withAnalytics,
+} from "./commonBehavior.ts";
+
+const name = "upgrade-components";
+const title = "Upgrade a list of components";
+const description = `<description>Find a list of components to upgrade. On failure, returns error details. *Always* ensure that components can be upgraded before trying to upgrade them.</description><usage>Use this tool to upgrade a list of components in a change set. To see all of its information after it has been updated, use the component-get tool.</usage>`;
+
+const UpgradeComponentInputSchemaRaw = {
+  changeSetId: z
+    .string()
+    .describe(
+      "The change set to upgrade the components in; components cannot be upgraded on the HEAD change set.",
+    ),
+};
+
+const UpgradeComponentOutputSchemaRaw = {
+  status: z
+    .enum(["success", "failure"])
+    .describe(
+      "success when components are successfully upgraded, failure when an error occurs during upgrades",
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "If the status is failure, the error message will contain information about what went wrong",
+    ),
+  data: z.object({
+    success: z.boolean().describe("a successful set of upgrades"),
+  }),
+};
+
+const UpgradeComponentOutputSchema = z.object(UpgradeComponentOutputSchemaRaw);
+
+type UpgradeComponentResult = z.infer<
+  typeof UpgradeComponentOutputSchema
+>["data"];
+
+export function upgradeComponentsTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "upgradeComponents",
+        UpgradeComponentOutputSchema,
+      ),
+      inputSchema: UpgradeComponentInputSchemaRaw,
+      outputSchema: UpgradeComponentOutputSchemaRaw,
+    },
+    async ({ changeSetId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
+        const siComponentsApi = new ComponentsApi(apiConfig);
+
+        try {
+          const upgradableResp = await siComponentsApi.searchComponents({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            searchComponentsV1Request: {
+              upgradable: true,
+            },
+          });
+
+          // Coercing the API response as a List of strings as it's picked up weird in the API!
+          const SearchComponentsV1ResponseSchema = z.object({
+            components: z.array(z.string()),
+          });
+
+          const result: UpgradeComponentResult = {
+            success: true,
+          };
+
+          if (upgradableResp.status === 200) {
+            const parsed = SearchComponentsV1ResponseSchema.parse(
+              upgradableResp.data,
+            );
+            const components = parsed.components;
+
+            for (const componentId of components) {
+              console.debug(`Starting upgrade of ${componentId}`);
+              await siComponentsApi.upgradeComponent({
+                workspaceId: WORKSPACE_ID,
+                changeSetId: changeSetId,
+                componentId,
+              });
+            }
+            return successResponse(result);
+          }
+          return successResponse(result);
+        } catch (error) {
+          return errorResponse(error);
+        }
+      });
+    },
+  );
+}

--- a/bin/si-mcp-server/test/test-runner.js
+++ b/bin/si-mcp-server/test/test-runner.js
@@ -4,6 +4,7 @@ import { mcpTest } from "mcp-jest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import process from "node:process";
 
 // Load environment variables
 dotenv.config();

--- a/deno.lock
+++ b/deno.lock
@@ -29,7 +29,7 @@
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@^1.0.6": "1.1.1",
     "jsr:@std/text@~1.0.7": "1.0.16",
-    "jsr:@systeminit/api-client@^1.0.8": "1.0.8",
+    "jsr:@systeminit/api-client@^1.1.2": "1.1.2",
     "jsr:@systeminit/cf-db@~0.1.4": "0.1.4",
     "jsr:@systeminit/remove-empty@0.1.3": "0.1.3",
     "npm:@apidevtools/json-schema-ref-parser@11.9.3": "11.9.3",
@@ -203,8 +203,8 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
-    "@systeminit/api-client@1.0.8": {
-      "integrity": "b0bff1aef4b8a6930104553a4b3423ea3b1352bf0df14f2a49e3c8d9114b3b1b",
+    "@systeminit/api-client@1.1.2": {
+      "integrity": "f71a29d4e12004d1e431ec046862f3b9fe53f9bdc43127ac11d79ca0a25cd56e",
       "dependencies": [
         "npm:axios@^1.6.1"
       ]
@@ -1662,7 +1662,7 @@
           "jsr:@onjara/optic@^2.0.3",
           "jsr:@std/assert@1",
           "jsr:@std/encoding@^1.0.10",
-          "jsr:@systeminit/api-client@^1.0.8",
+          "jsr:@systeminit/api-client@^1.1.2",
           "npm:@modelcontextprotocol/sdk@^1.16.0",
           "npm:axios@^1.6.1",
           "npm:jwt-decode@4",


### PR DESCRIPTION
Dealing with individual components:

```
can you upgrade the ec2 instance component in my workspace?

⏺ I'll help you upgrade the EC2 instance component. Let me first check what change sets and components are available.
  ⎿ <response>{"status":"success","data":[{"id":"01K481S57BN668GT03BJKAG98Z","name":"HEAD","status":"Open","isHead":true},{"id":"01K4K0BJQM799E3F8BV5DCHRG8","name":"Upgrade VPC Compone
    nt","status":"Open","isHead":false}]}</response>
    <hints>Apply, Force-Apply, and Abandon change sets using their 'id' and the change-set-status-update tool.</hints>


⏺ si-mcp-server - component-list (MCP)(changeSetId: "01K4K0BJQM799E3F8BV5DCHRG8")
  ⎿ <response>{"status":"success","data":[{"componentId":"01K4K05QN7BRCTHF5MFK56STWT","componentName":"si-0696","schemaName":"AWS::EC2::VPC"},{"componentId":"01K4K0KASERYN6VAM0ZN8Z112C
    ","componentName":"si-6784","schemaName":"AWS::EC2::Instance"}]}</response>


⏺ Perfect! I can see there's an EC2 instance component (si-6784) in the "Upgrade VPC Component" change set. Let me upgrade it for you.

⏺ si-mcp-server - component-update (MCP)(changeSetId: "01K4K0BJQM799E3F8BV5DCHRG8", componentId: "01K4K0KASERYN6VAM0ZN8Z112C", upgrade: true, attributes: {})
  ⎿  Error: {"status":"failure","errorMessage":"Error setting up request: Component is not able to be upgraded"}

⏺ The EC2 instance component (si-6784) cannot be upgraded as it's already on the latest version. The component is up to date and doesn't have any available upgrades.



> can you upgrade the vpc component in the same change set?

⏺ si-mcp-server - component-update (MCP)(changeSetId: "01K4K0BJQM799E3F8BV5DCHRG8", componentId: "01K4K05QN7BRCTHF5MFK56STWT", upgrade: true, attributes: {})
  ⎿  <response>{"status":"success","data":{"success":true}}</response>

⏺ The VPC component (si-0696) has been successfully upgraded in the "Upgrade VPC Component" change set.
```

When looking to find and upgrade a list of components:

```
> Can you find the components that can be upgrades and upgrade them?

⏺ I'll help you find and upgrade components that can be upgraded. Let me start by checking the available change sets and then look for components that need upgrading.
  ⎿  <response>{"status":"success","data":[{"id":"01K481S57BN668GT03BJKAG98Z","name":"HEAD","status":"Open","isHead":true}]}</response>
     <hints>Apply, Force-Apply, and Abandon change sets using their 'id' and the change-set-status-update tool.</hints>

⏺ I can see there's only the HEAD change set available. Since components cannot be upgraded directly on the HEAD change set, I'll need to create a new change set first, then check for
  components that can be upgraded.

⏺ si-mcp-server - change-set-create (MCP)(changeSetName: "Component Upgrades")
  ⎿  <response>{"status":"success","data":{"id":"01K4K4DP9TPQ602JRR9VY87H6W","name":"Component Upgrades","status":"Open","isHead":false}}</response>

⏺ Now let me check for components that can be upgraded in this new change set:

⏺ si-mcp-server - upgrade-components (MCP)(changeSetId: "01K4K4DP9TPQ602JRR9VY87H6W")
  ⎿  <response>{"status":"success","data":{"success":true}}</response>

⏺ Perfect! I've successfully:

  1. Created a new change set called "Component Upgrades"
  2. Found and upgraded all components that were eligible for upgrades

  The upgrade process completed successfully. All components that had available upgrades have been upgraded in the "Component Upgrades" change set (ID: 01K4K4DP9TPQ602JRR9VY87H6W).

  If you'd like to review the changes before applying them, you can examine the change set or apply it when you're ready.

```