### PR TITLE
feat: remove/report invalid connections in validation/migration endpoints

### DIFF
--- a/lib/dal/examples/snapshot-fixer/main.rs
+++ b/lib/dal/examples/snapshot-fixer/main.rs
@@ -12,6 +12,7 @@ use dal::{
     workspace_snapshot::graph::validator::{
         WithGraph,
         connections::connection_migrations,
+        validate_graph,
     },
 };
 use si_layer_cache::db::serialize;
@@ -50,13 +51,13 @@ async fn main() -> Result<()> {
     for migration in connection_migrations(&graph, vec![]) {
         println!("{}", WithGraph(&graph, &migration));
     }
-    // for issue in validate_graph(&graph)? {
-    //     println!("{}", WithGraph(&graph, &issue));
-    //     // Only fix ConnectionToUnknownSocket issues for now
-    //     if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
-    //         issue.fix(&mut graph)?
-    //     }
-    // }
+    for issue in validate_graph(&graph)? {
+        println!("{}", WithGraph(&graph, &issue));
+        // Only fix ConnectionToUnknownSocket issues for now
+        // if let issue @ ValidationIssue::ConnectionToUnknownSocket { .. } = issue {
+        //     issue.fix(&mut graph)?
+        // }
+    }
     // for issue in validate_graph(graph)? {
     //     // println!("{}", issue.with_graph(&graph));
     //     // Only fix ConnectionToUnknownSocket issues for now

--- a/lib/sdf-server/src/service/v2/admin/validate_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/admin/validate_snapshot.rs
@@ -83,7 +83,8 @@ async fn get_validation_issues(
 
 async fn fix_issue(ctx: &DalContext, issue: &ValidationIssue) -> AdminAPIResult<bool> {
     Ok(match issue {
-        &ValidationIssue::ConnectionToUnknownSocket { apa, .. } => {
+        &ValidationIssue::ConnectionToMissingComponent { apa, .. }
+        | &ValidationIssue::ConnectionToUnknownSocket { apa, .. } => {
             // These will never be fixed, so we just remove them
             AttributePrototypeArgument::remove(ctx, apa).await?;
             true
@@ -117,8 +118,10 @@ async fn fix_issue(ctx: &DalContext, issue: &ValidationIssue) -> AdminAPIResult<
             AttributeValue::remove(ctx, duplicate).await?;
             true
         }
-        ValidationIssue::MultipleValues { .. }
+        ValidationIssue::ArgumentTargets { .. }
+        | ValidationIssue::ComponentHasParent { .. }
         | ValidationIssue::MissingChildAttributeValues { .. }
+        | ValidationIssue::MultipleValues { .. }
         | ValidationIssue::UnknownChildAttributeValue { .. } => false,
     })
 }


### PR DESCRIPTION
There are 4 invalid graphs in production workspaces with invalid connections that could not be migrated. This removes those.

The graph validator endpoint will now remove socket connections to missing components (of which there are 3 in production). This PR also makes it so migration will freeze a connection instead of migrating if the prop subscription could not be created for any reason (this handles exactly one invalid connection in production).

Finally, the validator endpoint will now report if there are any remaining parents or socket connections in the graph, as these are now illegal and gone from production.

This only affects the validation and migration endpoints.

## How was it tested?

- [X] Manual test: validation reports issues 

The migration change will be tested live on the one affected workspace with the invalid connection. (Dry run first, then actual migration if that does what we expect.)