### PR TITLE
fix(rootfs): Add Azure CLI back in via rootfs

### DIFF
--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -204,6 +204,9 @@ unzip -q deno.zip && mv deno /usr/local/bin/ && chmod +x /usr/local/bin/deno && 
 # Linode CLI
 pip3 install --break-system-packages linode-cli
 
+# Azure CLI
+pip3 install azure-cli
+
 cd / && rm -rf /tmp/* 2>/dev/null && adduser -D app
 
 # Create wrapper scripts for binaries


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

This installs the Azure CLI during the rootfs prelude script. As far as I can tell, https://github.com/systeminit/si/pull/6896 moved the CLI tools which are available to functions from the `langJsExtraPkgs` list in `flake.nix` to prelude-si/rootfs/rootfs_build.sh.

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

As far as I can see, there is no precedent for testing a CLI tool is available to functions, but if there is, point me at it.

Draft PR until I test manually.

- [X] Integration tests pass
- [ ] Manual test: new functionality works in UI

## In short: [:link:](https://giphy.com/)

![](put .gif link here - click the :link: besides the gif on giphy to copy it)
