### PR TITLE
Fix: api & form observability

### DIFF
--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -2,7 +2,6 @@
 import { Buffer } from "buffer";
 import { HoneycombWebSDK } from "@honeycombio/opentelemetry-web";
 import { DocumentLoadInstrumentation } from "@opentelemetry/instrumentation-document-load";
-import { UserInteractionInstrumentation } from "@opentelemetry/instrumentation-user-interaction";
 import { LongTaskInstrumentation } from "@opentelemetry/instrumentation-long-task";
 import opentelemetry, { Span } from "@opentelemetry/api";
 import { mapStackTrace } from "sourcemapped-stacktrace";
@@ -37,12 +36,6 @@ const sdk = new HoneycombWebSDK({
   instrumentations: [
     // we're not auto-instrumenting XMLHttpRequest, we're instrumenting that in pinia_tools.APIRequest
     new DocumentLoadInstrumentation(),
-    new UserInteractionInstrumentation({
-      shouldPreventSpanCreation: (eventType, element, span) => {
-        span.setAttribute("target.tagName", element.tagName);
-        span.setAttribute("target.html", element.outerHTML);
-      },
-    }), // just click events for now
     new LongTaskInstrumentation({
       observerCallback: (span, _longtaskEvent) => {
         span.setAttribute("location.pathname", window.location.pathname);

--- a/app/web/src/newhotness/EditViewModal.vue
+++ b/app/web/src/newhotness/EditViewModal.vue
@@ -228,7 +228,7 @@ const open = (
   viewId.value = openViewId;
   isDefaultView.value = openIsDefaultView;
   modalRef.value?.open();
-  nameForm.reset();
+  wForm.reset(nameForm);
   nameOnOpen.value = openViewName;
   nameForm.setFieldValue("name", openViewName);
 };


### PR DESCRIPTION
## How does this PR change the system?

Getting both `watchedForm` and `watchedApi` with http request data squared away.

#### Out of Scope:

One tiny missed form reset from last PR

## How was it tested?

Make an API call

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOHJhN29qYXVwYXpjbHNjZ2h6cXJ5Zmo1Yjk1djUweGplNmYybDhzYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ALtzQ6CHfC7vO5nRz7/giphy.gif"/>
