### PR TITLE
chore(clover): refactor to allow selecting a provider

### DIFF
--- a/.github/workflows/asset-compare.yml
+++ b/.github/workflows/asset-compare.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate Specs
         run: |
           cd bin/clover
-          LOG_LEVEL=debug deno task run generate-specs
+          LOG_LEVEL=debug deno task run generate-specs --provider=aws
 
       - name: Generate Diff
         run: |

--- a/.github/workflows/asset-diff.yml
+++ b/.github/workflows/asset-diff.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate Specs
         run: |
           cd bin/clover
-          LOG_LEVEL=debug deno task run generate-specs
+          LOG_LEVEL=debug deno task run generate-specs --provider=aws
 
       - name: Generate Diff
         run: |

--- a/.github/workflows/asset-push.yml
+++ b/.github/workflows/asset-push.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate Specs
         run: |
           cd bin/clover
-          LOG_LEVEL=debug deno task run generate-specs
+          LOG_LEVEL=debug deno task run generate-specs --provider=aws
 
       - name: Push Specs
         run: |

--- a/bin/clover/src/cli.ts
+++ b/bin/clover/src/cli.ts
@@ -51,6 +51,13 @@ To generate all specs containing "ECS" or "S3", you can pass some services as ar
       "--force-update-existing-packages",
       "Force the existing package list to be updated",
     )
