### PR TITLE
Hot fix: if the first time modal api call fails users are stuck in the lobby

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -480,6 +480,7 @@ const checkOnboardingCompleteData = async () => {
     // If we don't get onboarding status back successfully, default to skipping onboarding.
     // Because we do not want to end up in a state where a user is locked out of a workspace!
     onboardingCompleted.value = true;
+    loadedOnboardingStateFromApi.value = true;
     return;
   }
 


### PR DESCRIPTION
## How was it tested?

I can't repro the endpoint failure locally. However, I changed the check for "success"
```
  if (status !== 300) {
```
- So when it succeeds with 200, it goes into this logic check.
- With that change, I am stuck in the lobby.
- Now I make my fix
- No longer stuck