### PR TITLE
auth portal profile save button text should go back to save on email verify

### DIFF
--- a/app/auth-portal/src/pages/ProfilePage.vue
+++ b/app/auth-portal/src/pages/ProfilePage.vue
@@ -209,6 +209,7 @@ watch(storeUser, checkUserOnboarding, { immediate: true });
 watch([refreshAuth0ReqStatus, storeUser], () => {
   if (storeUser.value?.emailVerified) {
     failedEmailVerify.value = false;
+    saveButtonLabel.value = "Save";
   }
 });
 


### PR DESCRIPTION
This PR just fixes a small bug where the text on the Profile save button in the auth portal does not go back to the text "Save" once the user verifies their email.