### PR TITLE
feat(clover): handle oneOf and normalize objects

### DIFF
--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -453,29 +453,35 @@ export function createPropFromCf(
 
     return prop;
   } else if (normalizedCfProp.type === "object") {
-    if (normalizedCfProp.patternProperties) {
+    if (normalizedCfProp.patternProperties || normalizedCfProp.additionalProperties) {
       const prop = partialProp as ExpandedPropSpecFor["map"];
       prop.kind = "map";
       prop.data.widgetKind = "Map";
 
-      const patternProps = Object.entries(normalizedCfProp.patternProperties);
-
       let cfItemProp;
-      if (patternProps.length === 1) {
-        const [_thing, patternProp] = patternProps[0];
-        cfItemProp = patternProp;
-      } else if (patternProps.length === 2) {
-        // If there is 2 pattern props, that means we have a validation for the key and another one for the value of the map.
-        // We take the second one as the type of the value, since it's the thing we can store right now
-        const [_thing, patternProp] = patternProps[1];
-        cfItemProp = patternProp;
-      } else {
-        console.log(patternProps);
-        throw new Error("too many pattern props you fool");
+
+      if (normalizedCfProp.patternProperties) {
+        const patternProps = Object.entries(normalizedCfProp.patternProperties);
+
+        if (patternProps.length === 1) {
+          const [_thing, patternProp] = patternProps[0];
+          cfItemProp = patternProp;
+        } else if (patternProps.length === 2) {
+          // If there is 2 pattern props, that means we have a validation for the key and another one for the value of the map.
+          // We take the second one as the type of the value, since it's the thing we can store right now
+          const [_thing, patternProp] = patternProps[1];
+          cfItemProp = patternProp;
+        } else {
+          console.log(patternProps);
+          throw new Error("too many pattern props you fool");
+        }
+      } else if (normalizedCfProp.additionalProperties) {
+        // Use additionalProperties as the map value type
+        cfItemProp = normalizedCfProp.additionalProperties;
       }
 
       if (!cfItemProp) {
-        throw new Error("could not extract type from pattern prop");
+        throw new Error("could not extract type from pattern prop or additionalProperties");
       }
 
       queue.push({


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Handles complex object types, specifically `oneOf` including ones with multiple type props.  This fixes the `label` objects not being maps.

#### Screenshots:

<img width="859" height="256" alt="image" src="https://github.com/user-attachments/assets/bae74c2b-b51c-4e12-90b7-9b8fc40036fc" />

#### Out of Scope:

`anyOf` as I don't think there are any.

## How was it tested?

Manually. The PR will validate AWS is oaky


## In short: [:link:](https://giphy.com/)
<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZXhoM3hlcWFlc2pienEyMjdwdmZ4cmVqa3VzcHpveG14ZTJoZmtudSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/RHPxe7KPnb8KaAtBbE/giphy.gif"/>
