### PR TITLE
feat(rootfs): add back azure cli

### DIFF
--- a/prelude-si/rootfs/rootfs_build.sh
+++ b/prelude-si/rootfs/rootfs_build.sh
@@ -120,7 +120,14 @@ apk update && apk add --no-cache \
   runuser \
   skopeo \
   wget \
-  xz
+  xz \
+  gcc \
+  musl-dev \
+  python3-dev \
+  libffi-dev \
+  openssl-dev \
+  cargo \
+  make
 
 # Minimal nix setup for dynamic linking
 mkdir -p /nix && cd /tmp
@@ -203,6 +210,12 @@ unzip -q deno.zip && mv deno /usr/local/bin/ && chmod +x /usr/local/bin/deno && 
 
 # Linode CLI
 pip3 install --break-system-packages linode-cli
+
+# Azure CLI
+pip3 install --break-system-packages azure-cli
+
+# Clean up build dependencies
+apk del gcc musl-dev python3-dev libffi-dev openssl-dev cargo make
 
 cd / && rm -rf /tmp/* 2>/dev/null && adduser -D app
 


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Adds the azure cli back to the firecracker jail. This was a bit tricky, but we got there in the end.



## How was it tested?

In a func run locally, I am able to run a func that starts the cli.

Locally in a firecracker vm:

```
localhost:~# az

Welcome to Azure CLI!
---------------------
Use `az -h` to see available commands or go to https://aka.ms/cli.

Telemetry
---------
The Azure CLI collects usage data in order to improve your experience.
The data is anonymous and does not include commandline argument values.
The data is collected by Microsoft.

You can change your telemetry settings with `az configure`.


     /\
    /  \    _____   _ _  ___ _
   / /\ \  |_  / | | | \'__/ _\
  / ____ \  / /| |_| | | |  __/
 /_/    \_\/___|\__,_|_|  \___|
```

- [X] Integration tests pass

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdldzJ2N3drZGJ3b2hscndya2c3NnFhYTZraWFkamZtajFldjNsaTRxcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/nOzU7E6g2IVhfustqQ/giphy.gif"/>