### PR TITLE
App & Web Worker are querying & firing requests way too much

### DIFF
--- a/app/web/src/workers/webworker.test.ts
+++ b/app/web/src/workers/webworker.test.ts
@@ -5371,6 +5371,15 @@ const fullDiagnosticTest = async (db: Comlink.Remote<TabDBInterface>) => {
     `atom checksum not updated: ${atomChecksum?.toString()} != ${indexChecksum}`,
   );
 
+  // get the index mv, assures that the atom and MTM are in place!
+  const indexListAtom = (await db.get(
+    workspaceId,
+    changeSetId,
+    EntityKind.MvIndex,
+    workspaceId,
+  )) as object | -1;
+  assert(indexListAtom !== -1, `MvIndex Atom doesn't exist when it should`);
+
   log("index update patched");
 };
 


### PR DESCRIPTION
## How does this PR change the system?

1. quieting down the bust logging
2. but the real fix, i made a dedupe queue and didnt fill it ☹️ 
3. fix to wrongly deleting the MvIndex atom MTM

I'm _somewhat_ confident that the "my whole grid started going skeletons" problems is related to MvIndex deletion. Here is the theory:
1. the IndexMv patches
2. then its MTM gets deleted
3. on the next index patch
4. we try to patch, but cannot find the previous atom
5. so we run niflheim
6. which replaces all the MTMs in a giant sql statement
7. and calls to bust all the tanstack caches
8. which re-runs all the UI queries

On a large enough workspace, those queries will contend and run slowly enough, as well as pushing all the data across the thread interface, you'll see skeletons.

## How was it tested?

1. Seeing that on load only one getSchemaMembers query fires.
10. On a change set, duplicate a component, wait for patches to come through
11. Then delete that component, wait for patches to come through
12. You should not see any calls to `/index` or the log message "Cannot patch" regarding the MvIndex

Updated the web worker test case to catch this problem.

<img width="909" height="341" alt="image" src="https://github.com/user-attachments/assets/9c81afef-5849-4750-a3a6-d6f847ad6f49" />

<img width="330" height="270" alt="image" src="https://github.com/user-attachments/assets/9a302bcd-1b26-48c5-a26e-da3e09146881" />
