### PR TITLE
NewButton no longer changes size on loading

### DIFF
--- a/app/web/src/newhotness/ApplyChangeSetButton.vue
+++ b/app/web/src/newhotness/ApplyChangeSetButton.vue
@@ -4,20 +4,12 @@
       ref="applyButtonRef"
       tone="action"
       label="Apply Change Set"
+      :pill="proposedActions.length"
       class="ml-2xs mr-xs"
       loadingText="Applying Changes"
       :loading="applyInFlight"
       @click="openApplyChangeSetModal"
-    >
-      <template #iconRight>
-        <PillCounter
-          :count="proposedActions.length"
-          :paddingX="proposedActions.length > 10 ? '2xs' : 'xs'"
-          noColorStyles
-          class="border border-action-200 ml-2xs py-2xs"
-        />
-      </template>
-    </NewButton>
+    />
     <ApplyChangeSetModal
       ref="applyChangeSetModalRef"
       votingKind="merge"
@@ -29,7 +21,7 @@
 <script lang="ts" setup>
 import { computed, ref, watchEffect, nextTick } from "vue";
 import * as _ from "lodash-es";
-import { PillCounter, NewButton } from "@si/vue-lib/design-system";
+import { NewButton } from "@si/vue-lib/design-system";
 import { useQuery } from "@tanstack/vue-query";
 import { useRoute, useRouter } from "vue-router";
 import {

--- a/app/web/src/newhotness/ComponentHistory.vue
+++ b/app/web/src/newhotness/ComponentHistory.vue
@@ -6,15 +6,9 @@
     @scrollend="handleScrollEnd"
   >
     <div class="flex flex-row justify-between items-center gap-xs pb-xs">
+      <NewButton class="grow" label="Expand All" @click="handleAll('expand')" />
       <NewButton
         class="grow"
-        size="xs"
-        label="Expand All"
-        @click="handleAll('expand')"
-      />
-      <NewButton
-        class="grow"
-        size="xs"
         label="Collapse All"
         @click="handleAll('collapse')"
       />

--- a/app/web/src/newhotness/Onboarding2.vue
+++ b/app/web/src/newhotness/Onboarding2.vue
@@ -4,6 +4,7 @@
 // without creating anything, and without needing to pass the AI agent checks.
 // Debug mode also ALWAYS shows button disabled tooltips so they can be seen
 // MAKE SURE YOU SET IT BACK TO FALSE WHEN YOU ARE DONE!
+// MAKE SURE YOU TEST THE FUNCTIONALITY OF THE FLOW WITH DEBUG MODE TURNED OFF!
 export const DEBUG_MODE = false;
 </script>
 

--- a/app/web/src/pages/DebugPage.vue
+++ b/app/web/src/pages/DebugPage.vue
@@ -42,17 +42,27 @@
 
       <div class="w-full px-lg text-xl text-left">Button Garden (NEW UI)</div>
       <div
-        class="w-full flex flex-row gap-sm flex-wrap px-lg pb-lg justify-start"
+        v-for="num in Array(6).keys()"
+        :key="num"
+        :class="
+          clsx(
+            'w-full flex flex-row gap-sm flex-wrap px-lg justify-start h-8',
+            num === 5 && 'mb-lg',
+          )
+        "
       >
-        <NewButton label="Neutral" />
-        <NewButton label="Action" tone="action" />
-        <NewButton label="Warning" tone="warning" />
-        <NewButton label="Destructive" tone="destructive" />
-        <NewButton
-          v-tooltip="'Here is the tooltip'"
-          label="Disabled"
-          disabled
-        />
+        <template v-for="variant in buttonVariants" :key="variant">
+          <NewButton
+            v-tooltip="getButtonTooltip(variant)"
+            :label="variant.charAt(0).toUpperCase() + variant.slice(1)"
+            :tone="variant !== 'disabled' ? (variant as ButtonTones) : undefined"
+            :pill="num > 3 ? 'test' : undefined"
+            :icon="num === 1 || num === 5 ? 'cat' : undefined"
+            :iconRight="num === 2 ? 'cat' : undefined"
+            :loading="num === 3"
+            :disabled="variant === 'disabled'"
+          />
+        </template>
       </div>
 
       <div class="w-full px-lg text-xl text-left">
@@ -247,10 +257,13 @@ import {
   ColorNamesArray,
   SPINNABLE_ICONS,
   NewButton,
+  ButtonTones,
+  BUTTON_TONES,
 } from "@si/vue-lib/design-system";
 import { colors } from "@si/vue-lib";
 import SiLogo from "@si/vue-lib/brand-assets/si-logo-symbol.svg?component";
 import clsx from "clsx";
+import { computed } from "vue";
 import CheechSvg from "@/assets/images/cheech-and-chong.svg?component";
 import EmptyStateIcon, { BIG_ICONS } from "@/components/EmptyStateIcon.vue";
 import AppLayout from "@/components/layout/AppLayout.vue";
@@ -271,4 +284,18 @@ type ColorNumber =
 
 const indexToColorNumber = (i: number) =>
   (i === 1 ? 50 : (i - 1) * 100).toString() as ColorNumber;
+
+const buttonVariants = computed(() => [...BUTTON_TONES, "disabled"]);
+
+const getButtonTooltip = (variant: string) => {
+  if (variant === "disabled") {
+    return "Disabled buttons can have explanatory tooltips";
+  } else if (variant === "empty") {
+    return "The empty variant is used to clear all tone related styles";
+  } else if (variant === "nostyle") {
+    return "The nostyle variant is used to clear ALL styles";
+  } else {
+    return undefined;
+  }
+};
 </script>

--- a/lib/vue-lib/src/design-system/general/NewButton.vue
+++ b/lib/vue-lib/src/design-system/general/NewButton.vue
@@ -14,7 +14,8 @@
       clsx(
         'newbutton',
         tone !== 'nostyle' && [
-          'flex flex-row items-center gap-xs transition-all justify-center whitespace-nowrap leading-none font-medium rounded-sm',
+          'flex flex-row items-center gap-xs justify-center rounded-sm',
+          'transition-all whitespace-nowrap leading-none font-medium max-h-fit',
           hasLabel ? 'px-xs py-2xs' : 'p-3xs m-3xs',
           tone !== 'empty' && 'border',
           computedTextSize,
@@ -60,19 +61,11 @@
     @click="clickHandler($event)"
   >
     <template v-if="computedLoading">
-      <Icon
-        :size="iconSize ? iconSize : size"
-        :class="iconClasses"
-        :name="loadingIcon"
-      />
+      <Icon :size="computedIconSize" :class="iconClasses" :name="loadingIcon" />
       <span v-if="loadingText">{{ loadingText }}</span>
     </template>
     <template v-else-if="showSuccess">
-      <Icon
-        :size="iconSize ? iconSize : size"
-        :class="iconClasses"
-        :name="successIcon"
-      />
+      <Icon :size="computedIconSize" :class="iconClasses" :name="successIcon" />
       <span>
         <slot v-if="successText" name="success">{{ successText }}</slot>
       </span>
@@ -81,12 +74,16 @@
       <slot name="icon">
         <Icon
           v-if="icon"
-          :size="iconSize ? iconSize : size"
+          :size="computedIconSize"
           :class="iconClasses"
           :name="icon"
         />
       </slot>
-      <TruncateWithTooltip v-if="truncateText" ref="truncateRef">
+      <TruncateWithTooltip
+        v-if="truncateText && hasLabel"
+        ref="truncateRef"
+        class="py-2xs"
+      >
         <slot v-if="confirmClick && confirmFirstClickAt" name="confirm-click">
           |
           {{
@@ -97,7 +94,7 @@
         </slot>
         <slot v-else>{{ label }}</slot>
       </TruncateWithTooltip>
-      <span v-else-if="hasLabel">
+      <span v-else-if="hasLabel" class="py-2xs">
         <slot v-if="confirmClick && confirmFirstClickAt" name="confirm-click">
           |
           {{
@@ -111,7 +108,7 @@
       <slot name="iconRight">
         <Icon
           v-if="iconRight"
-          :size="iconSize ? iconSize : size"
+          :size="computedIconSize"
           :class="iconClasses"
           :name="iconRight"
         />
@@ -122,7 +119,7 @@
           v-if="pill"
           :class="
             clsx(
-              'ml-2xs min-w-[22px] text-center',
+              'min-w-[22px] text-center',
               {
                 neutral: '',
                 action: '',
@@ -158,15 +155,6 @@ import { themeClasses } from "../utils/theme_tools";
 
 const SHOW_SUCCESS_DELAY = 2000;
 
-export type ButtonSizes = "2xs" | "xs" | "sm" | "md" | "lg" | "xl";
-export type ButtonTones =
-  | "neutral"
-  | "action"
-  | "warning"
-  | "destructive"
-  | "empty" // hides all tone styles but keeps basic styling
-  | "nostyle"; // removes ALL styles from the button, avoid using too much!
-
 const props = defineProps({
   size: { type: String as PropType<ButtonSizes>, default: "sm" },
   iconSize: { type: String as PropType<IconSizes> },
@@ -192,7 +180,10 @@ const props = defineProps({
   iconSuccess: { type: String as PropType<IconNames> },
   confirmClick: { type: [Boolean, String] },
   submit: { type: Boolean },
-  pill: { type: String, required: false },
+  pill: {
+    type: [String, Number] as PropType<string | number>,
+    required: false,
+  },
   truncateText: { type: Boolean },
   tabIndex: Number,
   tooltip: { type: String },
@@ -368,4 +359,22 @@ const tooltipObject = computed(() =>
 const slots = useSlots();
 
 const hasLabel = computed(() => !!(props.label || slots.default));
+
+const computedIconSize = computed(() => {
+  if (props.iconSize) return props.iconSize;
+  else return props.size as IconSizes;
+});
+</script>
+
+<script lang="ts">
+export type ButtonSizes = "2xs" | "xs" | "sm" | "md" | "lg" | "xl";
+export const BUTTON_TONES = [
+  "neutral",
+  "action",
+  "warning",
+  "destructive",
+  "empty", // hides all tone styles but keeps basic styling
+  "nostyle", // removes ALL styles from the button, avoid using too much!
+] as const;
+export type ButtonTones = (typeof BUTTON_TONES)[number];
 </script>

--- a/lib/vue-lib/src/design-system/index.ts
+++ b/lib/vue-lib/src/design-system/index.ts
@@ -20,6 +20,7 @@ export { default as RichText } from "./general/RichText.vue";
 export { default as Timestamp } from "./general/Timestamp.vue";
 export { default as VButton } from "./general/VButton.vue";
 export { default as NewButton } from "./general/NewButton.vue";
+export { BUTTON_TONES } from "./general/NewButton.vue";
 export type { ButtonTones, ButtonSizes } from "./general/NewButton.vue";
 export { default as IconButton } from "./general/IconButton.vue";
 export { default as SiSearch } from "./general/SiSearch.vue";


### PR DESCRIPTION
## How does this PR change the system?

This PR fixes the spacing on NewButton so that it does not change size if it gains or loses an icon. The DebugPage has a button garden showing all the possible variations.

It also replaces the non-standard pill on the ChangeSetButton with the standard one.

#### Screenshots:

<img width="1130" height="311" alt="Screenshot 2025-09-10 at 1 36 55 PM" src="https://github.com/user-attachments/assets/8dbefa00-1158-4b00-850a-efb2441e966b" />

#### Out of Scope:

This PR does not implement the secondary number pill shown in Figma as we are not using it anywhere yet.

This PR also does not finish eradicating VButton or IconButton from the few places it is left in the vue-lib and old UI.

## How was it tested?

Lots of manual testing, the DebugPage confirms that all possible variants match Figma.