### PR TITLE
fix: Adjust si-mcp-server to use latest OpenAPI types

### DIFF
--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -11,7 +11,7 @@
     "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
     "@std/assert": "jsr:@std/assert@1",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.1.4",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.1.6",
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",

--- a/bin/si-mcp-server/src/data/actions.ts
+++ b/bin/si-mcp-server/src/data/actions.ts
@@ -2,12 +2,12 @@ import { z } from "zod";
 
 export const ActionSchemaRaw = {
   actionId: z.string().describe("the action id"),
-  componentId: z.string().describe("the component id the action is on"),
-  componentName: z.string().describe("the component name the action is on"),
+  componentId: z.string().nullable().optional().describe("the component id the action is on"),
+  componentName: z.string().optional().describe("the component name the action is on"),
   funcRunId: z.string().nullable().optional().describe(
     "the function run id for the last executed function for this action",
   ),
-  schemaName: z.string().describe(
+  schemaName: z.string().optional().describe(
     "the schema name of the component the action is on",
   ),
   name: z.string().describe("The name of the Action"),

--- a/bin/si-mcp-server/src/tools/componentDiscover.ts
+++ b/bin/si-mcp-server/src/tools/componentDiscover.ts
@@ -168,7 +168,9 @@ export function componentDiscoverTool(server: McpServer) {
                     discoverResponse.data.managementFuncJobStateId,
                 });
                 discoverState = status.data.state;
-                discoverTemplateResult["funcRunId"] = status.data.funcRunId;
+                if (status.data.funcRunId) {
+                  discoverTemplateResult["funcRunId"] = status.data.funcRunId;
+                }
                 currentCount += 1;
               } catch (error) {
                 return errorResponse({

--- a/bin/si-mcp-server/src/tools/componentImport.ts
+++ b/bin/si-mcp-server/src/tools/componentImport.ts
@@ -135,7 +135,9 @@ export function componentImportTool(server: McpServer) {
                     importResponse.data.managementFuncJobStateId,
                 });
                 importState = status.data.state;
-                result["funcRunId"] = status.data.funcRunId;
+                if (status.data.funcRunId) {
+                  result["funcRunId"] = status.data.funcRunId;
+                }
                 currentCount += 1;
               } catch (error) {
                 return errorResponse({

--- a/bin/si-mcp-server/src/tools/funcRunGet.ts
+++ b/bin/si-mcp-server/src/tools/funcRunGet.ts
@@ -14,8 +14,7 @@ import { decodeBase64 } from "@std/encoding/base64";
 
 const name = "func-run-get";
 const title = "Get a function run information";
-const description =
-  `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
+const description = `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
 
 const GetFuncRunInputSchemaRaw = {
   changeSetId: z
@@ -77,12 +76,18 @@ const GetFuncRunOutputSchemaRaw = {
         ),
       componentId: z
         .string()
+        .optional()
+        .nullable()
         .describe("the component id this function run was for"),
       componentName: z
         .string()
+        .optional()
+        .nullable()
         .describe("the component name this function run was for"),
       schemaName: z
         .string()
+        .optional()
+        .nullable()
         .describe("the schema name of the component this function was for"),
       functionName: z.string().describe("the name of the function"),
       functionKind: z
@@ -173,12 +178,10 @@ export function funcRunGetTool(server: McpServer) {
             }
             changeSetId = head.id;
           } catch (error) {
-            const errorMessage = error instanceof Error
-              ? error.message
-              : String(error);
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
             return errorResponse({
-              message:
-                `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
+              message: `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
             });
           }
         }
@@ -197,7 +200,8 @@ export function funcRunGetTool(server: McpServer) {
             componentId: response.data.funcRun.componentId,
             componentName: response.data.funcRun.componentName,
             schemaName: response.data.funcRun.schemaName,
-            functionName: response.data.funcRun.functionDisplayName ||
+            functionName:
+              response.data.funcRun.functionDisplayName ||
               response.data.funcRun.functionName,
             functionKind: response.data.funcRun
               .functionKind as FuncRunResult["functionKind"],

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -44,6 +44,7 @@ const FindSchemaOutputSchemaRaw = {
       schemaName: z.string().describe("the name of the schema"),
       description: z
         .string()
+        .nullable()
         .optional()
         .describe(
           "a description of the schema, frequently containing documentation",

--- a/bin/si-mcp-server/src/tools/templateRun.ts
+++ b/bin/si-mcp-server/src/tools/templateRun.ts
@@ -41,7 +41,7 @@ const TemplateRunOutputSchemaRaw = {
     managementFuncJobStateId: z.string().describe(
       "The job state ID for the enqueued or executed management function",
     ),
-    message: z.string().optional().describe(
+    message: z.string().nullable().optional().describe(
       "Optional message from the management function execution",
     ),
   }).describe(

--- a/deno.lock
+++ b/deno.lock
@@ -29,7 +29,7 @@
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@^1.0.6": "1.1.1",
     "jsr:@std/text@~1.0.7": "1.0.16",
-    "jsr:@systeminit/api-client@^1.1.4": "1.1.4",
+    "jsr:@systeminit/api-client@^1.1.6": "1.1.6",
     "jsr:@systeminit/cf-db@~0.1.4": "0.1.4",
     "jsr:@systeminit/remove-empty@0.1.3": "0.1.3",
     "npm:@apidevtools/json-schema-ref-parser@11.9.3": "11.9.3",
@@ -206,8 +206,8 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
-    "@systeminit/api-client@1.1.4": {
-      "integrity": "5d88f54adde71fedf60e8bfed67b652b0a41ea5cbaeb33a1e2a6f930a031f570",
+    "@systeminit/api-client@1.1.6": {
+      "integrity": "bcb7c01bf52d4a2b6b2f89d85521ef67f3259f796368589cd6ab6c4e82dbd778",
       "dependencies": [
         "npm:axios@^1.6.1"
       ]
@@ -1676,7 +1676,7 @@
           "jsr:@onjara/optic@^2.0.3",
           "jsr:@std/assert@1",
           "jsr:@std/encoding@^1.0.10",
-          "jsr:@systeminit/api-client@^1.1.4",
+          "jsr:@systeminit/api-client@^1.1.6",
           "npm:@modelcontextprotocol/sdk@^1.16.0",
           "npm:axios@^1.6.1",
           "npm:jwt-decode@4",


### PR DESCRIPTION
Many Luminork response fields were made optional in a recent OpenAPI spec and si-mcp-server no longer compiles. This PR adjusts si-mcp-server to accept (and sometimes pass through to Claude) these undefined or null values.

## Out of Scope

Some of these things (e.g. componentId on action) seem like they really *aren't* optional, so I wonder whether Luminork's API should be changed instead for those things.

## How was it tested?

- [x] Claude can still use these endpoints
