### PR TITLE
Proceed without the previous version if unable to retrieve during deployment MV building

### DIFF
--- a/lib/edda-server/src/materialized_view/deployment.rs
+++ b/lib/edda-server/src/materialized_view/deployment.rs
@@ -629,13 +629,22 @@ where
 {
     // For deployment MVs, check if object exists in deployment storage
     let op = {
-        let maybe_previous_version = frigg
+        let maybe_previous_version = match frigg
             .get_current_deployment_object_with_index(
                 mv_kind,
                 &mv_id,
                 (*maybe_deployment_mv_index).clone(),
             )
-            .await?;
+            .await
+        {
+            Ok(maybe_previous) => maybe_previous,
+            Err(err) => {
+                warn!(
+                    "Unable to retreive previous deployment MV version; proceeding without: {err}"
+                );
+                None
+            }
+        };
 
         if let Some(previous_version) = maybe_previous_version {
             BuildMvOp::UpdateFrom {


### PR DESCRIPTION
We apparently have some deployment-level MVs in the MvIndex where we are missing the MV itself. While it's a problem that we were missing the actual MV listed in the index, we're also in the process of building the missing MV when this error happens. Now, if we encounter this, we'll log a warning that it happened so we don't have this happening without any visibility, but we'll also proceed as if it wasn't in the MvIndex to start with to allow the build to continue and hopefully finish.
