### PR TITLE
fix(auth-api): Fix Docker container startup after TSX/TypeScript 5.x upgrade

### DIFF
--- a/bin/auth-api/package.json
+++ b/bin/auth-api/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx watch src/main.ts",
     "dev:run": "tsx watch src/main.ts",
     "build": "tsc --incremental false -p tsconfig-build.json",
-    "boot": "node --experimental-specifier-resolution=node ./dist/main.js",
+    "boot": "tsx src/main.ts",
     "boot-ts": "tsx src/main.ts",
     "lint": "eslint src test --ext .ts,.cjs",
     "lint:strict": "pnpm run lint --max-warnings=0",

--- a/deno.lock
+++ b/deno.lock
@@ -62,6 +62,7 @@
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:json-schema-typed@^8.0.1": "8.0.1",
     "npm:jwt-decode@4": "4.0.0",
+    "npm:lago-javascript-client@*": "1.32.0",
     "npm:lodash-es@4.17.21": "4.17.21",
     "npm:lodash-es@^4.17.21": "4.17.21",
     "npm:lodash@*": "4.17.21",
@@ -276,15 +277,13 @@
         "@humanwhocodes/object-schema",
         "debug",
         "minimatch"
-      ],
-      "deprecated": true
+      ]
     },
     "@humanwhocodes/module-importer@1.0.1": {
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
     },
     "@humanwhocodes/object-schema@2.0.3": {
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": true
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
     },
     "@jsdevtools/ono@7.1.3": {
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
@@ -389,8 +388,7 @@
       ]
     },
     "acorn@8.15.0": {
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "bin": true
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "adze@2.2.1": {
       "integrity": "sha512-zTQPl28v/WNEZo4Pmb3HThpYLLTeMuHX3fvC8Aw1CIAHT7nZR5JiqbmE/mB+3qemX4n0ygj+3KfcFpKxLINa/A==",
@@ -672,9 +670,7 @@
         "optionator",
         "strip-ansi",
         "text-table"
-      ],
-      "deprecated": true,
-      "bin": true
+      ]
     },
     "espree@9.6.1_acorn@8.15.0": {
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
@@ -893,8 +889,7 @@
         "minimatch",
         "once",
         "path-is-absolute"
-      ],
-      "deprecated": true
+      ]
     },
     "globals@13.24.0": {
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
@@ -966,8 +961,7 @@
       "dependencies": [
         "once",
         "wrappy"
-      ],
-      "deprecated": true
+      ]
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
@@ -1007,8 +1001,7 @@
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": [
         "argparse"
-      ],
-      "bin": true
+      ]
     },
     "json-buffer@3.0.1": {
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
@@ -1030,6 +1023,9 @@
       "dependencies": [
         "json-buffer"
       ]
+    },
+    "lago-javascript-client@1.32.0": {
+      "integrity": "sha512-aGlKaQgBvI1R9NdeO3OvDppXkNDSeC9Ob2uzvOQQpC/kibSJNlKoXuQm9p3V9c8Fl4fZDThX6DhpA4eCFrrGwQ=="
     },
     "levn@0.4.1": {
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
@@ -1061,8 +1057,7 @@
       "dependencies": [
         "@modelcontextprotocol/sdk",
         "zod"
-      ],
-      "bin": true
+      ]
     },
     "media-typer@1.1.0": {
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
@@ -1104,17 +1099,13 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
     },
     "node-domexception@1.0.0": {
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": true
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch@2.7.0_encoding@0.1.13": {
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": [
         "encoding",
         "whatwg-url"
-      ],
-      "optionalPeers": [
-        "encoding"
       ]
     },
     "object-assign@4.1.1": {
@@ -1138,20 +1129,15 @@
     "openai@4.104.0_zod@3.25.76_encoding@0.1.13": {
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "dependencies": [
-        "@types/node@18.19.120",
         "@types/node-fetch",
+        "@types/node@18.19.120",
         "abort-controller",
         "agentkeepalive",
         "form-data-encoder",
         "formdata-node",
         "node-fetch",
         "zod"
-      ],
-      "optionalPeers": [
-        "ws@^8.18.0",
-        "zod"
-      ],
-      "bin": true
+      ]
     },
     "optionator@0.9.4": {
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
@@ -1259,9 +1245,7 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dependencies": [
         "glob"
-      ],
-      "deprecated": true,
-      "bin": true
+      ]
     },
     "router@2.2.0": {
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
@@ -1409,12 +1393,10 @@
       ]
     },
     "typescript@4.9.5": {
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": true
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "ulid@3.0.1": {
-      "integrity": "sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q==",
-      "bin": true
+      "integrity": "sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q=="
     },
     "undici-types@5.26.5": {
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
@@ -1454,8 +1436,7 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
         "isexe"
-      ],
-      "bin": true
+      ]
     },
     "word-wrap@1.2.5": {
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
@@ -1698,7 +1679,7 @@
         ],
         "packageJson": {
           "dependencies": [
-            "npm:axios@^1.6.1",
+            "npm:axios@^1.12.0",
             "npm:dotenv@^16.3.1",
             "npm:jwt-decode@4",
             "npm:mcp-jest@1"

--- a/lib/tsconfig/tsconfig.node.json
+++ b/lib/tsconfig/tsconfig.node.json
@@ -8,6 +8,8 @@
     ],
     "strict": true,
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
The TSX/TypeScript 5.x upgrade in PR #7318 broke the production Docker container startup with this error:
 ` Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/dist/init-env' imported from /app/dist/main.js`
 
 The upgrade introduced ES module resolution issues where:
  1. The boot script pointed to `./dist/main.js` but TypeScript compiled to `./dist/src/main.js`
  2. ES modules require explicit file extensions (.js) in imports, but the compiled output used extensionless imports
  3. Workspace package resolution failed in the compiled JavaScript

This fixes that issue to make it use the moe common pattern