### PR TITLE
fix: git_info sha hash length not guarenteed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           b3sum
           buck2
           deno
-          git
+          gitMinimal
           makeWrapper
           nodePkgs.pnpm
           nodejs

--- a/prelude-si/git/git_info.py
+++ b/prelude-si/git/git_info.py
@@ -70,6 +70,7 @@ def parse_git_show() -> Dict[str, str]:
         "git",
         "show",
         "--no-patch",
+        "--abbrev=8",
         f"--format=format:{format_str}",
     ]
     result = subprocess.run(git_show_cmd, capture_output=True)
@@ -99,6 +100,7 @@ def finalize(data: Dict[str, Any]):
         ABBREVIATED_COMMIT_HASH,
         "HASH-NOT-FOUND",
     )
+    abbreviated_commit_hash = abbreviated_commit_hash[:8]
     dt_str = data.get(COMMITER_DATE_STRICT)
     is_dirty = data.get(IS_DIRTY)
 


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

This ensures that the hashes we generate are always 8 characters long. In some cases, we were generating 9 character long hashes, causing mismatched during promote vs. publish steps 

This also swaps out `git` for `gitMinimal` in the flake. This is what we used to use and this change was unintentional. It's possible the minimal version of git was less prone to generating 9 characters short hashes?


## How was it tested?

CI will be a good test for this. Locally, this works for me

## In short: [:link:](https://giphy.com/)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbG85MDl1YWtkN3RkbXdpdHhzZ2E2NGlnNW5yeW9xeTg3eTJjYjc4bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/10GUbOX16lS15C/giphy.gif"/>