### PR TITLE
fix: filter build if only changes made to mcp server

### DIFF
--- a/bxl/dependent_targets.bxl
+++ b/bxl/dependent_targets.bxl
@@ -273,7 +273,13 @@ def _dependent_modified_file_targets(ctx: bxl.Context) -> bxl.UnconfiguredTarget
     for results in results_set.values():
         targets = targets + results
 
-    return _rdeps_for_targets(ctx, map(lambda e: "{}".format(e.label), targets))
+    rdeps = _rdeps_for_targets(ctx, map(lambda e: "{}".format(e.label), targets))
+
+    # If only si-mcp-server files changed, exclude other bin/* services
+    if all([f.startswith("bin/si-mcp-server/") for f in ctx.cli_args.modified_file]):
+        return ctx.uquery().filter("^(?!//bin/)|^//bin/si-mcp-server:", rdeps)
+
+    return rdeps
 
 # Computes a list of targets which are reverse dependencies of given targets within a universe.
 def _rdeps_for_targets(ctx: bxl.Context, targets: list[str]) -> bxl.UnconfiguredTargetSet:


### PR DESCRIPTION
## How does this PR change the system?

Currently when making changes to the MCP server artifacts are being built for other services despite no changes being made. This aims to filter out other services when only changes to the MCP server are made.

Previously, a PR in the MCP server repo resulted in 3 artifacts being built for other untouched services, here's a link to the pipeline run - https://buildkite.com/system-initiative/si-merge-queue/builds/7261 - this is the PR that was merged to trigger this pipeline - https://github.com/systeminit/si/pull/7348

## How was it tested?

I'm not sure it can be tested before it is merged.

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExazd5MnVheWpqZGhsZTI2ZmZ4MzZzOTY5ZWZqcnZhZnNnbDltZ2lkMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/VfyC5j7sR4cso/giphy.gif)
