### PR TITLE
Add the rebuildinator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6856,6 +6856,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rebuildinator"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "color-eyre",
+ "edda-client",
+ "si-data-nats",
+ "si-id",
+ "si-std",
+ "tokio",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "bin/openapi-extractor",
   "bin/pinga",
   "bin/rebaser",
+  "bin/rebuildinator",
   "bin/sdf",
   "bin/si-fs",
   "bin/veritech",

--- a/bin/rebuildinator/BUCK
+++ b/bin/rebuildinator/BUCK
@@ -1,0 +1,20 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "rebuildinator",
+    deps = [
+        "//lib/edda-client:edda-client",
+        "//lib/si-data-nats:si-data-nats",
+        "//lib/si-id:si-id",
+        "//lib/si-std:si-std",
+        "//third-party/rust:clap",
+        "//third-party/rust:color-eyre",
+        "//third-party/rust:tokio",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+    env = {"CARGO_BIN_NAME": "rebuildinator"},
+)
+

--- a/bin/rebuildinator/Cargo.toml
+++ b/bin/rebuildinator/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rebuildinator"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+clap = { workspace = true }
+color-eyre = { workspace = true }
+edda-client = { path = "../../lib/edda-client" }
+si-data-nats = { path = "../../lib/si-data-nats" }
+si-id = { path = "../../lib/si-id" }
+si-std = { path = "../../lib/si-std" }
+tokio = { workspace = true }

--- a/bin/rebuildinator/src/main.rs
+++ b/bin/rebuildinator/src/main.rs
@@ -1,0 +1,122 @@
+use std::{
+    path::PathBuf,
+    str::FromStr,
+};
+
+use clap::Parser;
+use color_eyre::{
+    Result,
+    eyre::{
+        Error,
+        eyre,
+    },
+};
+use edda_client::Client;
+use si_data_nats::{
+    NatsClient,
+    NatsConfig,
+};
+use si_id::{
+    ChangeSetId,
+    WorkspacePk,
+};
+use si_std::SensitiveString;
+
+const NAME: &str = "rebuildinator";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = NAME,
+    about = "Rebuilds MVs for a given list of workspace and change set pairs"
+)]
+struct Args {
+    /// Pairs of workspace and change set identifiers in the following format: "<workspace-id>:<change-set-id>"
+    workspace_and_change_set_pairs: Vec<WorkspaceAndChangeSetPair>,
+
+    /// NATS connection URL [example: demo.nats.io]
+    #[arg(long)]
+    nats_url: Option<String>,
+
+    /// NATS credentials string
+    #[arg(long, allow_hyphen_values = true)]
+    nats_creds: Option<SensitiveString>,
+
+    /// NATS credentials file
+    #[arg(long)]
+    nats_creds_path: Option<PathBuf>,
+
+    /// NATS subject prefix (typically used in tests)
+    #[arg(long)]
+    nats_subject_prefix: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Parse the args first because this can fail.
+    let args = Args::parse();
+    if args.workspace_and_change_set_pairs.is_empty() {
+        return Err(eyre!("no workspace and change set pairs provided"));
+    }
+
+    // Create a NATS client.
+    let mut nats_config = NatsConfig {
+        connection_name: Some(NAME.to_string()),
+        creds: args.nats_creds.map(|c| c.to_string()),
+        creds_file: args.nats_creds_path.map(|p| p.display().to_string()),
+        subject_prefix: args.nats_subject_prefix,
+        ..Default::default()
+    };
+    if let Some(url) = args.nats_url {
+        nats_config.url = url;
+    }
+    let nats = NatsClient::new(&nats_config).await?;
+
+    // Create an edda client.
+    let edda_client = Client::new(nats).await?;
+
+    // Perform the requests!
+    for WorkspaceAndChangeSetPair {
+        workspace_id,
+        change_set_id,
+    } in args.workspace_and_change_set_pairs
+    {
+        println!("requesting for workspace '{workspace_id}' and change set '{change_set_id}'...");
+        let request_id = edda_client
+            .rebuild_for_change_set(workspace_id, change_set_id)
+            .await?;
+        println!("successfully sent the request with ID '{request_id}'");
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceAndChangeSetPair {
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+}
+
+impl FromStr for WorkspaceAndChangeSetPair {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+        if parts.len() != 2 {
+            return Err(eyre!(
+                "invalid format (expected '<workspace-id>:<change-set-id>', got '{s}')"
+            ));
+        }
+
+        let workspace_id: WorkspacePk = parts[0]
+            .parse()
+            .map_err(|e| eyre!("invalid workspace ID: '{}' (error: {e})", parts[0]))?;
+        let change_set_id: ChangeSetId = parts[1]
+            .parse()
+            .map_err(|e| eyre!("invalid change set ID: '{}' (error: {e})", parts[1]))?;
+
+        Ok(WorkspaceAndChangeSetPair {
+            workspace_id,
+            change_set_id,
+        })
+    }
+}


### PR DESCRIPTION
## Description

This change adds the rebuildinator, which is a wrapper around the edda client to build MVs for a given list of workspace and change set pairs.

If invalid IDs are provided, then the requests will sit on "EDDA_REQUESTS" stream, but they are ultimately not harmful. The rebuildinator intentionally does not pull in the dal in order to minimize dependency usage. Thus, both the workspace ID and change set ID are required (no practical way to determine the workspace from the change set without the dal).

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdla2Rpb2E5dmVkaGNqdnBpbGxxaDB1eDRrOW9zZHl2ZzVuNnRnM2MyNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/11fFFMrKhR0Nt6/giphy.gif"/>

## Testing

- Ran the local stack
- Disabled the edda resource in Tilt and ran locally with debug logs (`buck2 run @//mode/release //bin/edda:edda -- -vvv`)
- Open a new change set and do some work
- Run the rebuildinator with the local workspace and the new change set
- Observe in the logs that it worked
- Run the rebuildinator with bad arguments
- Observe that it failed to run with a non-zero exit code
- Run the rebuildinator with the IDs swapped (valid ULIDs, but incorrect domain-wise)
- Observe that no failures occur and nothing is logged in edda, but the request sits on `EDDA_REQUESTS`