### PR TITLE
Lobby exit should not be within a queue

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -3859,15 +3859,17 @@ const dbInterface: TabDBInterface = {
             } else if (data.kind === MessageKind.WORKSPACE_INDEXUPDATE) {
               // Index has been updated - signal lobby exit
               debug("📨 INDEX UPDATE", data.meta.changeSetId);
+
+              // this part doesn't go into the queue, tell the app an index is ready right away
+              // it will be re-requested
+              if (lobbyExitFn) {
+                lobbyExitFn(data.meta.workspaceId, data.meta.changeSetId);
+              }
               processPatchQueue.add(async () => {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 await sqlite!.transaction(async (db) =>
                   handleIndexMvPatch(db, data),
                 );
-
-                if (lobbyExitFn) {
-                  lobbyExitFn(data.meta.workspaceId, data.meta.changeSetId);
-                }
               });
             } else if (data.kind === MessageKind.DEPLOYMENT_INDEXUPDATE) {
               // NOOP for now, DEPLOYMENT_PATCH does the work


### PR DESCRIPTION
## How does this PR change the system?

Immediately fire the callback for "exit the lobby". We don't need to patch the index with the data right away, the system will re-request the `/index` endpoint.

#### Out of Scope:

Note: This change I am fixing here never made it to users. It was merged today, but not deployed.

## How was it tested?

My local workspace with two change sets was stuck in the lobby because the 2nd change set didn't fire "exit lobby" because the queue is paused b/c we're cold starting.

In order to get an empty `frigg` I used this command `nats stream purge KV_FRIGG` so all change sets needed to rebuild when I hit my workspace.