### PR TITLE
Only rebuild MVs for added/removed modules

### DIFF
--- a/lib/edda-core/src/api_types.rs
+++ b/lib/edda-core/src/api_types.rs
@@ -1,5 +1,6 @@
 pub mod new_change_set_request;
 pub mod rebuild_request;
+pub mod rebuild_minimal_request;
 pub mod update_request;
 
 pub use acceptable::*;

--- a/lib/edda-core/src/api_types/rebuild_minimal_request.rs
+++ b/lib/edda-core/src/api_types/rebuild_minimal_request.rs
@@ -1,0 +1,153 @@
+use acceptable::{
+    AllVersions,
+    Container,
+    CurrentContainer,
+    IntoContainer,
+    UpgradeError,
+};
+use serde::Deserialize;
+
+mod v1;
+
+pub use self::v1::RebuildMinimalRequestV1;
+
+#[remain::sorted]
+#[derive(AllVersions, CurrentContainer, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum RebuildMinimalRequestAllVersions {
+    #[acceptable(current)]
+    V1(RebuildMinimalRequestV1),
+}
+
+impl IntoContainer for RebuildMinimalRequestAllVersions {
+    type Container = RebuildMinimalRequest;
+
+    fn into_container(self) -> Result<Self::Container, UpgradeError> {
+        match self {
+            Self::V1(inner) => Ok(Self::Container::new(inner)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        error::Error,
+        fmt,
+        fs::File,
+        io::{
+            self,
+            BufRead as _,
+            BufReader,
+            Read as _,
+        },
+        path::Path,
+    };
+
+    use serde::{
+        Serialize,
+        de::DeserializeOwned,
+    };
+
+    /// Tests that a versioned object will always serialize to the same representation, no matter
+    /// what future versions or changes to the object.
+    ///
+    /// NOTE: It is imperative that incremental refactorings do not lead to a version-incompatible
+    /// or serialize-incompatible change. If a test fails and it's because there is a diff to the
+    /// commiteed `.snap` file, this should be considered a failed refactoring. The remediation is
+    /// to *not* update the `.snap` file but rather to fix the code so that the `.snap` format is
+    /// 100% preserved.
+    pub fn assert_serialize(name: &str, version: u64, serialize: impl Serialize) {
+        insta::with_settings!({
+            snapshot_path => format!("rebuild_minimal_request/snapshots-v{version}"),
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+            description => concat!(
+                "\n",
+                "\n",
+                "!!!\n",
+                "!!! System Initiative Developers:\n",
+                "!!!\n",
+                "!!! IMPORTANT:\n",
+                "!!!\n",
+                "!!!     The contents of this snapshot should *never* be modified as it\n",
+                "!!!     represents the serialization of a versioned Rust type. If a tests fails\n",
+                "!!!     with this warning, then something about a Rust type has changed\n",
+                "!!!     the wire serialization of this type and would represent a potential\n",
+                "!!!     production outage or data corruption.\n",
+                "!!!\n",
+                "!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n",
+                "!!!     an out-of-date snapshot or fixture!\n",
+                "!!!\n",
+                "\n",
+                "\n",
+            ),
+        }, {
+            insta::assert_json_snapshot!(name, serialize);
+        });
+    }
+
+    pub fn assert_deserialize<T>(snapshot_name: &str, version: u64, expected: T)
+    where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let actual: T = read_from_snapshot(
+            snapshot_name,
+            &format!("rebuild_minimal_request/snapshots-v{version}"),
+        )
+        .expect("failed to deserialize from snapshot");
+
+        assert_eq!(actual, expected);
+    }
+
+    fn read_from_snapshot<T>(name: &str, path: &str) -> Result<T, Box<dyn Error>>
+    where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let glob = format!("{path}/{name}.snap");
+
+        let mut maybe_obj_result = None;
+        insta::glob!(&glob, |path| {
+            let bytes = read_snapshot_content(path).unwrap();
+
+            maybe_obj_result = Some(serde_json::from_slice(&bytes).map_err(Into::into));
+        });
+
+        match maybe_obj_result {
+            Some(object_result) => object_result,
+            None => Err(Box::new(io::Error::other(format!(
+                "snapshot not found: {glob}"
+            )))),
+        }
+    }
+
+    // Implementation is adapted from the [`insta::Snapshot::from_file`] function.
+    //
+    // See: <https://github.com/mitsuhiko/insta/blob/62bb0a3/insta/src/snapshot.rs#L339-L421>
+    fn read_snapshot_content(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+        let mut f = BufReader::new(File::open(path)?);
+
+        // Skip through the snapshot metadata, that being the first YAML document, where YAML
+        // documents are delimited with a `"---"` line
+        {
+            let mut buf = String::new();
+            f.read_line(&mut buf)?;
+            if buf.trim_end() == "---" {
+                loop {
+                    let read = f.read_line(&mut buf)?;
+                    if read == 0 {
+                        break;
+                    }
+                    if buf[buf.len() - read..].trim_end() == "---" {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf)?;
+
+        Ok(buf)
+    }
+}

--- a/lib/edda-core/src/api_types/rebuild_minimal_request/snapshots-v1/serialized.snap
+++ b/lib/edda-core/src/api_types/rebuild_minimal_request/snapshots-v1/serialized.snap
@@ -1,0 +1,13 @@
+---
+source: lib/edda-core/src/api_types/rebuild_request.rs
+description: "\n\n!!!\n!!! System Initiative Developers:\n!!!\n!!! IMPORTANT:\n!!!\n!!!     The contents of this snapshot should *never* be modified as it\n!!!     represents the serialization of a versioned Rust type. If a tests fails\n!!!     with this warning, then something about a Rust type has changed\n!!!     the wire serialization of this type and would represent a potential\n!!!     production outage or data corruption.\n!!!\n!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n!!!     an out-of-date snapshot or fixture!\n!!!\n\n\n"
+---
+{
+  "id": "01JQCVVDHXYX6S9YCV773R13MG",
+  "newModuleIds": [
+    "01JQCVVDHXYX6S9YCV773R13MG"
+  ],
+  "removedModuleIds": [
+    "01JQCVVDHXYX6S9YCV773R13MG"
+  ]
+}

--- a/lib/edda-core/src/api_types/rebuild_minimal_request/v1.rs
+++ b/lib/edda-core/src/api_types/rebuild_minimal_request/v1.rs
@@ -1,0 +1,48 @@
+use acceptable::{
+    RequestId,
+    Versioned,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::CachedModuleId;
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq, Versioned)]
+#[serde(rename_all = "camelCase")]
+#[acceptable(version = 1)]
+// NOTE: **do not modify this datatype--it represents a historically stable, versioned request**
+pub struct RebuildMinimalRequestV1 {
+    pub id: RequestId,
+    pub new_module_ids: Vec<CachedModuleId>,
+    pub removed_module_ids: Vec<CachedModuleId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::test::*,
+        *,
+    };
+
+    const SNAPSHOT_NAME: &str = "serialized";
+    const VERSION: u64 = 1;
+
+    fn msg() -> RebuildMinimalRequestV1 {
+        RebuildMinimalRequestV1 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            new_module_ids: vec!["01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),],
+            removed_module_ids: vec!["01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),],
+        }
+    }
+
+    #[test]
+    fn serialize() {
+        assert_serialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+
+    #[test]
+    fn deserialize() {
+        assert_deserialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+}

--- a/lib/edda-server/src/api_types/deployment_request.rs
+++ b/lib/edda-server/src/api_types/deployment_request.rs
@@ -9,12 +9,15 @@ use edda_core::api_types::{
     Negotiate,
     NegotiateError,
     rebuild_request::RebuildRequest,
+    rebuild_minimal_request::RebuildMinimalRequest,
+
 };
 use naxum::async_trait;
 use serde::{
     Deserialize,
     Serialize,
 };
+use si_id::CachedModuleId;
 use strum::AsRefStr;
 use telemetry::prelude::*;
 
@@ -27,6 +30,7 @@ use super::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DeploymentRequest {
     Rebuild(RebuildRequest),
+    RebuildMinimal(RebuildMinimalRequest),
 }
 
 impl Negotiate for DeploymentRequest {
@@ -52,6 +56,7 @@ impl Negotiate for DeploymentRequest {
 #[derive(AsRefStr, Clone, Debug, Deserialize, Serialize)]
 pub enum CompressedDeploymentRequest {
     Rebuild { src_requests_count: usize },
+    RebuildMinimal { src_requests_count: usize, new_module_ids: Vec<CachedModuleId>, removed_module_ids: Vec<CachedModuleId> },
 }
 
 #[async_trait]
@@ -100,6 +105,7 @@ impl CompressedDeploymentRequest {
     pub fn src_requests_count(&self) -> usize {
         match self {
             Self::Rebuild { src_requests_count } => *src_requests_count,
+            Self::RebuildMinimal { src_requests_count, new_module_ids, removed_module_ids } => *src_requests_count,
         }
     }
 

--- a/lib/edda-server/src/deployment_processor_task.rs
+++ b/lib/edda-server/src/deployment_processor_task.rs
@@ -362,13 +362,25 @@ mod handlers {
 
         match request {
             CompressedDeploymentRequest::Rebuild { .. } => {
-                // Rebuild
                 materialized_view::build_all_mvs_for_deployment(
                     ctx,
                     frigg,
                     edda_updates,
                     parallel_build_limit,
                     "explicit rebuild",
+                )
+                .await
+                .map_err(Into::into)
+            },
+            CompressedDeploymentRequest::RebuildMinimal { src_requests_count: _, new_module_ids, removed_module_ids } => {
+                materialized_view::build_minimal_mvs_for_deployment(
+                    ctx,
+                    frigg,
+                    edda_updates,
+                    parallel_build_limit,
+                    new_module_ids,
+                    removed_module_ids,
+                    "minimal rebuild",
                 )
                 .await
                 .map_err(Into::into)

--- a/lib/sdf-server/src/migrations.rs
+++ b/lib/sdf-server/src/migrations.rs
@@ -147,10 +147,7 @@ impl Migrator {
         }
 
         if update_module_cache {
-            let nats_connection = self.services_context.nats_conn().clone();
-            let edda_client = EddaClient::new(nats_connection).await?;
-
-            self.migrate_module_cache(edda_client)
+            self.migrate_module_cache()
                 .await
                 .map_err(|err| span.record_err(err))?;
         }
@@ -206,17 +203,16 @@ impl Migrator {
     }
 
     #[instrument(name = "sdf.migrator.migrate_module_cache", level = "info", skip_all)]
-    async fn migrate_module_cache(&self, edda_client: EddaClient) -> MigratorResult<()> {
+    async fn migrate_module_cache(&self) -> MigratorResult<()> {
         async fn update_cached_modules(
             ctx: DalContext,
-            edda_client: EddaClient,
         ) -> MigratorResult<()> {
-            let new_modules = CachedModule::update_cached_modules(&ctx, edda_client)
+            let (new_module_ids, _) = CachedModule::update_cached_modules(&ctx)
                 .await
                 .map_err(MigratorError::migrate_cached_modules)?;
             info!(
                 "{} new builtin assets found in module index",
-                new_modules.len()
+                new_module_ids.len()
             );
             Ok::<(), MigratorError>(())
         }
@@ -230,7 +226,7 @@ impl Migrator {
         info!("Updating local module cache");
 
         tokio::spawn(async move {
-            match update_cached_modules(ctx, edda_client).await {
+            match update_cached_modules(ctx).await {
                 Ok(()) => {
                     info!("Module cache updated successfully");
                 }

--- a/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
+++ b/lib/sdf-server/src/service/v2/admin/update_module_cache.rs
@@ -87,7 +87,7 @@ pub async fn update_cached_modules_inner(
     edda_client: edda_client::EddaClient,
 ) -> AdminAPIResult<()> {
     info!("Starting module cache update");
-    CachedModule::update_cached_modules(ctx, edda_client.clone()).await?;
+    let (new_module_ids, removed_module_ids) = CachedModule::update_cached_modules(ctx).await?;
     edda_client.rebuild_for_deployment().await?;
 
     track(

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -16,6 +16,7 @@ use serde::{
     Serialize,
 };
 pub use si_id::ulid;
+pub use si_id::CachedModuleId;
 use split_snapshot_rebase_batch_address::SplitSnapshotRebaseBatchAddress;
 
 mod action;


### PR DESCRIPTION
This change ensures that we only rebuild deployment MVs for modules that have been added or removed.

<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI
- [X] Manual test: (regression check) creating a component still works

## In short: [:link:](https://giphy.com/)

![](put .gif link here - click the :link: besides the gif on giphy to copy it)
