### PR TITLE
feat: introducing a basic schema creator in the si mcp server

### DIFF
--- a/bin/si-mcp-server/src/server.ts
+++ b/bin/si-mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import { changeSetUpdateTool } from "./tools/changeSetUpdateStatus.ts";
 import { schemaFindTool } from "./tools/schemaFind.ts";
 import { schemaAttributesListTool } from "./tools/schemaAttributesList.ts";
 import { schemaAttributesDocumentationTool } from "./tools/schemaAttributesDocumentation.ts";
+// import { schemaCreateTool } from "./tools/schemaCreate.ts"; uncomment for local development
 import { actionListTool } from "./tools/actionList.ts";
 import { actionUpdateTool } from "./tools/actionUpdateStatus.ts";
 import { funcRunGetTool } from "./tools/funcRunGet.ts";
@@ -43,6 +44,7 @@ export function createServer(): McpServer {
   schemaFindTool(server);
   schemaAttributesListTool(server);
   schemaAttributesDocumentationTool(server);
+  // schemaCreateTool(server); uncomment for local development
   actionListTool(server);
   actionUpdateTool(server);
   funcRunGetTool(server);

--- a/bin/si-mcp-server/src/tools/schemaCreate.ts
+++ b/bin/si-mcp-server/src/tools/schemaCreate.ts
@@ -1,0 +1,79 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { SchemasApi } from "@systeminit/api-client";
+import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
+import {
+  errorResponse,
+  generateDescription,
+  successResponse,
+  withAnalytics,
+} from "./commonBehavior.ts";
+
+const name = "schema-create";
+const title = "Create a new Schema";
+const description =
+  `<description></description><usage></usage>`;
+
+const SchemaCreateInputSchemaRaw = {
+  changeSetId: z.string().describe(
+    "The change set to create a schema in; schemas cannot be created on HEAD",
+  ),
+  name: z.string().describe("The name of the schema").min(1),
+};
+
+const SchemaCreateOutputSchemaRaw = {
+  status: z.enum(["success", "failure"]),
+  errorMessage: z.string().optional().describe(
+    "If the status is failure, the error message will contain information about what went wrong",
+  ),
+  data: z.object({}),
+};
+
+const SchemaCreateOutputSchema = z.object(
+  SchemaCreateOutputSchemaRaw,
+);
+
+type SchemaCreateResult = z.infer<
+  typeof SchemaCreateOutputSchema
+>["data"];
+
+export function schemaCreateTool(server: McpServer) {
+  server.registerTool(
+    name,
+    {
+      title,
+      description: generateDescription(
+        description,
+        "schemaCreate",
+        SchemaCreateOutputSchema,
+      ),
+      inputSchema: SchemaCreateInputSchemaRaw,
+      outputSchema: SchemaCreateOutputSchemaRaw,
+    },
+    async (
+      { changeSetId, name }: { changeSetId: string; name: string },
+    ): Promise<CallToolResult> => {
+      return await withAnalytics(name, async () => {
+        const siSchemasApi = new SchemasApi(apiConfig);
+
+        try {
+          const response = await siSchemasApi.createSchema({
+            workspaceId: WORKSPACE_ID,
+            changeSetId: changeSetId,
+            createSchemaV1Request: {
+              name,
+              code: `function main() {
+    const asset = new AssetBuilder();
+    return asset.build();
+}`
+            },
+          });
+          return successResponse({});
+        } catch (error) {
+          return errorResponse(error);
+        }
+      });
+    },
+  );
+}


### PR DESCRIPTION
Creates a basic schema creator tool in the mcp server to be iterated on. Will not be made available externally YET.

## How does this PR change the system?

Introduces a very basic schema creator tool - to be iterated on. This will not be available externally yet and is commented so in server.ts

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: Claude created a new schema with the most basic call and code within

## In short: [:link:](https://giphy.com/)

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmM2YmVjY3pxc3UxcGgycG12Y3lpNDl3bzBlNTcyN3A5Y2RtMjk1ZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/2Kw4Yqb91tdSQ7srBN/giphy.gif)
