### PR TITLE
don't get stuck in lobby if checkonboarding fails

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -451,8 +451,9 @@ const checkOnboardingCompleteData = async () => {
   const { data, status } = await call.get();
 
   if (status !== 200) {
-    tokenFail.value = true;
-    tokenFailStatus.value = status;
+    // If we don't get onboarding status back successfully, default to skipping onboarding.
+    // Because we do not want to end up in a state where a user is locked out of a workspace!
+    onboardingCompleted.value = true;
     return;
   }
 


### PR DESCRIPTION
## How does this PR change the system?

Previously if we received a non-200 status for the `checkOnboardingCompleteApi` call we would assume it was a token issue and as a result a user could get stuck in the lobby.

Now we default to skipping onboarding if the `checkOnboardingCompleteApi` returns a non-200 status. Token issues should be handled properly elsewhere.