### PR TITLE
SI AI capture duplicate action kind error and respond appropriately

### DIFF
--- a/bin/si-mcp-server/src/tools/commonBehavior.ts
+++ b/bin/si-mcp-server/src/tools/commonBehavior.ts
@@ -56,9 +56,10 @@ export function successResponse(
 }
 
 // deno-lint-ignore no-explicit-any
-export function errorResponse(error: any): CallToolResult {
+export function errorResponse(error: any, hints?: string): CallToolResult {
+  let textResponse, structuredContent;
   if (error.response) {
-    const errorResponse = {
+    structuredContent = {
       status: "failure",
       errorMessage: `Error Status: ${
         error.response.status
@@ -66,45 +67,33 @@ export function errorResponse(error: any): CallToolResult {
         error.message
       }`,
     };
-    return {
-      content: [
-        {
-          type: "text",
-          text: `<response>${JSON.stringify(errorResponse)}</response>`,
-        },
-      ],
-      structuredContent: errorResponse,
-      isError: true,
-    };
+    textResponse = `<response>${JSON.stringify(structuredContent)}</response>`;
   } else if (error.request) {
-    const errorResponse = {
+    structuredContent = {
       status: "failure",
       errorMessage: `No response recieved, but request failed`,
     };
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(errorResponse),
-        },
-      ],
-      structuredContent: errorResponse,
-      isError: true,
-    };
+    textResponse = JSON.stringify(structuredContent);
   } else {
-    const errorResponse = {
+    structuredContent = {
       status: "failure",
       errorMessage: `Error setting up request: ${error.message}`,
     };
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(errorResponse),
-        },
-      ],
-      structuredContent: errorResponse,
-      isError: true,
-    };
+    textResponse = JSON.stringify(structuredContent);
   }
+
+  if (hints) {
+    textResponse += `\n<hints>${hints}</hints>`;
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: textResponse,
+      },
+    ],
+    structuredContent,
+    isError: true,
+  };
 }


### PR DESCRIPTION
## How does this PR change the system?

This PR completes the demo for [ENG-3238](https://linear.app/system-initiative/issue/ENG-3238/scaffold-the-authoring-mcp-tools) by more cleanly capturing the error which happens if you attempt to create a duplicate action function of any kind except Manual.

#### Out of Scope:

Because there is not yet a Luminork API endpoint for the AI to use to check what action functions a schema has, this version can only respond to the error when it happens instead of preempting it.