### PR TITLE
Apply a batch of patches in batches

### DIFF
--- a/app/web/src/workers/webworker.ts
+++ b/app/web/src/workers/webworker.ts
@@ -1456,8 +1456,6 @@ const applyWorkspacePatch = async (
           "indexChecksum:",
           indexChecksum,
         );
-        // TODO, can we do this outside the batch?
-        initIndexAndChangeSet(db, atom, span);
         const inserted = insertAtomMTM(db, atom, indexChecksum);
         span.setAttribute("insertedMTM", inserted);
         debug("🔧 MTM inserted:", inserted, "for:", atom.kind, atom.id);


### PR DESCRIPTION
## How does this PR change the system?

We are seeing `PatchBatch` data come over the wire from Edda to the web worker with hundreds of patches in a single batch. As a result we are sending too much work directly at SQLite—and too much work without allowing the UI to refresh. (Note: we started to see slow downs above 50+ patches in a batch)

1. chunk the patches into sets of 45, which will bust the cache for the UI to remain responsive.
2. lower the amount of queries being run by doing the `kind, args, checksum` check for an `indexChecksum` all at once into a map that is provided to each `applyPatch` run. This removes 2 queries per patch.
3. Removed an unnecessary idempotent call that the parent caller runs. This removes 2 queries per patch.
4. Add performance timings to individual DB queries

#### Out of Scope:

Edda shouldn't allow hundreds of patches to get compressed into a single batch. It ought to read and compress at smaller batch sizes for a more responsive experience.

## How was it tested?

1. New change set, add components, delete components, erase components. Apply. General basic functionality.
5. Also the web worker test covers this behavior.

## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlajFpeWI5aGM4cDg3M2xmdmVrbHduNXVyYXRlNjZ0ZGkxNDB2NWp6NiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/9RxNrPV8OZ20zzc4F1/giphy.gif"/>