### PR TITLE
chore: Fix deno.lock to v4

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "5",
+  "version": "4",
   "specifiers": {
     "jsr:@cliffy/command@^1.0.0-rc.7": "1.0.0-rc.8",
     "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",


### PR DESCRIPTION
This was upgraded to v5 and has broken starting the MCP server LOCALLY - it works in the CI environment and in production

Without this change we got an error:

```
 ~/code/systeminit/si/bin/si-mcp-server/ [gitbutler/workspace*] deno task build
Warning "nodeModulesDir" field can only be specified in the workspace root deno.json file.
    at file:///Users/stack72/code/systeminit/si/bin/si-mcp-server/deno.json
error: Failed reading lockfile at '/Users/stack72/code/systeminit/si/deno.lock'

Caused by:
    Unsupported lockfile version '5'. Try upgrading Deno or recreating the lockfile
```
