### PR TITLE
fix(sdf,luminork): harmonize create change set btw sdf & luminork

### DIFF
--- a/lib/luminork-server/src/service/v1/change_sets/mod.rs
+++ b/lib/luminork-server/src/service/v1/change_sets/mod.rs
@@ -36,6 +36,8 @@ pub enum ChangeSetError {
     ChangeSet(#[from] dal::ChangeSetError),
     #[error("change set apply error: {0}")]
     ChangeSetApply(#[from] dal::ChangeSetApplyError),
+    #[error("change set mvs error: {0}")]
+    ChangeSetMvs(#[from] sdf_core::change_set_mvs::ChangeSetMvsError),
     #[error("change set not found: {0}")]
     ChangeSetNotFound(ChangeSetId),
     #[error("component error: {0}")]

--- a/lib/sdf-server/src/service/v2/change_set/create.rs
+++ b/lib/sdf-server/src/service/v2/change_set/create.rs
@@ -38,7 +38,7 @@ pub async fn create_change_set(
 ) -> Result<impl IntoResponse> {
     let change_set_name = name.to_owned();
 
-    let change_set = ChangeSet::fork_head(ctx, change_set_name.clone()).await?;
+    let change_set = ChangeSet::fork_head(ctx, &change_set_name).await?;
     let change_set_id = change_set.id;
 
     tracker.track(
@@ -49,7 +49,7 @@ pub async fn create_change_set(
         }),
     );
 
-    ctx.write_audit_log(AuditLogKind::CreateChangeSet, change_set_name.to_string())
+    ctx.write_audit_log(AuditLogKind::CreateChangeSet, change_set_name.clone())
         .await?;
 
     WsEvent::change_set_created(ctx, change_set.id, change_set.workspace_snapshot_address)
@@ -59,6 +59,7 @@ pub async fn create_change_set(
 
     let change_set = change_set.into_frontend_type(ctx).await?;
     ctx.commit_no_rebase().await?;
+
     if create_index_for_new_change_set_and_watch(
         &frigg,
         &edda_client,


### PR DESCRIPTION
This change attempts to harmonize the code flows between SDF and Luminork's "create change set" handlers.

Importantly with this change:

- Luminork now waits the *same* 30 seconds for the Frigg index to be built and populated before return (same as SDF was doing)
- The timing of Luminork's `ctx.commit_no_rebase()` now happens *before* the call to Edda goes out. Prior to this change we published the Edda request before we commited the database change in Luminork meaning that Edda might process a message and not see the new change set in the `changeset_pointers` table (as Luminork may not have finished with its db txn commit).
- Luminork uses the workspace snapshot address from the `DalContext` when crafting the request to Edda. Prior to this change, the address comes back from the object from `ChangeSet::fork_head` which may or may not be the specific *new* change set snapshot address. I am less sure if this may have caused an issue, but now Luminork determines this value identically to SDF.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlODJwMHdwNm8wemxoaXRycngzZ24ybXJ5aDJ4MjdqdjZtNG81Mnc0NCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/kD5cIPhzpGIoVCKsTO/giphy.gif"/>