### PR TITLE
redirect for old SI launcher url

### DIFF
--- a/app/auth-portal/src/router.ts
+++ b/app/auth-portal/src/router.ts
@@ -64,6 +64,13 @@ export const routerOptions: RouterOptions = {
         return { name: "workspaces" };
       },
     },
+    {
+      path: "/download",
+      name: "download",
+      redirect() {
+        return { name: "workspaces" };
+      },
+    },
     { path: "/workspaces", name: "workspaces", component: WorkspacesPage },
     { path: "/billing", name: "billing", component: BillingPage },
     {


### PR DESCRIPTION
This PR adds a simple redirect for the old auth portal URL for the SI Launcher `/download`

This redirect is being added based on seeing users hit a 404 at this URL in Posthog recently.