+    .option(
+      "-p, --provider=[provider]",
+      "The specific provider to generate specs for",
+      {
+        required: true,
+      },
+    )
     .env(
       "SI_BEARER_TOKEN=<value:string>",
       "Auth token for interacting with the module index",

--- a/bin/clover/src/pipelines/aws/pipeline-steps/addDefaultPropsAndSockets.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/addDefaultPropsAndSockets.ts
@@ -3,8 +3,8 @@ import {
   createObjectProp,
   createScalarProp,
   ExpandedPropSpec,
-} from "../spec/props.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+} from "../../../spec/props.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 
 export interface PropUsageMap {
   createOnly: string[];

--- a/bin/clover/src/pipelines/aws/pipeline-steps/addInferredEnums.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/addInferredEnums.ts
@@ -1,7 +1,7 @@
-import _logger from "../logger.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import { bfsPropTree } from "../spec/props.ts";
-import { Inferred } from "../spec/inferred.ts";
+import _logger from "../../../logger.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import { bfsPropTree } from "../../../spec/props.ts";
+import { Inferred } from "../../../spec/inferred.ts";
 
 export function addInferredEnums(
   specs: ExpandedPkgSpec[],

--- a/bin/clover/src/pipelines/aws/pipeline-steps/assetSpecificOverrides.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/assetSpecificOverrides.ts
@@ -1,6 +1,6 @@
 import _ from "npm:lodash";
-import _logger from "../logger.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import _logger from "../../../logger.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 import {
   addPropSuggestSource,
   bfsPropTree,
@@ -8,7 +8,7 @@ import {
   ExpandedPropSpec,
   ExpandedPropSpecFor,
   findPropByName,
-} from "../spec/props.ts";
+} from "../../../spec/props.ts";
 import { PropUsageMap } from "./addDefaultPropsAndSockets.ts";
 import {
   ACTION_FUNC_SPECS,
@@ -18,14 +18,14 @@ import {
   MANAGEMENT_FUNCS,
   modifyFunc,
   strippedBase64,
-} from "../spec/funcs.ts";
+} from "../../../spec/funcs.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
-import { FuncArgumentSpec } from "../bindings/FuncArgumentSpec.ts";
-import { ActionFuncSpecKind } from "../bindings/ActionFuncSpecKind.ts";
-import { FuncSpec } from "../bindings/FuncSpec.ts";
-import { ActionFuncSpec } from "../bindings/ActionFuncSpec.ts";
-import { LeafFunctionSpec } from "../bindings/LeafFunctionSpec.ts";
-import { AttrFuncInputSpec } from "../bindings/AttrFuncInputSpec.ts";
+import { FuncArgumentSpec } from "../../../bindings/FuncArgumentSpec.ts";
+import { ActionFuncSpecKind } from "../../../bindings/ActionFuncSpecKind.ts";
+import { FuncSpec } from "../../../bindings/FuncSpec.ts";
+import { ActionFuncSpec } from "../../../bindings/ActionFuncSpec.ts";
+import { LeafFunctionSpec } from "../../../bindings/LeafFunctionSpec.ts";
+import { AttrFuncInputSpec } from "../../../bindings/AttrFuncInputSpec.ts";
 
 // Easy way to create property overrides
 // Matches the schema and prop and calls the override
@@ -651,8 +651,9 @@ const SCHEMA_OVERRIDES = new Map<string, OverrideFn>([
       const extraProp = objectPropForOverride(variant.domain, "extra");
 
       const propUsageMapProp = propForOverride(extraProp, "PropUsageMap");
-      if (!propUsageMapProp.data?.defaultValue)
+      if (!propUsageMapProp.data?.defaultValue) {
         throw new Error("Prop has no default value");
+      }
 
       const defaultValue = JSON.parse(
         propUsageMapProp.data.defaultValue as string,
@@ -664,10 +665,9 @@ const SCHEMA_OVERRIDES = new Map<string, OverrideFn>([
         const prop = propForOverride(variant.domain, propName);
 
         const currentWidgetOptions = prop.data.widgetOptions;
-        prop.data.widgetOptions =
-          currentWidgetOptions?.filter(
-            (w) => w.label !== "si_create_only_prop",
-          ) ?? null;
+        prop.data.widgetOptions = currentWidgetOptions?.filter(
+          (w) => w.label !== "si_create_only_prop",
+        ) ?? null;
 
         createOnly = createOnly?.filter((p: string) => p !== propName);
 
@@ -937,7 +937,6 @@ const SCHEMA_OVERRIDES = new Map<string, OverrideFn>([
       ];
     },
   ],
-
   // TODO prop suggestion DistributionViewerCertificate.AcmCertificateArn <- CertificateArn
   // [
   //   "AWS::CloudFront::Distribution",
@@ -1164,8 +1163,9 @@ function propInputBinding(
 
 // Overrides for PolicyDocument JSON props
 function policyDocumentProp(prop: ExpandedPropSpec) {
-  if (prop.kind !== "string" && prop.kind !== "json")
+  if (prop.kind !== "string" && prop.kind !== "json") {
     throw new Error(`${prop.metadata.propPath} is not a string`);
+  }
   prop.kind = "json";
   prop.data.widgetKind = "CodeEditor";
   addPropSuggestSource(prop, {
@@ -1182,8 +1182,9 @@ function arnProp(suggestSchema: string, suggestProp: string = "Arn") {
 
 /// Suggestion override. If prop does not start with /, it is assumed to be under /resource_value
 function suggest(suggestSchema: string, suggestProp: string) {
-  if (!suggestProp.startsWith("/"))
+  if (!suggestProp.startsWith("/")) {
     suggestProp = `/resource_value/${suggestProp}`;
+  }
   return (addToProp: ExpandedPropSpec) =>
     addPropSuggestSource(addToProp, {
       schema: suggestSchema,

--- a/bin/clover/src/pipelines/aws/pipeline-steps/attachDefaultActionFuncs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/attachDefaultActionFuncs.ts
@@ -2,9 +2,9 @@ import _ from "lodash";
 import {
   createActionFuncSpec,
   createDefaultActionFuncs,
-} from "../spec/funcs.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import { CfHandlerKind } from "../cfDb.ts";
+} from "../../../spec/funcs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import { CfHandlerKind } from "../../../cfDb.ts";
 
 export function attachDefaultActionFuncs(
   specs: ExpandedPkgSpec[],

--- a/bin/clover/src/pipelines/aws/pipeline-steps/attachDefaultManagementFuncs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/attachDefaultManagementFuncs.ts
@@ -2,8 +2,8 @@ import _ from "lodash";
 import {
   createDefaultManagementFuncs,
   createManagementFuncSpec,
-} from "../spec/funcs.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+} from "../../../spec/funcs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 
 export function attachDefaultManagementFuncs(
   specs: ExpandedPkgSpec[],

--- a/bin/clover/src/pipelines/aws/pipeline-steps/createSuggestionsAcrossAssets.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/createSuggestionsAcrossAssets.ts
@@ -1,10 +1,10 @@
 import _ from "npm:lodash";
 
-import { bfsPropTree } from "../spec/props.ts";
+import { bfsPropTree } from "../../../spec/props.ts";
 import pluralize from "npm:pluralize";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import { addPropSuggestSource } from "../spec/props.ts";
-import _logger from "../logger.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import { addPropSuggestSource } from "../../../spec/props.ts";
+import _logger from "../../../logger.ts";
 const logger = _logger.ns("test").seal();
 
 export function createSuggestionsForPrimaryIdentifiers(
@@ -83,10 +83,12 @@ export function createSuggestionsForPrimaryIdentifiers(
     bfsPropTree(
       domain,
       (prop) => {
-        for (const [
-          specName,
-          [propName, possibleNames],
-        ] of schemasToPrimaryIdents.entries()) {
+        for (
+          const [
+            specName,
+            [propName, possibleNames],
+          ] of schemasToPrimaryIdents.entries()
+        ) {
           if (spec.name != specName && possibleNames.has(prop.name)) {
             logger.debug(
               `suggest {schema:${specName}, prop:${propName}} for prop ${prop.name} on ${spec.name}`,

--- a/bin/clover/src/pipelines/aws/pipeline-steps/generateAssetFuncs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/generateAssetFuncs.ts
@@ -1,9 +1,15 @@
-import type { FuncSpecData } from "../../../../lib/si-pkg/bindings/FuncSpecData.ts";
-import { FuncSpec } from "../../../../lib/si-pkg/bindings/FuncSpec.ts";
+import type { FuncSpecData } from "../../../../../../lib/si-pkg/bindings/FuncSpecData.ts";
+import { FuncSpec } from "../../../../../../lib/si-pkg/bindings/FuncSpec.ts";
 import _ from "lodash";
-import { strippedBase64 } from "../spec/funcs.ts";
-import { CREATE_ONLY_PROP_LABEL, ExpandedPropSpec } from "../spec/props.ts";
-import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
+import { strippedBase64 } from "../../../spec/funcs.ts";
+import {
+  CREATE_ONLY_PROP_LABEL,
+  ExpandedPropSpec,
+} from "../../../spec/props.ts";
+import {
+  ExpandedPkgSpec,
+  ExpandedSchemaVariantSpec,
+} from "../../../spec/pkgs.ts";
 
 export function generateAssetFuncs(
   specs: ExpandedPkgSpec[],
@@ -61,9 +67,11 @@ function generateAssetCodeFromVariantSpec(
 
     for (const prop of variant.domain.entries) {
       const varName = `${prop.name}Prop`.replaceAll(" ", "");
-      propDeclarations += `${indent(
-        1,
-      )}const ${varName} = ${generatePropBuilderString(prop, 2)};\n\n`;
+      propDeclarations += `${
+        indent(
+          1,
+        )
+      }const ${varName} = ${generatePropBuilderString(prop, 2)};\n\n`;
       propAdds += `${indent(2)}.addProp(${varName})\n`;
     }
 
@@ -85,9 +93,11 @@ function generateAssetCodeFromVariantSpec(
 
     for (const prop of variant.secrets.entries) {
       const varName = `${prop.name}SecretProp`.replaceAll(" ", "");
-      propDeclarations += `${indent(
-        1,
-      )}const ${varName} = ${generateSecretPropBuilderString(prop, 2)};\n\n`;
+      propDeclarations += `${
+        indent(
+          1,
+        )
+      }const ${varName} = ${generateSecretPropBuilderString(prop, 2)};\n\n`;
       propAdds += `${indent(2)}.addSecretProp(${varName})\n`;
     }
     declarations += propDeclarations;
@@ -103,9 +113,11 @@ function generateAssetCodeFromVariantSpec(
 
     for (const prop of variant.resourceValue.entries) {
       const varName = `${prop.name}Resource`.replaceAll(" ", "");
-      propDeclarations += `${indent(
-        1,
-      )}const ${varName} = ${generatePropBuilderString(prop, 2)};\n\n`;
+      propDeclarations += `${
+        indent(
+          1,
+        )
+      }const ${varName} = ${generatePropBuilderString(prop, 2)};\n\n`;
       propAdds += `${indent(2)}.addResourceProp(${varName})\n`;
     }
 
@@ -141,25 +153,25 @@ function generatePropBuilderString(
   switch (prop.kind) {
     case "array":
     case "map": {
-      const entryBlock =
-        `${indent(indent_level)}.setEntry(\n` +
-        `${indent(indent_level + 1)}${generatePropBuilderString(
-          prop.typeProp,
-          indent_level + 1,
-        )}\n` +
+      const entryBlock = `${indent(indent_level)}.setEntry(\n` +
+        `${indent(indent_level + 1)}${
+          generatePropBuilderString(
+            prop.typeProp,
+            indent_level + 1,
+          )
+        }\n` +
         `${indent(indent_level)})\n`;
       return generatePropBuilderStringInner(prop.kind, entryBlock);
     }
     case "object": {
       const children = prop.entries.map((p) =>
-        generatePropBuilderString(p, indent_level + 1),
+        generatePropBuilderString(p, indent_level + 1)
       );
 
       let addChildBlock = "";
 
       for (const child of children) {
-        addChildBlock +=
-          `${indent(indent_level)}.addChild(\n` +
+        addChildBlock += `${indent(indent_level)}.addChild(\n` +
           `${indent(indent_level + 1)}${child}\n` +
           `${indent(indent_level)})\n`;
       }
@@ -178,8 +190,7 @@ function generatePropBuilderString(
   function generatePropBuilderStringInner(kind: string, inner: string = "") {
     const is_create_only = prop.metadata.createOnly ?? false;
 
-    const result =
-      `new PropBuilder()\n` +
+    const result = `new PropBuilder()\n` +
       `${indent(indent_level)}.setName("${prop.name}")\n` +
       `${indent(indent_level)}.setKind("${kind}")\n` +
       `${indent(indent_level)}.setHidden(${prop.data?.hidden ?? false})\n` +
@@ -190,22 +201,28 @@ function generatePropBuilderString(
         prop.data?.widgetOptions,
       ) +
       (prop.data?.defaultValue
-        ? `${indent(indent_level)}.setDefaultValue(${JSON.stringify(
+        ? `${indent(indent_level)}.setDefaultValue(${
+          JSON.stringify(
             prop.data.defaultValue,
-          )})\n`
+          )
+        })\n`
         : "") +
       (prop.joiValidation
         ? `${indent(indent_level)}.setValidationFormat(${prop.joiValidation})\n`
         : "") +
       (prop.data?.docLink
-        ? `${indent(indent_level)}.setDocLink(${JSON.stringify(
+        ? `${indent(indent_level)}.setDocLink(${
+          JSON.stringify(
             prop.data.docLink,
-          )})\n`
+          )
+        })\n`
         : "") +
       (prop.data?.documentation
-        ? `${indent(indent_level)}.setDocumentation(${JSON.stringify(
+        ? `${indent(indent_level)}.setDocumentation(${
+          JSON.stringify(
             prop.data.documentation,
-          )})\n`
+          )
+        })\n`
         : "") +
       generateSuggestSourceString(prop, indent_level) +
       inner +
@@ -239,9 +256,9 @@ function generateWidgetString(
   if (options) {
     for (const option of options) {
       if (option.label === CREATE_ONLY_PROP_LABEL) continue;
-      widgetStr += `\n${indent(indentLevel + 1)}.addOption("${
-        option.label
-      }", "${option.value}")`;
+      widgetStr += `\n${
+        indent(indentLevel + 1)
+      }.addOption("${option.label}", "${option.value}")`;
     }
   }
 

--- a/bin/clover/src/pipelines/aws/pipeline-steps/generateDefaultLeafFuncs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/generateDefaultLeafFuncs.ts
@@ -2,8 +2,8 @@ import _ from "lodash";
 import {
   createDefaultCodeGenFuncs,
   createLeafFuncSpec,
-} from "../spec/funcs.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+} from "../../../spec/funcs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 
 export function generateDefaultLeafFuncs(
   specs: ExpandedPkgSpec[],

--- a/bin/clover/src/pipelines/aws/pipeline-steps/generateIntrinsicFuncs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/generateIntrinsicFuncs.ts
@@ -1,6 +1,6 @@
 import _ from "npm:lodash";
-import { createSiFuncs } from "../spec/siFuncs.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { createSiFuncs } from "../../../spec/siFuncs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 
 export function generateIntrinsicFuncs(
   specs: ExpandedPkgSpec[],

--- a/bin/clover/src/pipelines/aws/pipeline-steps/generateQualificationFuncs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/generateQualificationFuncs.ts
@@ -2,8 +2,8 @@ import _ from "lodash";
 import {
   createDefaultQualificationFuncs,
   createLeafFuncSpec,
-} from "../spec/funcs.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+} from "../../../spec/funcs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 
 export function generateDefaultQualificationFuncs(
   specs: ExpandedPkgSpec[],

--- a/bin/clover/src/pipelines/aws/pipeline-steps/generateSubAssets.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/generateSubAssets.ts
@@ -4,10 +4,13 @@ import {
   createDefaultProp,
   ExpandedPropSpec,
   generatePropHash,
-} from "../spec/props.ts";
+} from "../../../spec/props.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
-import _logger from "../logger.ts";
-import { ExpandedPkgSpec, ExpandedSchemaVariantSpec } from "../spec/pkgs.ts";
+import _logger from "../../../logger.ts";
+import {
+  ExpandedPkgSpec,
+  ExpandedSchemaVariantSpec,
+} from "../../../spec/pkgs.ts";
 
 const logger = _logger.ns("subAssets").seal();
 
@@ -110,10 +113,12 @@ export function generateSubAssets(
   }
 
   // Select best name and category for each subAsset
-  for (const { spec, names } of _.values(newSpecsByHash) as {
-    spec: ExpandedPkgSpec;
-    names: string[];
-  }[]) {
+  for (
+    const { spec, names } of _.values(newSpecsByHash) as {
+      spec: ExpandedPkgSpec;
+      names: string[];
+    }[]
+  ) {
     let finalObjName: string | null | undefined = undefined;
     let finalAwsCategory: string | null | undefined = undefined;
     let finalParent: string | null | undefined = undefined;

--- a/bin/clover/src/pipelines/aws/pipeline-steps/genericAwsProperties.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/genericAwsProperties.ts
@@ -1,9 +1,9 @@
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 import {
   addPropSuggestSource,
   ExpandedPropSpecFor,
   findPropByName,
-} from "../spec/props.ts";
+} from "../../../spec/props.ts";
 
 // We want to ensure that the first suggestion for any region
 // prop in the generated assets have a suggestion of a Region schema

--- a/bin/clover/src/pipelines/aws/pipeline-steps/pruneCfAssets.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/pruneCfAssets.ts
@@ -1,12 +1,12 @@
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import _logger from "../logger.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import _logger from "../../../logger.ts";
 import {
   CODE_GENERATION_FUNC_SPECS,
   createFunc,
   strippedBase64,
-} from "../spec/funcs.ts";
+} from "../../../spec/funcs.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
-import { FuncArgumentSpec } from "../bindings/FuncArgumentSpec.ts";
+import { FuncArgumentSpec } from "../../../bindings/FuncArgumentSpec.ts";
 
 const logger = _logger.ns("pruneCfAssets").seal();
 
@@ -26,7 +26,7 @@ export function pruneCfAssets(specs: ExpandedPkgSpec[]): ExpandedPkgSpec[] {
     variant.leafFunctions = variant.leafFunctions.filter(
       (func) =>
         func.funcUniqueId ===
-        CODE_GENERATION_FUNC_SPECS.awsCloudFormationLint.id,
+          CODE_GENERATION_FUNC_SPECS.awsCloudFormationLint.id,
     );
 
     const attrFunc = createAttributeFunc();

--- a/bin/clover/src/pipelines/aws/pipeline-steps/removeBadDocLinks.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/removeBadDocLinks.ts
@@ -1,6 +1,6 @@
-import _logger from "../logger.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import { bfsPropTree } from "../spec/props.ts";
+import _logger from "../../../logger.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import { bfsPropTree } from "../../../spec/props.ts";
 import { existsSync } from "node:fs";
 
 const logger = _logger.ns("siSpecs").seal();

--- a/bin/clover/src/pipelines/aws/pipeline-steps/removeUnneededAssets.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/removeUnneededAssets.ts
@@ -1,6 +1,6 @@
-import _logger from "../logger.ts";
+import _logger from "../../../logger.ts";
 import _ from "npm:lodash";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 const IGNORED_CATEGORIES = [
   "AWS::IAM::",
   "AWS::QuickSight::",

--- a/bin/clover/src/pipelines/aws/pipeline-steps/reorderProps.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/reorderProps.ts
@@ -1,6 +1,6 @@
-import _logger from "../logger.ts";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
-import { ExpandedPropSpec } from "../spec/props.ts";
+import _logger from "../../../logger.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import { ExpandedPropSpec } from "../../../spec/props.ts";
 
 export function reorderProps(specs: ExpandedPkgSpec[]): ExpandedPkgSpec[] {
   for (const { schemas: [{ variants: [variant] }] } of specs) {

--- a/bin/clover/src/pipelines/aws/pipeline-steps/reportDeprecatedAssets.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/reportDeprecatedAssets.ts
@@ -1,6 +1,6 @@
-import _logger from "../logger.ts";
+import _logger from "../../../logger.ts";
 import _ from "npm:lodash";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 const logger = _logger.ns("reportDeprecated").seal();
 
 export function reportDeprecatedAssets(

--- a/bin/clover/src/pipelines/aws/pipeline-steps/specPipeline.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/specPipeline.ts
@@ -1,15 +1,15 @@
-import { CfProperty, CfSchema } from "./cfDb.ts";
+import { CfProperty, CfSchema } from "../../../cfDb.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import {
   createDefaultPropFromCf,
   createDocLink,
   OnlyProperties,
-} from "./spec/props.ts";
+} from "../../../spec/props.ts";
 import {
   ExpandedPkgSpec,
   ExpandedSchemaSpec,
   ExpandedSchemaVariantSpec,
-} from "./spec/pkgs.ts";
+} from "../../../spec/pkgs.ts";
 
 export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
   const [metaCategory, category, name] = cfSchema.typeName.split("::");

--- a/bin/clover/src/pipelines/aws/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
+++ b/bin/clover/src/pipelines/aws/pipeline-steps/updateSchemaIdsForExistingSpecs.ts
@@ -1,6 +1,6 @@
-import _logger from "../logger.ts";
+import _logger from "../../../logger.ts";
 import _ from "npm:lodash";
-import { ExpandedPkgSpec } from "../spec/pkgs.ts";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 const logger = _logger.ns("updateExisting").seal();
 
 export function updateSchemaIdsForExistingSpecs(

--- a/bin/clover/src/pipelines/aws/pipeline.ts
+++ b/bin/clover/src/pipelines/aws/pipeline.ts
@@ -1,0 +1,89 @@
+import { assetSpecificOverrides } from "./pipeline-steps/assetSpecificOverrides.ts";
+import { loadCfDatabase } from "../../cfDb.ts";
+import { pkgSpecFromCf } from "./pipeline-steps/specPipeline.ts";
+import { generateAssetFuncs } from "./pipeline-steps/generateAssetFuncs.ts";
+import { attachDefaultActionFuncs } from "./pipeline-steps/attachDefaultActionFuncs.ts";
+import { generateDefaultLeafFuncs } from "./pipeline-steps/generateDefaultLeafFuncs.ts";
+import { generateDefaultQualificationFuncs } from "./pipeline-steps/generateQualificationFuncs.ts";
+import { attachDefaultManagementFuncs } from "./pipeline-steps/attachDefaultManagementFuncs.ts";
+import { addDefaultPropsAndSockets } from "./pipeline-steps/addDefaultPropsAndSockets.ts";
+import { generateSubAssets } from "./pipeline-steps/generateSubAssets.ts";
+import { generateIntrinsicFuncs } from "./pipeline-steps/generateIntrinsicFuncs.ts";
+import { updateSchemaIdsForExistingSpecs } from "./pipeline-steps/updateSchemaIdsForExistingSpecs.ts";
+import { getExistingSpecs } from "../../specUpdates.ts";
+
+import _logger from "../../logger.ts";
+import { ExpandedPkgSpec } from "../../spec/pkgs.ts";
+import { loadInferred } from "../../spec/inferred.ts";
+import { addInferredEnums } from "./pipeline-steps/addInferredEnums.ts";
+import { pruneCfAssets } from "./pipeline-steps/pruneCfAssets.ts";
+import { removeUnneededAssets } from "./pipeline-steps/removeUnneededAssets.ts";
+import { removeBadDocLinks } from "./pipeline-steps/removeBadDocLinks.ts";
+import { reorderProps } from "./pipeline-steps/reorderProps.ts";
+import { createSuggestionsForPrimaryIdentifiers } from "./pipeline-steps/createSuggestionsAcrossAssets.ts";
+import {
+  createCredentialSuggestion,
+  createRegionSuggestion,
+} from "./pipeline-steps/genericAwsProperties.ts";
+
+export async function generateAwsSpecs(options: {
+  forceUpdateExistingPackages?: boolean;
+  moduleIndexUrl: string;
+  docLinkCache: string;
+  inferred: string;
+  services?: string[];
+}): Promise<ExpandedPkgSpec[]> {
+  const db = await loadCfDatabase(options);
+  const existing_specs = await getExistingSpecs(options);
+  const inferred = await loadInferred(options.inferred);
+
+  const cfSchemas = Object.values(db);
+
+  let specs = [] as ExpandedPkgSpec[];
+
+  for (const cfSchema of cfSchemas) {
+    try {
+      const pkg = pkgSpecFromCf(cfSchema);
+
+      specs.push(pkg);
+    } catch (e) {
+      console.log(`Error Building: ${cfSchema.typeName}: ${e}`);
+    }
+  }
+
+  // EXECUTE PIPELINE STEPS
+
+  specs = await removeBadDocLinks(specs, options.docLinkCache);
+  specs = addInferredEnums(specs, inferred);
+  specs = addDefaultPropsAndSockets(specs);
+  specs = attachDefaultActionFuncs(specs);
+  specs = generateDefaultLeafFuncs(specs);
+  specs = attachDefaultManagementFuncs(specs);
+  specs = generateDefaultQualificationFuncs(specs);
+
+  // subAssets should not have any of the above, but need an asset func and
+  // intrinsics
+  specs = generateSubAssets(specs);
+  specs = generateIntrinsicFuncs(specs);
+  specs = removeUnneededAssets(specs);
+
+  // this step will eventually replace all the socket stuff. Must come before
+  // overrides so it can be... overriden
+  specs = createSuggestionsForPrimaryIdentifiers(specs);
+  specs = createRegionSuggestion(specs);
+  specs = createCredentialSuggestion(specs);
+
+  // Our overrides right now only run after the prop tree and the sockets are generated
+  specs = assetSpecificOverrides(specs);
+
+  // prune assets that cannot be created by cloud control and must be create
+  // using cf
+  specs = pruneCfAssets(specs);
+
+  // These need everything to be complete
+  specs = reorderProps(specs);
+  specs = generateAssetFuncs(specs);
+  specs = updateSchemaIdsForExistingSpecs(existing_specs, specs);
+
+  return specs;
+}

--- a/deno.lock
+++ b/deno.lock
@@ -50,6 +50,7 @@
     "npm:adze@^2.2.1": "2.2.5",
     "npm:argparse@2.0.1": "2.0.1",
     "npm:axios@*": "1.11.0",
+    "npm:axios@^1.12.0": "1.12.2",
     "npm:axios@^1.6.1": "1.11.0",
     "npm:data-uri-to-buffer@4.0.1": "4.0.1",
     "npm:dotenv@^16.3.1": "16.6.1",
@@ -276,15 +277,13 @@
         "@humanwhocodes/object-schema",
         "debug",
         "minimatch"
-      ],
-      "deprecated": true
+      ]
     },
     "@humanwhocodes/module-importer@1.0.1": {
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
     },
     "@humanwhocodes/object-schema@2.0.3": {
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": true
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
     },
     "@jsdevtools/ono@7.1.3": {
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
@@ -389,8 +388,7 @@
       ]
     },
     "acorn@8.15.0": {
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "bin": true
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "adze@2.2.1": {
       "integrity": "sha512-zTQPl28v/WNEZo4Pmb3HThpYLLTeMuHX3fvC8Aw1CIAHT7nZR5JiqbmE/mB+3qemX4n0ygj+3KfcFpKxLINa/A==",
@@ -439,6 +437,14 @@
     },
     "axios@1.11.0": {
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dependencies": [
+        "follow-redirects",
+        "form-data",
+        "proxy-from-env"
+      ]
+    },
+    "axios@1.12.2": {
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dependencies": [
         "follow-redirects",
         "form-data",
@@ -672,9 +678,7 @@
         "optionator",
         "strip-ansi",
         "text-table"
-      ],
-      "deprecated": true,
-      "bin": true
+      ]
     },
     "espree@9.6.1_acorn@8.15.0": {
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
@@ -893,8 +897,7 @@
         "minimatch",
         "once",
         "path-is-absolute"
-      ],
-      "deprecated": true
+      ]
     },
     "globals@13.24.0": {
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
@@ -966,8 +969,7 @@
       "dependencies": [
         "once",
         "wrappy"
-      ],
-      "deprecated": true
+      ]
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
@@ -1007,8 +1009,7 @@
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": [
         "argparse"
-      ],
-      "bin": true
+      ]
     },
     "json-buffer@3.0.1": {
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
@@ -1061,8 +1062,7 @@
       "dependencies": [
         "@modelcontextprotocol/sdk",
         "zod"
-      ],
-      "bin": true
+      ]
     },
     "media-typer@1.1.0": {
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
@@ -1104,17 +1104,13 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
     },
     "node-domexception@1.0.0": {
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": true
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch@2.7.0_encoding@0.1.13": {
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": [
         "encoding",
         "whatwg-url"
-      ],
-      "optionalPeers": [
-        "encoding"
       ]
     },
     "object-assign@4.1.1": {
@@ -1138,20 +1134,15 @@
     "openai@4.104.0_zod@3.25.76_encoding@0.1.13": {
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "dependencies": [
-        "@types/node@18.19.120",
         "@types/node-fetch",
+        "@types/node@18.19.120",
         "abort-controller",
         "agentkeepalive",
         "form-data-encoder",
         "formdata-node",
         "node-fetch",
         "zod"
-      ],
-      "optionalPeers": [
-        "ws@^8.18.0",
-        "zod"
-      ],
-      "bin": true
+      ]
     },
     "optionator@0.9.4": {
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
@@ -1209,7 +1200,7 @@
     "posthog-node@4.18.0": {
       "integrity": "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==",
       "dependencies": [
-        "axios"
+        "axios@1.11.0"
       ]
     },
     "prelude-ls@1.2.1": {
@@ -1259,9 +1250,7 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dependencies": [
         "glob"
-      ],
-      "deprecated": true,
-      "bin": true
+      ]
     },
     "router@2.2.0": {
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
@@ -1409,12 +1398,10 @@
       ]
     },
     "typescript@4.9.5": {
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": true
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "ulid@3.0.1": {
-      "integrity": "sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q==",
-      "bin": true
+      "integrity": "sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q=="
     },
     "undici-types@5.26.5": {
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
@@ -1454,8 +1441,7 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
         "isexe"
-      ],
-      "bin": true
+      ]
     },
     "word-wrap@1.2.5": {
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
@@ -1698,7 +1684,7 @@
         ],
         "packageJson": {
           "dependencies": [
-            "npm:axios@^1.6.1",
+            "npm:axios@^1.12.0",
             "npm:dotenv@^16.3.1",
             "npm:jwt-decode@4",
             "npm:mcp-jest@1"


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Shifts around the existing AWS pipeline to be callable as a provider from the cli like 
```
clover generate-specs --provider aws
```

#### Out of Scope:

This makes no attempt to genericize the clover pipeline bits, simply moves the aws pipeline around so we can add more pipelines and make things more generic later.

## How was it tested?

- [X] Manual test: Runs locally
- [ ] Manual test: Will run diffs on this PR to ensure no changes

## In short: [:link:](https://giphy.com/)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlem1saXE1OXF1NmpseTlpODhpNnhsbzAwNjZsbHRiM25taHJjMDUzOSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/OOn7N4CfPuUTmNqFD7/giphy.gif"/>