### PR TITLE
feat(si-mcp-server): Split out the Abandon Change set from the changeSetUpdate tool

### DIFF
--- a/bin/si-mcp-server/src/server.ts
+++ b/bin/si-mcp-server/src/server.ts
@@ -26,6 +26,7 @@ import { upgradeComponentsTool } from "./tools/upgradeComponents.ts";
 import { templateGenerateTool } from "./tools/templateGenerate.ts";
 import { templateRunTool } from "./tools/templateRun.ts";
 import { templateListTool } from "./tools/templateList.ts";
+import { changeSetAbandonTool } from "./tools/changeSetAbandon.ts";
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -36,6 +37,7 @@ export function createServer(): McpServer {
   changeSetListTool(server);
   changeSetCreateTool(server);
   changeSetUpdateTool(server);
+  changeSetAbandonTool(server);
   schemaFindTool(server);
   schemaAttributesListTool(server);
   schemaAttributesDocumentationTool(server);

--- a/bin/si-mcp-server/src/tools/changeSetAbandon.ts
+++ b/bin/si-mcp-server/src/tools/changeSetAbandon.ts
@@ -1,0 +1,88 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { ChangeSetsApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+  withAnalytics,
+} from "./commonBehavior.ts";
+
+const name = "change-set-abandon";
+const title = "Abandon a change set";
+const description = `<description>Abandon a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon a change set. You may *never* abandon the HEAD change set.</usage>`;
+
+const AbandonChangeSetInputSchemaRaw = {
+  changeSetId: z.string().describe("the ID of the change set to abandon"),
+};
+
+const AbandonChangeSetOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "If the status is failure, the error message will contain information about what went wrong",
+    ),
+  data: z
+    .object({ success: z.boolean().describe("will always be true") })
+    .describe("will be true if the request succeeds"),
+};
+const AbandonChangeSetOutputSchema = z.object(AbandonChangeSetOutputSchemaRaw);
+
+export function changeSetAbandonTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "changeSetAbandonResponse",
+        AbandonChangeSetOutputSchema,
+      ),
+      annotations: {
+        destructiveHint: true,
+      },
+      inputSchema: AbandonChangeSetInputSchemaRaw,
+      outputSchema: AbandonChangeSetOutputSchemaRaw,
+    },
+    async ({ changeSetId }): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
+        if (!changeSetId) {
+          return errorResponse({
+            message:
+              "Must provide a change set id; ensure you get one from the user!",
+          });
+        }
+
+        const siApi = new ChangeSetsApi(apiConfig);
+        try {
+          const response = await siApi.getChangeSet({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+          });
+          if (response.data.changeSet.isHead) {
+            return errorResponse({
+              message:
+                "You may not abandon the HEAD change set. Inform the user that HEAD is immutable, and they should not try and abandon it. Call them a cheeky monkey.",
+            });
+          }
+        } catch (error) {
+          return errorResponse(error);
+        }
+
+        try {
+          const response = await siApi.abandonChangeSet({
+            workspaceId: WORKSPACE_ID,
+            changeSetId,
+          });
+          return successResponse(response.data);
+        } catch (error) {
+          return errorResponse(error);
+        }
+      });
+    },
+  );
+}

--- a/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
@@ -12,14 +12,13 @@ import {
 
 const name = "change-set-update-status";
 const title = "Update the status of a change set";
-const description =
-  `<description>Update the status of a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon (or 'delete') a change set, Apply a change set, or Force Apply the change set (ignoring all approvals). You may *never* update the status of the HEAD change set.</usage>`;
+const description = `<description>Update the status of a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Apply a change set or Force Apply the change set (ignoring all approvals). You may *never* update the status of the HEAD change set.</usage>`;
 
 const UpdateChangeSetInputSchemaRaw = {
   newStatus: z
-    .enum(["abandon", "apply", "force-apply"])
+    .enum(["apply", "force-apply"])
     .describe(
-      "'abandon' will abandon this change set, effectively deleting it. 'apply' will apply the change set and follow any workspace approval requirements. 'force-apply' will apply the change set *ignoring* all approval requirements",
+      "'apply' will apply the change set and follow any workspace approval requirements. 'force-apply' will apply the change set *ignoring* all approval requirements",
     ),
   changeSetId: z
     .string()
@@ -89,13 +88,7 @@ export function changeSetUpdateTool(server: McpServer) {
 
         try {
           // Confirm the change set you want to manipulate isn't HEAD
-          if (newStatus == "abandon") {
-            const response = await siApi.abandonChangeSet({
-              workspaceId: WORKSPACE_ID,
-              changeSetId,
-            });
-            return successResponse(response.data);
-          } else if (newStatus == "apply") {
+          if (newStatus == "apply") {
             const response = await siApi.requestApproval({
               workspaceId: WORKSPACE_ID,
               changeSetId,
@@ -124,8 +117,7 @@ export function changeSetUpdateTool(server: McpServer) {
             return successResponse(response.data);
           } else {
             return errorResponse({
-              message:
-                `Invalid status '${newStatus}'. Must be one of: abandon, apply or force-apply`,
+              message: `Invalid status '${newStatus}'. Must be one of: apply or force-apply`,
             });
           }
         } catch (error) {


### PR DESCRIPTION
We want these actions to be more explicit therefore, we are going to split them apart