### PR TITLE
Bump get public IP timeout in deploy stack

### DIFF
--- a/.ci/deploy-stack.py
+++ b/.ci/deploy-stack.py
@@ -528,8 +528,8 @@ def main():
         ip_output_file = './ip'
 
         try:
-            public_ip = get_public_ip(base_change_set_id, ec2_component_id, 60,
-                                      5)
+            public_ip = get_public_ip(base_change_set_id, ec2_component_id,
+                                      120, 5)
             print(f"Instance is reachable at: {public_ip}")
             with open(ip_output_file, 'w') as f:
                 f.write(f'{public_ip}')


### PR DESCRIPTION
## Description

We need a bit more time depending on both the system and AWS for the public IP to be available. This bumps it from 60 seconds to 120 seconds.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdld3JmNW50OW41NXdmcndndXR2Zm16NmRjcDQ1a2luYmNmaG41NzI4OSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SkzbKoAtrK7rJqJSf0/giphy.gif"/>