### PR TITLE
chore: add buck2 to ci-light

### DIFF
--- a/component/ci-light/Dockerfile
+++ b/component/ci-light/Dockerfile
@@ -1,3 +1,17 @@
+FROM alpine:3 AS buck2
+
+RUN apk add --no-cache curl zstd libc6-compat
+RUN ARCH=$(uname -m); \
+    case "$ARCH" in \
+        x86_64) BUCK2_ARCH="x86_64";; \
+        aarch64) BUCK2_ARCH="aarch64";; \
+        *) echo "unsupported arch $ARCH" && exit 1;; \
+    esac; \
+    curl -L \
+        "https://github.com/facebook/buck2/releases/download/latest/buck2-${BUCK2_ARCH}-unknown-linux-musl.zst" \
+        -o /tmp/buck2.zst && \
+    unzstd /tmp/buck2.zst -c > /bin/buck2 && chmod +x /bin/buck2
+
 FROM rust:1-alpine
 
 ARG BUILDEVENTS_VERSION=v0.17.0
@@ -23,5 +37,6 @@ RUN set -eux; \
         "https://github.com/honeycombio/buildevents/releases/download/${BUILDEVENTS_VERSION}/buildevents-${BUILDEVENTS_ARCH}" && \
     chmod +x /usr/local/bin/buildevents
 
-RUN rustup component add clippy rustfmt
+COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
+RUN rustup component add clippy rustfmt


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

this adds buck2 to ci-light so we can use it in place of the much larger ci-base in ci


## How was it tested?

built and verified locally

```
❯ docker run systeminit/ci-light:sha-15a7773121041e3523841ddd25fc56a20a51212e_dirty-dirty-amd64 buck2 --version
buck2 7531746f175a7324c4d6af15dc7a8c1da4bbccb7be7348e5d9fa9f8c65ce07bc <exe-hash>
```

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNG9hbXFhdTJsODB6cTZlbzEzem9vbTg4ZjI1MXZhZGVndnM1c25mayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Qld1cd6a6QlWw/giphy.gif"/>