### PR TITLE
fix(web): Redirect to new change set when restore on HEAD

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -966,7 +966,19 @@ const restoreComponent = async () => {
   restoreLoading.value = true;
   const result = await restoreComponents([component.value.id]);
   if (result.success) {
-    close();
+    if (result.newChangeSetId) {
+      // Navigate to the same component details page in the new change set
+      router.push({
+        name: "new-hotness-component",
+        params: {
+          workspacePk: route.params.workspacePk,
+          changeSetId: result.newChangeSetId,
+          componentId: component.value.id,
+        },
+      });
+    } else {
+      close();
+    }
   }
   restoreLoading.value = false;
 };


### PR DESCRIPTION
Fixes: BUG-1042

When on a component details page on the head change set and we click the restore button, we redirect to the new change set and stay on the component details page

https://jam.dev/c/d277e396-4fea-46d7-84c5-f919dc2725ba