### PR TITLE
feat: add a `nats-stream-copy-data` binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,6 +5453,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nats-stream-copy-data"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "futures",
+ "si-data-nats",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nats-subscriber"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "bin/innitctl",
   "bin/luminork",
   "bin/module-index",
+  "bin/nats-stream-copy-data",
   "bin/openapi-extractor",
   "bin/pinga",
   "bin/rebaser",

--- a/bin/nats-stream-copy-data/BUCK
+++ b/bin/nats-stream-copy-data/BUCK
@@ -1,0 +1,18 @@
+load(
+    "@prelude-si//:macros.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "nats-stream-copy-data",
+    deps = [
+        "//lib/si-data-nats:si-data-nats",
+        "//third-party/rust:clap",
+        "//third-party/rust:futures",
+        "//third-party/rust:tokio",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+    ],
+    srcs = glob(["src/**/*.rs"]),
+    env = {"CARGO_BIN_NAME": "nats-stream-copy-data"},
+)

--- a/bin/nats-stream-copy-data/Cargo.toml
+++ b/bin/nats-stream-copy-data/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "nats-stream-copy-data"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+clap = { workspace = true }
+futures = { workspace = true }
+si-data-nats = { path = "../../lib/si-data-nats" }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/bin/nats-stream-copy-data/src/args.rs
+++ b/bin/nats-stream-copy-data/src/args.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use si_data_nats::Subject;
+
+pub const NAME: &str = "nats-stream-copy-data";
+
+/// Parse, validate, and return the CLI arguments as a typed struct.
+pub(crate) fn parse() -> Args {
+    Args::parse()
+}
+
+/// Copy messages from one NATS stream to another
+#[derive(Parser, Debug)]
+#[command(name = NAME, max_term_width = 100)]
+pub(crate) struct Args {
+    /// Source Stream to copy messages from
+    pub(crate) source_stream: String,
+
+    /// Destination Stream for copied messages
+    pub(crate) destination_stream: String,
+
+    /// Subject filter from source Stream
+    #[arg(short, long)]
+    pub(crate) subject: Vec<Subject>,
+
+    /// NATS connection URL for source and destination Streams [example: demo.nats.io]
+    #[arg(
+        long,
+        default_value = Self::DEFAULT_NATS_URL,
+        env = "NATS_URL",
+        hide_env_values = true,
+        conflicts_with_all = [
+            "source_nats_url",
+            "destination_nats_url",
+        ]
+    )]
+    pub(crate) nats_url: Option<String>,
+
+    /// NATS credentials file for source and destination Streams
+    #[arg(long, env = "NATS_CREDS", hide_env_values = true)]
+    pub(crate) nats_creds: Option<PathBuf>,
+
+    /// NATS connection URL for source Stream [example: demo.nats.io]
+    #[arg(long, requires = "destination_nats_url", conflicts_with = "nats_url")]
+    pub(crate) source_nats_url: Option<String>,
+
+    /// NATS credentials file for source Stream
+    #[arg(long)]
+    pub(crate) source_nats_creds: Option<PathBuf>,
+
+    /// NATS connection URL for destination Streams [example: demo.nats.io]
+    #[arg(long, requires = "source_nats_url", conflicts_with = "nats_url")]
+    pub(crate) destination_nats_url: Option<String>,
+
+    /// NATS credentials file for destination Stream
+    #[arg(long)]
+    pub(crate) destination_nats_creds: Option<PathBuf>,
+}
+
+impl Args {
+    pub(crate) const DEFAULT_NATS_URL: &str = "nats://localhost:4222";
+
+    pub(crate) fn source_nats_url(&self) -> String {
+        match self.source_nats_url.as_ref() {
+            Some(url) => url.to_string(),
+            None => self
+                .nats_url
+                .as_ref()
+                .map(|url| url.to_string())
+                .unwrap_or_else(|| Self::DEFAULT_NATS_URL.to_string()),
+        }
+    }
+
+    pub(crate) fn source_nats_creds(&self) -> Option<String> {
+        match self.source_nats_creds.as_deref() {
+            Some(path) => Some(path),
+            None => self.nats_creds.as_deref(),
+        }
+        .map(|path| path.to_string_lossy().to_string())
+    }
+
+    pub(crate) fn destination_nats_url(&self) -> String {
+        match self.destination_nats_url.as_ref() {
+            Some(url) => url.to_string(),
+            None => self
+                .nats_url
+                .as_ref()
+                .map(|url| url.to_string())
+                .unwrap_or_else(|| Self::DEFAULT_NATS_URL.to_string()),
+        }
+    }
+
+    pub(crate) fn destination_nats_creds(&self) -> Option<String> {
+        match self.destination_nats_creds.as_deref() {
+            Some(path) => Some(path),
+            None => self.nats_creds.as_deref(),
+        }
+        .map(|path| path.to_string_lossy().to_string())
+    }
+}

