### PR TITLE
fix: make typescript types symlink work in cargo and buck2

### DIFF
--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -86,6 +86,7 @@ rust_library(
         "//third-party/rust:y-sync",
     ],
     srcs = glob(["src/**/*.rs"]) + ["//app/web:editor_typescript.txt"],
+    features = ["buck2_build"],
     env = {
         "CARGO_MANIFEST_DIR": ".",
     },

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -89,6 +89,9 @@ url = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }
 y-sync = { workspace = true }
 
+[features]
+buck2_build = []
+
 [dev-dependencies]
 dal-test = { path = "../../lib/dal-test" }
 indoc = { workspace = true }

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -210,6 +210,10 @@ impl From<AttributePrototypeArgumentError> for FsError {
 
 pub type FsResult<T> = Result<T, FsError>;
 
+// Use different paths for buck2 vs cargo check
+#[cfg(not(feature = "buck2_build"))]
+const ASSET_EDITOR_TYPES: &str = include_str!("./fs/editor_typescript.txt");
+#[cfg(feature = "buck2_build")]
 const ASSET_EDITOR_TYPES: &str = include_str!("../../../editor_typescript.txt");
 
 impl IntoResponse for FsError {

--- a/prelude-si/macros/rust.bzl
+++ b/prelude-si/macros/rust.bzl
@@ -84,6 +84,7 @@ def rust_binary(
             resources = test_unit_resources,
             env = env | test_unit_env,
             visibility = visibility,
+            **kwargs
         )
 
         _clippy_check(
@@ -239,6 +240,7 @@ def rust_library(
             resources = test_unit_resources,
             env = env | test_unit_env,
             visibility = visibility,
+            **kwargs
         )
 
         _clippy_check(


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Kind of clunky, but this lets us have the symlinked typescript bits and the buck2 exported ones, meaning cargo check and buck2 builds should both work.


## How was it tested?

local cargo checks and builds

## In short: [:link:](https://giphy.com/)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlenF6YmI2dGpzZHB4enJmcWhmc2N5OGF6aTBzYmN0cjdmZ2NrZzZvdiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jPAdK8Nfzzwt2/giphy.gif"/>