### PR TITLE
core(rebaser): allow certain errors to trigger request retries

### DIFF
--- a/lib/naxum/src/middleware/jetstream_post_process/future.rs
+++ b/lib/naxum/src/middleware/jetstream_post_process/future.rs
@@ -1,6 +1,7 @@
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{
         Context,
         Poll,
@@ -13,37 +14,41 @@ use pin_project_lite::pin_project;
 use tower::Service;
 
 use crate::{
+    Head,
     message::Message,
+    middleware::jetstream_post_process::{
+        Info,
+        OnFailure,
+        OnSuccess,
+    },
     response::Response,
 };
 
 pin_project! {
-    pub struct ResponseFuture<S>
+    pub struct ResponseFuture<S, OnSuccessT, OnFailureT>
     where
         S: Service<Message<jetstream::Message>>,
     {
         #[pin]
         pub(crate) inner: S::Future,
-        #[pin]
-        pub(crate) on_success_fut: BoxFuture<'static, ()>,
-        #[pin]
-        pub(crate) on_failure_fut: BoxFuture<'static, ()>,
+        pub(crate) on_success: OnSuccessT,
+        pub(crate) on_failure: OnFailureT,
         pub(crate) state: State<S::Response, S::Error>,
     }
 }
 
-#[derive(Clone, Default)]
 pub(crate) enum State<T, E> {
-    #[default]
-    Initial,
-    Success(Option<T>),
-    Failure(Option<T>),
-    Err(Option<E>),
+    Initial(Option<(Arc<Head>, Arc<Info>)>),
+    Success(Option<T>, BoxFuture<'static, ()>),
+    Failure(Option<T>, BoxFuture<'static, ()>),
+    Err(Option<E>, BoxFuture<'static, ()>),
 }
 
-impl<S> Future for ResponseFuture<S>
+impl<S, OnSuccessT, OnFailureT> Future for ResponseFuture<S, OnSuccessT, OnFailureT>
 where
     S: Service<Message<jetstream::Message>, Response = Response>,
+    OnSuccessT: OnSuccess,
+    OnFailureT: OnFailure,
 {
     type Output = Result<S::Response, S::Error>;
 
@@ -53,42 +58,64 @@ where
         loop {
             match this.state {
                 // Poll the nested service to yield our result
-                State::Initial => {
+                State::Initial(args) => {
                     let result = futures::ready!(this.inner.as_mut().poll(cx));
 
                     match result {
                         Ok(response) => {
                             if response.status().is_success() {
+                                let (head, info) = args
+                                    .take()
+                                    .expect("extracting owned value only happens once");
+                                let status = response.status();
+
                                 // Transition the state to run the success case
-                                *this.state = State::Success(Some(response));
+                                *this.state = State::Success(
+                                    Some(response),
+                                    this.on_success.call(head, info, status),
+                                );
                             } else {
+                                let (head, info) = args
+                                    .take()
+                                    .expect("extracting owned value only happens once");
+                                let status = Some(response.status());
+
                                 // Transition the state to run the failure case
-                                *this.state = State::Failure(Some(response));
+                                *this.state = State::Failure(
+                                    Some(response),
+                                    this.on_failure.call(head, info, status),
+                                );
                             }
                         }
                         Err(err) => {
+                            let (head, info) = args
+                                .take()
+                                .expect("extracting owned value only happens once");
+                            let status = None;
+
                             // Transition the state to run the failure case
-                            *this.state = State::Err(Some(err));
+                            *this.state =
+                                State::Err(Some(err), this.on_failure.call(head, info, status));
                         }
                     }
                 }
                 // Poll the on_success future and when ready return the `Ok` type
-                State::Success(sucess_response) => {
-                    futures::ready!(this.on_success_fut.poll(cx));
+                State::Success(sucess_response, on_success_fut) => {
+                    futures::ready!(on_success_fut.as_mut().poll(cx));
                     return Poll::Ready(Ok(sucess_response
                         .take()
                         .expect("extracting owned value only happens once")));
                 }
                 // Poll the on_failure future and when ready return the `Ok` type
-                State::Failure(failure_response) => {
-                    futures::ready!(this.on_failure_fut.poll(cx));
+                State::Failure(failure_response, on_failure_fut) => {
+                    futures::ready!(on_failure_fut.as_mut().poll(cx));
                     return Poll::Ready(Ok(failure_response
                         .take()
                         .expect("extracting owned value only happens once")));
                 }
                 // Poll the on_failure future and when ready return the `Err` type
-                State::Err(err) => {
-                    futures::ready!(this.on_failure_fut.poll(cx));
+                State::Err(err, on_failure_fut) => {
+                    futures::ready!(on_failure_fut.as_mut().poll(cx));
                     return Poll::Ready(Err(err
                         .take()
                         .expect("extracting owned value only happens once")));

--- a/lib/naxum/src/middleware/jetstream_post_process/on_failure.rs
+++ b/lib/naxum/src/middleware/jetstream_post_process/on_failure.rs
@@ -1,13 +1,19 @@
 use std::sync::Arc;
 
+use async_nats::StatusCode;
 use futures::future::BoxFuture;
 use tracing::error;
 
 use super::Info;
 use crate::Head;
 
-pub trait OnFailure {
-    fn call(&mut self, head: Arc<Head>, info: Arc<Info>) -> BoxFuture<'static, ()>;
+pub trait OnFailure: Clone {
+    fn call(
+        &mut self,
+        head: Arc<Head>,
+        info: Arc<Info>,
+        status: Option<StatusCode>,
+    ) -> BoxFuture<'static, ()>;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -20,7 +26,12 @@ impl DefaultOnFailure {
 }
 
 impl OnFailure for DefaultOnFailure {
-    fn call(&mut self, head: Arc<Head>, info: Arc<Info>) -> BoxFuture<'static, ()> {
+    fn call(
+        &mut self,
+        head: Arc<Head>,
+        info: Arc<Info>,
+        _status: Option<StatusCode>,
+    ) -> BoxFuture<'static, ()> {
         Box::pin(async move {
             error!(
                 subject = head.subject.as_str(),

--- a/lib/naxum/src/middleware/jetstream_post_process/on_success.rs
+++ b/lib/naxum/src/middleware/jetstream_post_process/on_success.rs
@@ -1,13 +1,19 @@
 use std::sync::Arc;
 
+use async_nats::StatusCode;
 use futures::future::BoxFuture;
 use tracing::trace;
 
 use super::Info;
 use crate::Head;
 
-pub trait OnSuccess {
-    fn call(&mut self, head: Arc<Head>, info: Arc<Info>) -> BoxFuture<'static, ()>;
+pub trait OnSuccess: Clone {
+    fn call(
+        &mut self,
+        head: Arc<Head>,
+        info: Arc<Info>,
+        status: StatusCode,
+    ) -> BoxFuture<'static, ()>;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -20,7 +26,12 @@ impl DefaultOnSuccess {
 }
 
 impl OnSuccess for DefaultOnSuccess {
-    fn call(&mut self, _head: Arc<Head>, _info: Arc<Info>) -> BoxFuture<'static, ()> {
+    fn call(
+        &mut self,
+        _head: Arc<Head>,
+        _info: Arc<Info>,
+        _status: StatusCode,
+    ) -> BoxFuture<'static, ()> {
         Box::pin(async move {
             trace!("message on success");
         })

--- a/lib/naxum/src/middleware/jetstream_post_process/service.rs
+++ b/lib/naxum/src/middleware/jetstream_post_process/service.rs
@@ -56,7 +56,7 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = ResponseFuture<S>;
+    type Future = ResponseFuture<S, OnSuccessT, OnFailureT>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -91,14 +91,11 @@ where
 
         let response = self.inner.call(message);
 
-        let on_success_fut = self.on_success.call(head.clone(), info.clone());
-        let on_failure_fut = self.on_failure.call(head.clone(), info.clone());
-
         ResponseFuture {
             inner: response,
-            on_success_fut,
-            on_failure_fut,
-            state: super::future::State::default(),
+            on_success: self.on_success.clone(),
+            on_failure: self.on_failure.clone(),
+            state: super::future::State::Initial(Some((head, info))),
         }
     }
 }

--- a/lib/naxum/src/response/inner.rs
+++ b/lib/naxum/src/response/inner.rs
@@ -107,6 +107,18 @@ impl<T> Response<T> {
         }
     }
 
+    pub fn default_bad_gateway() -> Self
+    where
+        T: Default,
+    {
+        Self {
+            head: Parts {
+                status: StatusCode::from_u16(502).expect("status code is in valid range"),
+            },
+            body: T::default(),
+        }
+    }
+
     pub fn default_service_unavailable() -> Self
     where
         T: Default,

--- a/lib/rebaser-server/src/change_set_processor_task.rs
+++ b/lib/rebaser-server/src/change_set_processor_task.rs
@@ -20,6 +20,7 @@ use naxum::{
     MessageHead,
     ServiceBuilder,
     ServiceExt as _,
+    StatusCode,
     TowerServiceExt as _,
     extract::MatchedSubject,
     handler::Handler as _,
@@ -233,6 +234,7 @@ impl jetstream_post_process::OnSuccess for DeleteMessageOnSuccess {
         &mut self,
         head: Arc<naxum::Head>,
         info: Arc<jetstream_post_process::Info>,
+        _status: StatusCode,
     ) -> BoxFuture<'static, ()> {
         let stream = self.stream.clone();
 
@@ -269,6 +271,7 @@ impl jetstream_post_process::OnFailure for MoveMessageOnFailure {
         &mut self,
         head: Arc<naxum::Head>,
         info: Arc<jetstream_post_process::Info>,
+        _status: Option<StatusCode>,
     ) -> BoxFuture<'static, ()> {
         let stream = self.stream.clone();
         let dead_letter_queue = self.dead_letter_queue.clone();

--- a/lib/shuttle-server/src/middleware.rs
+++ b/lib/shuttle-server/src/middleware.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use naxum::middleware::jetstream_post_process;
+use naxum::{
+    StatusCode,
+    middleware::jetstream_post_process,
+};
 use si_data_nats::async_nats;
 use telemetry::prelude::*;
 
@@ -21,6 +24,7 @@ impl jetstream_post_process::OnSuccess for DeleteMessageOnSuccess {
         &mut self,
         head: Arc<naxum::Head>,
         info: Arc<jetstream_post_process::Info>,
+        _status: StatusCode,
     ) -> BoxFuture<'static, ()> {
         let stream = self.stream.clone();
 


### PR DESCRIPTION
This change is primarily focused on the code called in the
`ChangeSetProcessorTask` for each request that is being processed.

Prior to this change any error that was encountered that used the
question mark operator (i.e. Rust's `?`) would trigger the `default`
Naxum handler to return a `Result::Err(_)`. The `JetstreamPostProcess`
middleware had a custom `OnFailure` function which would copy the
message from the original stream subscription to the dead letter queue
stream (i.e. "DLQ"), treating all errors as unrecoverable. With more
time and experience seeing the service deployed in production, it's
clear that not all errors are unrecoverable, but rather some errors at
certain points in the business logic *should* be retried (as not
retrying some of these requests would lead to dropped graph changes).

This change updates the `OnFailure` implementation and uses a new
wrapping error type--still called `HandlerError` which only has 4
possible variants:

- `PostCommit`: a message processing error *after* committing to a
  graph change
- `PreCommit`: a message processing error *before* committing to a graph
  change
- `TransientService`: an error occurring due to an error from an
  external service (this could be Postgres, NATS, etc.)
- `Unprocessable`: a request message that is not processable in a
  deterministic way (such as a failure to deserialize a NATS header, for
  example)

Importantly this error type implements the `naxum::IntoResponse` trait,
meaning that each of these variants will map to a Response with a
discrete `StatusCode`. The `OnFailure` function can use the `StatusCode`
values to determine which failures should be retried and which should
not.

The "retry" logic is not apparent in the code change as the retry
activity is an outcome of the task scheduling of the Rebaser. Each
subscription for a `ChangeSetProcessorTask` is an push-based ordered
consumer, meaning the consumer is essentially a core NATS subscriber
with messages being pushed to the subsciber as fast as the messages can
be read. One side effect of this style of consumer is that there is no
Ack/Nack'ing of message.

A successful processing of a message is generally deleted, if the
message stream is expected to be a "work queue". With the
`ChangeSetProcessorTask`, a successful handler result (that is, the
`async fn default(...) -> Result<(), _>` function returns `Ok(()`) will
invoke the `OnSuccess` middleware callback function and the message will
be deleted before the Naxum app pulls the next message from the
subscription stream.

If the handler returns an `Err(_)` however, the `OnFailure` middleware
callback function would have copied the message onto the DLQ and then
also delete the message. With this change, the `OnFailure` function uses
the `StatusCode` to determine if a message should be retried. There is a
new "internal token" (i.e. another `CancellationToken`) which this
`OnFailure` function uses to stop the execution of the
`ChangeSetProcessorTask`'s Naxum app so that no further messages will be
pulled for processing. This is important as the Rebaser should *not*
process any further messages before first attempting to process the
just-failed request at least one more time. In shutting down the
`ChangeSetProcessorTask` in such a way that it is re-scheduled to run
again, the just-failed request is the first request message to consider
when a new `ChangeSetProcessorTask` is spun up.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMWRnbXkxY2F3bnRuOWFlZmtoYXk2YWJ1Mjh4ZG9qNmUwcDJzbWZ5MCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Jt4sQOFEh29Ob8KAxg/giphy.gif"/>