### PR TITLE
feat(dal): schema level actions

### DIFF
--- a/lib/dal/src/action.rs
+++ b/lib/dal/src/action.rs
@@ -47,7 +47,6 @@ use crate::{
     Func,
     FuncError,
     HelperError,
-    SchemaVariant,
     SchemaVariantError,
     TransactionsError,
     WorkspaceSnapshotError,
@@ -877,13 +876,13 @@ impl Action {
         should_dispatch: bool,
     ) -> ActionResult<()> {
         let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
-        let refresh_actions = SchemaVariant::find_action_prototypes_by_kind(
+        let refresh_actions = ActionPrototype::find_by_kind_for_schema_or_variant(
             ctx,
-            schema_variant_id,
             ActionKind::Refresh,
+            schema_variant_id,
         )
         .await?;
-        if let Ok(&prototype_id) = refresh_actions.iter().exactly_one().map_err(|_| {
+        if let Ok(prototype) = refresh_actions.iter().exactly_one().map_err(|_| {
             ActionError::UnexpectedNumberOfActionKinds(ActionKind::Refresh, schema_variant_id)
         }) {
             let maybe_duplicate_action =
@@ -905,7 +904,7 @@ impl Action {
                         Action::dispatch_action(ctx, action_id).await?;
                     } else {
                         let new_action_id =
-                            Self::enqueue_new_refresh(ctx, prototype_id, component_id).await?;
+                            Self::enqueue_new_refresh(ctx, prototype.id(), component_id).await?;
                         Action::dispatch_action(ctx, new_action_id).await?;
                     }
                 } else {
@@ -923,7 +922,8 @@ impl Action {
                 }
             } else {
                 // No duplicate actions - create a new one and optionally dispatch
-                let action_id = Self::enqueue_new_refresh(ctx, prototype_id, component_id).await?;
+                let action_id =
+                    Self::enqueue_new_refresh(ctx, prototype.id(), component_id).await?;
                 if should_dispatch {
                     Action::dispatch_action(ctx, action_id).await?;
                 }

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -2400,14 +2400,14 @@ impl Component {
         // into being to_delete.
         if to_delete && !original_to_delete {
             // Enqueue delete actions for component
-            for prototype_id in SchemaVariant::find_action_prototypes_by_kind(
+            for prototype in ActionPrototype::find_by_kind_for_schema_or_variant(
                 ctx,
-                schema_variant_id,
                 ActionKind::Destroy,
+                schema_variant_id,
             )
             .await?
             {
-                Action::new(ctx, prototype_id, Some(component_id)).await?;
+                Action::new(ctx, prototype.id(), Some(component_id)).await?;
             }
         } else if !to_delete {
             // Remove delete actions for component
@@ -2439,25 +2439,26 @@ impl Component {
                 {
                     // then if the current component has an update action, enqueue it
                     let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
-                    let mut prototypes_for_variant = SchemaVariant::find_action_prototypes_by_kind(
-                        ctx,
-                        schema_variant_id,
-                        ActionKind::Update,
-                    )
-                    .await?;
+                    let mut prototypes_for_variant =
+                        ActionPrototype::find_by_kind_for_schema_or_variant(
+                            ctx,
+                            ActionKind::Update,
+                            schema_variant_id,
+                        )
+                        .await?;
 
                     if prototypes_for_variant.len() > 1 {
                         // if there are multiple update funcs, not sure which one to enqueue!
                         return Ok(None);
                     }
-                    if let Some(prototype_id) = prototypes_for_variant.pop() {
+                    if let Some(prototype) = prototypes_for_variant.pop() {
                         // Don't enqueue an update if there is already an Action of any kind enqueued for this Component.
                         if Action::find_for_component_id(ctx, component_id)
                             .await?
                             .is_empty()
                         {
                             let new_action =
-                                Action::new(ctx, prototype_id, Some(component_id)).await?;
+                                Action::new(ctx, prototype.id(), Some(component_id)).await?;
                             return Ok(Some(new_action));
                         }
                     }

--- a/lib/dal/src/component/new.rs
+++ b/lib/dal/src/component/new.rs
@@ -33,7 +33,10 @@ use crate::{
     SchemaVariant,
     action::{
         Action,
-        prototype::ActionKind,
+        prototype::{
+            ActionKind,
+            ActionPrototype,
+        },
     },
     attribute::value::default_subscription::{
         DefaultSubscription,
@@ -333,15 +336,15 @@ impl Component {
             potential_sub.subscribe(ctx).await?;
         }
 
-        // Find all create action prototypes for the variant and create actions for them.
-        for prototype_id in SchemaVariant::find_action_prototypes_by_kind(
+        // Find the create action prototype for the schema or variant and enqueue the create action
+        for prototype in ActionPrototype::find_by_kind_for_schema_or_variant(
             ctx,
-            schema_variant_id,
             ActionKind::Create,
+            schema_variant_id,
         )
         .await?
         {
-            Action::new(ctx, prototype_id, Some(component.id)).await?;
+            Action::new(ctx, prototype.id(), Some(component.id)).await?;
         }
 
         // Clear the prop suggestion cache's mapping

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -244,6 +244,7 @@ impl AttributeFuncDestination {
 pub enum EventualParent {
     SchemaVariant(SchemaVariantId),
     Component(ComponentId),
+    Schema(SchemaId),
 }
 impl EventualParent {
     /// Returns an error if the [`EventualParent`] is a locked [`SchemaVariant`]
@@ -252,7 +253,7 @@ impl EventualParent {
             EventualParent::SchemaVariant(schema_variant_id) => {
                 Ok(SchemaVariant::error_if_locked(ctx, *schema_variant_id).await?)
             }
-            EventualParent::Component(_) => Ok(()),
+            EventualParent::Schema(_) | EventualParent::Component(_) => Ok(()),
         }
     }
 }
@@ -260,7 +261,7 @@ impl EventualParent {
 impl From<EventualParent> for Option<si_events::ComponentId> {
     fn from(value: EventualParent) -> Self {
         match value {
-            EventualParent::SchemaVariant(_) => None,
+            EventualParent::SchemaVariant(_) | EventualParent::Schema(_) => None,
             EventualParent::Component(component_id) => Some(component_id),
         }
     }
@@ -270,7 +271,7 @@ impl From<EventualParent> for Option<si_events::SchemaVariantId> {
     fn from(value: EventualParent) -> Self {
         match value {
             EventualParent::SchemaVariant(schema_variant_id) => Some(schema_variant_id),
-            EventualParent::Component(_) => None,
+            EventualParent::Component(_) | EventualParent::Schema(_) => None,
         }
     }
 }

--- a/lib/dal/src/func/binding/attribute.rs
+++ b/lib/dal/src/func/binding/attribute.rs
@@ -442,6 +442,7 @@ impl AttributeBinding {
                             .await?;
                         }
                     }
+                    EventualParent::Schema(_) => {}
                 }
             }
             AttributeFuncDestination::OutputSocket(output_socket_id) => {
@@ -495,6 +496,7 @@ impl AttributeBinding {
                         )
                         .await?;
                     }
+                    EventualParent::Schema(_) => {}
                 }
             }
             // we don't let users configure this right now

--- a/lib/dal/src/func/binding/leaf.rs
+++ b/lib/dal/src/func/binding/leaf.rs
@@ -19,6 +19,7 @@ use crate::{
     Func,
     FuncId,
     Prop,
+    Schema,
     SchemaVariant,
     SchemaVariantId,
     attribute::prototype::argument::AttributePrototypeArgument,
@@ -134,6 +135,9 @@ impl LeafBinding {
                 // let attribute_prototype_id =
                 //     Component::upsert_leaf_function(ctx, component_id, leaf_kind, inputs, &func).await?;
             }
+            EventualParent::Schema(_) => {
+                // zack: how to handle?
+            }
         }
 
         let new_bindings = FuncBinding::for_func_id(ctx, func_id).await?;
@@ -227,6 +231,9 @@ impl LeafBinding {
                 // )
                 // .await?;
             }
+            EventualParent::Schema(_) => {
+                // zack: todo
+            }
         }
         FuncBinding::for_func_id(ctx, func_id).await
     }
@@ -283,6 +290,10 @@ impl LeafBinding {
                     let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
                     schema_variant_ids.push(schema_variant_id);
                 }
+                EventualParent::Schema(schema_id) => {
+                    let default_variant = Schema::default_variant_id(ctx, schema_id).await?;
+                    schema_variant_ids.push(default_variant);
+                }
             }
         }
         let mut ts_type = "type Input = {\n".to_string();
@@ -304,6 +315,7 @@ impl LeafBinding {
 
         Ok(ts_type)
     }
+
     async fn get_per_variant_types_for_prop_path(
         ctx: &DalContext,
         variant_ids: &[SchemaVariantId],

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -16,6 +16,7 @@ use si_events::{
     ContentHash,
     Timestamp,
 };
+use si_id::ActionPrototypeId;
 use si_layer_cache::LayerDbError;
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -178,6 +179,14 @@ impl Schema {
         destination_id: SchemaVariantId,
         add_fn: add_edge_to_variant,
         discriminant: EdgeWeightKindDiscriminants::Use,
+        result: SchemaResult,
+    );
+
+    implement_add_edge_to!(
+        source_id: SchemaId,
+        destination_id: ActionPrototypeId,
+        add_fn: add_edge_to_action_prototype,
+        discriminant: EdgeWeightKindDiscriminants::ActionPrototype,
         result: SchemaResult,
     );
 

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -73,10 +73,7 @@ use crate::{
     WsEvent,
     WsEventResult,
     WsPayload,
-    action::prototype::{
-        ActionKind,
-        ActionPrototype,
-    },
+    action::prototype::ActionPrototype,
     attribute::{
         prototype::{
             AttributePrototypeError,
@@ -1395,35 +1392,6 @@ impl SchemaVariant {
         discriminant: EdgeWeightKindDiscriminants::ManagementPrototype,
         result: SchemaVariantResult,
     );
-
-    pub async fn find_action_prototypes_by_kind(
-        ctx: &DalContext,
-        schema_variant_id: SchemaVariantId,
-        kind: ActionKind,
-    ) -> SchemaVariantResult<Vec<ActionPrototypeId>> {
-        let workspace_snapshot = ctx.workspace_snapshot()?;
-        let id: Ulid = schema_variant_id.into();
-
-        let action_prototype_node_idxs = workspace_snapshot
-            .outgoing_targets_for_edge_weight_kind(id, EdgeWeightKindDiscriminants::ActionPrototype)
-            .await?;
-
-        let mut prototype_ids = vec![];
-
-        for prototype_idx in action_prototype_node_idxs {
-            let NodeWeight::ActionPrototype(weight) =
-                workspace_snapshot.get_node_weight(prototype_idx).await?
-            else {
-                continue;
-            };
-
-            if weight.kind() == kind {
-                prototype_ids.push(weight.id().into());
-            }
-        }
-
-        Ok(prototype_ids)
-    }
 
     pub async fn find_leaf_item_functions(
         ctx: &DalContext,

--- a/lib/dal/tests/integration_test/action.rs
+++ b/lib/dal/tests/integration_test/action.rs
@@ -36,6 +36,8 @@ use pretty_assertions_sorted::{
 use serde_json::json;
 use si_id::ActionId;
 
+mod schema_level;
+
 #[test]
 async fn prototype_id(ctx: &mut DalContext) -> Result<()> {
     let component =

--- a/lib/dal/tests/integration_test/action/schema_level.rs
+++ b/lib/dal/tests/integration_test/action/schema_level.rs
@@ -1,0 +1,156 @@
+use base64::Engine;
+use dal::{
+    AttributeValue,
+    Component,
+    DalContext,
+    Func,
+    Schema,
+    action::{
+        Action,
+        dependency_graph::ActionDependencyGraph,
+        prototype::{
+            ActionKind,
+            ActionPrototype,
+        },
+    },
+};
+use dal_test::{
+    Result,
+    helpers::create_component_for_default_schema_name_in_default_view,
+    prelude::ChangeSetTestHelpers,
+    test,
+};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn schema_level_action_prototype(ctx: &mut DalContext) -> Result<()> {
+    let schema = Schema::get_by_name(ctx, "swifty").await?;
+    let default_schema_variant_id = Schema::default_variant_id(ctx, schema.id()).await?;
+
+    let create_action_code = "async function main() {
+                return { payload: { \"when you're\": \"strange\"}, status: \"ok\" };
+            }";
+
+    let create_func = Func::new(
+        ctx,
+        "test:schemaCreateActionSwifty",
+        None::<String>,
+        None::<String>,
+        None::<String>,
+        false,
+        false,
+        dal::FuncBackendKind::JsAction,
+        dal::FuncBackendResponseType::Action,
+        "main".into(),
+        Some(base64::engine::general_purpose::STANDARD_NO_PAD.encode(create_action_code)),
+        false,
+    )
+    .await?;
+
+    let schema_action_prototype = ActionPrototype::new(
+        ctx,
+        ActionKind::Create,
+        "test:schemaCreateActionSwifty".into(),
+        None,
+        schema.id(),
+        create_func.id,
+    )
+    .await?;
+
+    let default_create = ActionPrototype::find_by_kind_for_schema_or_variant(
+        ctx,
+        ActionKind::Create,
+        default_schema_variant_id,
+    )
+    .await?
+    .pop()
+    .expect("should have one!");
+
+    assert_eq!(schema_action_prototype.id(), default_create.id());
+
+    let component =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "taylor kelce")
+            .await?;
+
+    let mut actions = Action::find_for_component_id(ctx, component.id())
+        .await
+        .expect("should be able to find actions");
+
+    assert_eq!(1, actions.len());
+
+    let action_id = actions.pop().expect("should have one action");
+
+    let prototype_id = Action::prototype_id(ctx, action_id).await?;
+    let func_id = ActionPrototype::func_id(ctx, prototype_id).await?;
+
+    assert_eq!(schema_action_prototype.id(), prototype_id);
+    assert_eq!(create_func.id, func_id);
+
+    let action_graph = ActionDependencyGraph::for_workspace(ctx).await?;
+    assert!(action_graph.contains_value(action_id));
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
+
+    let component_on_head = Component::get_by_id(ctx, component.id()).await?;
+    let payload_id = component_on_head
+        .attribute_values_for_prop(ctx, &["root", "resource", "payload"])
+        .await?
+        .pop()
+        .expect("vivre");
+
+    let payload = AttributeValue::view(ctx, payload_id)
+        .await?
+        .expect("a value should exist");
+
+    assert_eq!(serde_json::json!({"when you're": "strange"}), payload);
+
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+
+    // Now, we remove the schema level prototype and confirm the variant level one takes precedence
+    ActionPrototype::remove(ctx, schema_action_prototype.id()).await?;
+
+    let schema_variant_create_id = ActionPrototype::for_variant(ctx, default_schema_variant_id)
+        .await?
+        .into_iter()
+        .filter(|proto| proto.kind == ActionKind::Create)
+        .map(|proto| proto.id())
+        .next()
+        .expect("should have a create");
+
+    let default_create = ActionPrototype::find_by_kind_for_schema_or_variant(
+        ctx,
+        ActionKind::Create,
+        default_schema_variant_id,
+    )
+    .await?
+    .pop()
+    .expect("should have one!");
+
+    assert_eq!(schema_variant_create_id, default_create.id());
+
+    let second =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "1984").await?;
+
+    let mut actions = Action::find_for_component_id(ctx, second.id())
+        .await
+        .expect("should be able to find actions");
+
+    assert_eq!(1, actions.len());
+
+    let action_id = actions.pop().expect("should have one action");
+
+    let prototype_id = Action::prototype_id(ctx, action_id).await?;
+
+    assert_eq!(schema_variant_create_id, prototype_id);
+
+    let action_graph = ActionDependencyGraph::for_workspace(ctx).await?;
+    assert!(action_graph.contains_value(action_id));
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
+
+    Ok(())
+}

--- a/lib/sdf-server/src/service/v2/func/binding/attribute/reset_attribute_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/attribute/reset_attribute_binding.rs
@@ -109,6 +109,7 @@ pub async fn reset_attribute_binding(
                 )
                 .await?;
             }
+            EventualParent::Schema(_) => {}
         }
     }
 

--- a/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
@@ -162,6 +162,7 @@ pub async fn create_binding(
                                         Some(component_id),
                                         None,
                                     ),
+                                    EventualParent::Schema(_) => (String::new(), None, None),
                                 },
                                 None => (String::new(), None, None),
                             };

--- a/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/delete_binding.rs
@@ -175,6 +175,7 @@ pub async fn delete_binding(
                 )
                 .await?;
             }
+            EventualParent::Schema(_) => {}
         }
     }
 


### PR DESCRIPTION
Adds the ability to add an ActionPrototype  as an outgoing target of a Schema instead of a Schema Variant. When picking the action to run, the schema level action for a specific kind (Create, Refresh, Destroy, Update) will be chosen instead of the schema variant level action.

The ability to create these schema-level prototypes is not exposed anywhere, and only exercised in a test.