### PR TITLE
Map QOL: toggle checkbox for hiding components that aren't subscribed to the selected component

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -158,9 +158,7 @@
             </Transition>
           </div>
         </div>
-        <div
-          class="flex-none flex flex-row flex-wrap items-center gap-xs justify-between"
-        >
+        <div class="flex-none flex flex-row flex-wrap items-center gap-xs">
           <TabGroupToggle
             ref="groupRef"
             :aOrB="urlGridOrMap === 'grid'"
@@ -183,7 +181,16 @@
               />
             </template>
           </TabGroupToggle>
-          <div v-if="showGrid" class="flex flex-row flex-wrap gap-xs">
+          <label v-if="!showGrid" class="text-sm">
+            <input
+              type="checkbox"
+              :checked="queryHideSubscriptions"
+              class="focus:outline-none"
+              @click="toggleHide"
+            />
+            Hide unconnected components
+          </label>
+          <div v-if="showGrid" class="ml-auto flex flex-row flex-wrap gap-xs">
             <DefaultSubscriptionsButton
               v-if="featureFlagsStore.DEFAULT_SUBS"
               :selected="gridMode.mode === 'defaultSubscriptions'"
@@ -710,6 +717,25 @@ const collapsingStyles = computed(() =>
     historyRef.value?.openState,
   ]),
 );
+
+const queryHideSubscriptions = computed(() => {
+  const query: SelectionsInQueryString = {
+    ...router.currentRoute.value?.query,
+  };
+  return query.hideSubscriptions === "1";
+});
+
+const toggleHide = () => {
+  const query: SelectionsInQueryString = {
+    ...router.currentRoute.value?.query,
+  };
+  if (queryHideSubscriptions.value) {
+    delete query.hideSubscriptions;
+  } else {
+    query.hideSubscriptions = "1";
+  }
+  router.replace({ query });
+};
 
 const urlGridOrMap = computed((): "grid" | "map" => {
   const q: SelectionsInQueryString = router.currentRoute.value?.query;


### PR DESCRIPTION
## How does this PR change the system?

When you've got a big map (like tools prod) most of the subscriptions you can't even see because they're not close in the layout to the selected component. In order to better navigate the map you ought to be able to hide unconnected components, so only connections get re-layout'd and come into view for.

Currently, this feature is hidden behind a one-time-only query string value set from pressing "Visualize Subscriptions". Now it is always accessible.

#### Screenshots:

<img width="1444" height="439" alt="image" src="https://github.com/user-attachments/assets/364fc208-5306-4d1e-8560-bb94d3bcd78e" />

## How was it tested?

- Toggle the checkbox
- Toggle component selections
- Click on Visualize Subscriptions

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbWlranFtd3ZscGU4OGV2MW5nYXphdWxqeWJjZHAxZGtjdHUxbnZuaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GuYWqjSakPEkRHLLi3/giphy.gif"/>