### PR TITLE
add await to prevent race condition in webworker

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -1013,7 +1013,7 @@ const handleIndexMvPatch = async (db: Database, msg: WorkspaceIndexUpdate) => {
       operations: msg.patch.patch,
       id: msg.meta.workspaceId,
     };
-    patchAtom(db, atom);
+    await patchAtom(db, atom);
     const inserted = insertAtomMTM(db, atom, msg.meta.toIndexChecksum);
     span.setAttribute("insertedMTM", inserted);
     span.end();


### PR DESCRIPTION
## How does this PR change the system?

This tiny PR fixes a rare race condition which can cause the frontend to hang on the lobby.

The `handleIndexMvPatch` was possibly attempting to insert the MTM before the atom was done being patched.

This one line change will prevent that from happening.