### PR TITLE
feat(luminork): Adding the ability to return codegen from our list_components api

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -29,6 +29,7 @@
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@^1.0.6": "1.1.1",
     "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@systeminit/api-client@^1.1.4": "1.1.4",
     "jsr:@systeminit/cf-db@~0.1.4": "0.1.4",
     "jsr:@systeminit/remove-empty@0.1.3": "0.1.3",
     "npm:@apidevtools/json-schema-ref-parser@11.9.3": "11.9.3",
@@ -202,6 +203,12 @@
     },
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
+    },
+    "@systeminit/api-client@1.1.4": {
+      "integrity": "5d88f54adde71fedf60e8bfed67b652b0a41ea5cbaeb33a1e2a6f930a031f570",
+      "dependencies": [
+        "npm:axios@^1.6.1"
+      ]
     },
     "@systeminit/cf-db@0.1.4": {
       "integrity": "04abaef4707837dad4e252c69dca7e57014dd5038fd323dd1d11868ea1747816",
@@ -1668,7 +1675,7 @@
         ],
         "packageJson": {
           "dependencies": [
-            "npm:axios@^1.6.1",
+            "npm:axios@^1.12.0",
             "npm:dotenv@^16.3.1",
             "npm:jwt-decode@4",
             "npm:mcp-jest@1"

--- a/lib/luminork-server/src/service/v1/common.rs
+++ b/lib/luminork-server/src/service/v1/common.rs
@@ -123,4 +123,5 @@ pub struct PaginationParams {
     pub limit: Option<u32>,
     #[schema(example = "01H9ZQD35JPMBGHH69BT0Q79VY", nullable = true, value_type = Option<String>)]
     pub cursor: Option<String>,
+    pub include_codegen: bool,
 }


### PR DESCRIPTION
This is going to be used to allow us to get a generated cloudformation template for use in cost-exploration

This is a querySstring param and when set returns:

```
{
  "componentDetails": [
    {
      "componentId": "01K5EYSC2QTZ49DVEPNQY2TGJH",
      "name": "si-0070",
      "schemaName": "AWS::EC2::VPC",
      "codegen": {
        "code": "{\n  \"AWSTemplateFormatVersion\": \"2010-09-09\",\n  \"Resources\": {\n    \"cfnResource\": {\n      \"Type\": \"AWS::EC2::VPC\",\n      \"Properties\": {\n        \"CidrBlock\": \"10.0.0.0/16\",\n        \"EnableDnsHostnames\": true,\n        \"EnableDnsSupport\": true\n      }\n    }\n  }\n}",
        "format": "json"
      }
    }
  ],
  "nextCursor": null
}
```