### PR TITLE
Add event for created funcs in luminork

### DIFF
--- a/bin/luminork/README.md
+++ b/bin/luminork/README.md
@@ -1,0 +1,18 @@
+# Luminork
+
+`luminork` is an API server for automating SI and for making requests to its internal API directly.
+It is the API server that SI's [MCP Server](../si-mcp-server) communicates with.
+
+## Running Locally
+
+Start by [running the local stack](../../DEV_DOCS.md) with the following environment variable set:
+
+```shell
+export SI_BASE_URL="http://localhost:5380"
+```
+
+If testing with the local MCP server, ensure that it is also using the same base URL.
+
+## Generated API Documentation
+
+Our [Swagger UI](https://api.systeminit.com/swagger-ui) contains the generated API documentation for `luminork` as of its last deployment.

--- a/lib/luminork-server/src/service/v1/schemas/create_action.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_action.rs
@@ -104,6 +104,8 @@ pub async fn create_variant_action(
     )
     .await?;
 
+    FuncAuthoringClient::publish_func_create_event(ctx, &func).await?;
+
     tracker.track(
         ctx,
         "api_create_action_func",

--- a/lib/luminork-server/src/service/v1/schemas/create_authentication.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_authentication.rs
@@ -97,6 +97,8 @@ pub async fn create_variant_authentication(
     )
     .await?;
 
+    FuncAuthoringClient::publish_func_create_event(ctx, &func).await?;
+
     tracker.track(
         ctx,
         "api_create_authentication_func",

--- a/lib/luminork-server/src/service/v1/schemas/create_codegen.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_codegen.rs
@@ -113,6 +113,8 @@ pub async fn create_variant_codegen(
     )
     .await?;
 
+    FuncAuthoringClient::publish_func_create_event(ctx, &func).await?;
+
     tracker.track(
         ctx,
         "api_create_codegen_func",

--- a/lib/luminork-server/src/service/v1/schemas/create_management.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_management.rs
@@ -100,6 +100,8 @@ pub async fn create_variant_management(
     )
     .await?;
 
+    FuncAuthoringClient::publish_func_create_event(ctx, &func).await?;
+
     tracker.track(
         ctx,
         "api_create_management_func",

--- a/lib/luminork-server/src/service/v1/schemas/create_qualification.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_qualification.rs
@@ -117,6 +117,8 @@ pub async fn create_variant_qualification(
     )
     .await?;
 
+    FuncAuthoringClient::publish_func_create_event(ctx, &func).await?;
+
     tracker.track(
         ctx,
         "api_create_qualification_func",

--- a/lib/luminork-server/src/service/v1/schemas/mod.rs
+++ b/lib/luminork-server/src/service/v1/schemas/mod.rs
@@ -98,7 +98,7 @@ pub enum SchemaError {
     Transactions(#[from] TransactionsError),
     #[error("validation error: {0}")]
     Validation(String),
-    #[error("variant authuring error: {0}")]
+    #[error("variant authoring error: {0}")]
     VariantAuthoring(#[from] VariantAuthoringError),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -1032,11 +1032,7 @@ async fn create_func(
     ctx.write_audit_log(attach_audit_log, func.name.clone())
         .await?;
 
-    let summary = func.into_frontend_type(&ctx).await?;
-    WsEvent::func_created(&ctx, summary)
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
+    FuncAuthoringClient::publish_func_create_event(&ctx, &func).await?;
 
     let bindings_size = get_bindings(&ctx, func.id, schema_id).await?.0.byte_size();
     let types_size = func_types_size(&ctx, func.id).await?;
@@ -1501,11 +1497,7 @@ async fn unlock_func(
         variant
     };
 
-    let summary = new_func.into_frontend_type(&ctx).await?;
-    WsEvent::func_created(&ctx, summary.clone())
-        .await?
-        .publish_on_commit(&ctx)
-        .await?;
+    FuncAuthoringClient::publish_func_create_event(&ctx, &new_func).await?;
 
     ctx.write_audit_log(
         AuditLogKind::UnlockFunc {

--- a/lib/sdf-server/src/service/v2/func/create_func.rs
+++ b/lib/sdf-server/src/service/v2/func/create_func.rs
@@ -402,11 +402,7 @@ pub async fn create_func(
     };
 
     let code = get_code_response(ctx, func.id).await?;
-    let summary = func.into_frontend_type(ctx).await?;
-    WsEvent::func_created(ctx, summary.clone())
-        .await?
-        .publish_on_commit(ctx)
-        .await?;
+    let summary = FuncAuthoringClient::publish_func_create_event(ctx, &func).await?;
     track(
         &posthog_client,
         ctx,
@@ -415,9 +411,9 @@ pub async fn create_func(
         "created_func",
         serde_json::json!({
             "how": "/func/created_func",
-            "func_id": summary.func_id,
-            "func_name": summary.name.to_owned(),
-            "func_kind": summary.kind,
+            "func_id": func.id,
+            "func_name": func.name.to_owned(),
+            "func_kind": func.kind,
         }),
     );
 


### PR DESCRIPTION
## Description

This change adds a WsEvent for created and attached funcs in luminork. This fixes an issue where authoring with the MCP server resulted in not seeing the new funcs appear in the customization UI. Publishing the event is now shared logic between sdf and luminork.

In addition to the above, this change adds a README for luminork.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb3B4Zzh3Z3kxZ21qdzVmbzNla2ZoYWZwcmExMzZtZWY2ZnljMXBneSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GpCMacav9VprdAgmVa/giphy.gif"/>

## Screenshot

The authoring UI after it automatically drops you into the function without clicking anything.

<img width="3690" height="1584" alt="image" src="https://github.com/user-attachments/assets/3a20a01a-1eed-428a-a083-7bec9e2a8d59" />

## Known Issue

The counters to the left remain broken. This is fixed when using the UI to add a function. The `func.store.ts` pinia store works around this by adding func bindings upon creation.
