### PR TITLE
fixed first time user default workspace redirect

### DIFF
--- a/app/auth-portal/src/pages/DefaultWorkspacePage.vue
+++ b/app/auth-portal/src/pages/DefaultWorkspacePage.vue
@@ -25,6 +25,11 @@ onMounted(async () => {
     return router.push({
       name: "review-legal",
     });
+  } else if (!authStore.user.emailVerified) {
+    // unverified users who have finished the ToS go to the profile page
+    return router.push({
+      name: "profile",
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
## How does this PR change the system?

This PR fixes an issue where first time users were not being redirected to their default workspace after setting up their account.

It also updates the UI/UX so that users whose email has not been verified get better feedback and are redirected properly when they are locked on the user profile step.

Manually tested a bunch with the local auth stack for every possible scenario I could think of!