### PR TITLE
change auth token placeholder to be less misleading

### DIFF
--- a/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
@@ -42,7 +42,7 @@
               inlineLabel
               label="Expiration"
               required
-              placeholder="48h, 1d, 1m, 1y, etc."
+              placeholder="60m, 48h, 3d, 1y, etc."
               type="time-string"
               :maxLength="99"
               @keydown.enter.prevent="onFormSubmit"


### PR DESCRIPTION
"1m" in the current placeholder implies that the token will be for 1 month, but it results in a 1 minute token.

This placeholder change makes it less misleading.

old placeholder -
<img width="303" height="77" alt="Screenshot 2025-09-26 at 1 36 14 PM" src="https://github.com/user-attachments/assets/089bc6ac-6f51-496c-baf1-28109bced149" />

new placeholder -
<img width="293" height="69" alt="Screenshot 2025-09-26 at 1 36 53 PM" src="https://github.com/user-attachments/assets/5a31d2b0-b2a6-47b3-b4bd-f64f52e07d71" />