--- a/bin/nats-stream-copy-data/src/main.rs
+++ b/bin/nats-stream-copy-data/src/main.rs
@@ -1,0 +1,132 @@
+use std::error;
+
+use futures::TryStreamExt;
+use si_data_nats::{
+    NatsClient,
+    NatsConfig,
+    Subject,
+    async_nats::jetstream::consumer::push,
+    jetstream,
+};
+use tracing::{
+    Level,
+    debug,
+    field,
+    info,
+    span,
+    trace,
+};
+use tracing_subscriber::{
+    EnvFilter,
+    Registry,
+    fmt::{
+        self,
+        format::FmtSpan,
+    },
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
+
+mod args;
+
+const BIN_NAME: &str = env!("CARGO_BIN_NAME");
+
+const TRACING_LOG_ENV_VAR: &str = "SI_LOG";
+const DEFAULT_TRACING_DIRECTIVES: &str = "nats_stream_copy_data=debug,si_data_nats=warn,info";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error + Send + Sync>> {
+    Registry::default()
+        .with(
+            EnvFilter::try_from_env(TRACING_LOG_ENV_VAR)
+                .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACING_DIRECTIVES)),
+        )
+        .with(
+            fmt::layer()
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_span_events(FmtSpan::CLOSE)
+                .pretty(),
+        )
+        .try_init()?;
+
+    let args = args::parse();
+    debug!(arguments =?args, "parsed cli arguments");
+
+    let source_nats_config = NatsConfig {
+        connection_name: Some(format!("{BIN_NAME}-source")),
+        url: args.source_nats_url(),
+        creds_file: args.source_nats_creds(),
+        ..Default::default()
+    };
+
+    let destination_nats_config = NatsConfig {
+        connection_name: Some(format!("{BIN_NAME}-destination")),
+        url: args.destination_nats_url(),
+        creds_file: args.destination_nats_creds(),
+        ..Default::default()
+    };
+
+    stream_copy_data(
+        &source_nats_config,
+        args.source_stream.as_str(),
+        args.subject,
+        &destination_nats_config,
+        args.destination_stream.as_str(),
+    )
+    .await
+}
+
+async fn stream_copy_data(
+    source_config: &NatsConfig,
+    source_stream_name: &str,
+    filter_subjects: Vec<Subject>,
+    destination_config: &NatsConfig,
+    destination_stream_name: &str,
+) -> Result<(), Box<dyn error::Error + Send + Sync>> {
+    let source_client = NatsClient::new(source_config).await?;
+    let source_ctx = jetstream::new(source_client.clone());
+    let source_stream = source_ctx.get_stream(source_stream_name).await?;
+
+    let mut messages = source_stream
+        .create_consumer(push::OrderedConfig {
+            deliver_subject: source_client.new_inbox(),
+            filter_subjects: filter_subjects.into_iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        })
+        .await?
+        .messages()
+        .await?;
+
+    let destination_client = NatsClient::new(destination_config).await?;
+    let destination_ctx = jetstream::new(destination_client);
+    let _destination_stream = destination_ctx.get_stream(destination_stream_name).await?;
+
+    let mut num_copied = 0;
+
+    let span = span!(Level::INFO, "copy_data", num_copied = field::Empty);
+    let _enter = span.enter();
+
+    while let Some(message) = messages.try_next().await? {
+        let info = message.info()?;
+        let pending = info.pending;
+        trace!(pending = pending);
+
+        let (message, _) = message.split();
+
+        destination_ctx
+            .publish(message.subject, message.payload)
+            .await?;
+
+        num_copied += 1;
+
+        if pending == 0 {
+            info!("no more pending messages; copy complete");
+            break;
+        }
+    }
+
+    span.record("num_copied", num_copied);
+
+    Ok(())
+}


### PR DESCRIPTION
This program copies all NATS messages from a source Stream to a destination Stream and will be used for some data migration tasks.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcm00NGtpYnoybGlwNTU4djA1emN0MGtqMWdscHkybncxenVybHlpayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/oCCLHVNt8YO64/giphy.gif"/>