### PR TITLE
allow users to enter names with a wider set of characters

### DIFF
--- a/app/auth-portal/src/lib/validations.ts
+++ b/app/auth-portal/src/lib/validations.ts
@@ -1,4 +1,11 @@
-export const ALLOWED_INPUT_REGEX = /^[a-zA-Z0-9-.,_@/+ ]*$/;
+// Our old regex here prevented usage of accents in names
+// ^[a-zA-Z0-9-.,_@/+ ]*$/;
+
+// This one is much more permissive but still might not be quite right
+// We probably want to figure out exactly what characters to include or not include
+// Useful here - https://en.wikipedia.org/wiki/List_of_Unicode_characters
+// TODO - update this REGEX to be even better!
+export const ALLOWED_INPUT_REGEX = /^[0-9A-Za-zÀ-ÖØ-öø-ÿĀ-ỹ-.,_@/+ ]*$/;
 
 export const ALLOWED_URL_REGEX =
   "^https?://([\\da-z.-]+)(:\\d+)?(/[\\w .-]*)*/?$";

--- a/bin/auth-api/src/lib/validation-helpers.ts
+++ b/bin/auth-api/src/lib/validation-helpers.ts
@@ -14,6 +14,6 @@ export function validate<Z extends Zod.Schema>(obj: any, schema: Z) {
   }
 }
 
-export const ALLOWED_INPUT_REGEX = /^[a-zA-Z0-9-.,_@/+ ]*$/;
+export const ALLOWED_INPUT_REGEX = /^[0-9A-Za-zÀ-ÖØ-öø-ÿĀ-ỹ-.,_@/+ ]*$/;
 
 export const ALLOWED_URL_REGEX = "^https?://([\\da-z.-]+)(:\\d+)?(/[\\w .-]*)*/?$";


### PR DESCRIPTION
This PR changes the regex used in the auth portal to allow for users to enter more characters. This is to address the common user problem of not being able to enter their name properly if it contains an accent or other uncommon character.

The old regex only allowed for a-z, A-Z, 0-9, and -,_@/+

The new regex allows for those characters as well as a wider range of uppercase and lowercase latin characters with accents and other diacritics. This should allow users to enter any name written with latin characters without any security risks.