### PR TITLE
refactor: add exponential backoff retry + jitter to the AWS Functions in c…

### DIFF
--- a/bin/clover/src/pipelines/aws/funcs/actions/awsCloudControlDelete.ts
+++ b/bin/clover/src/pipelines/aws/funcs/actions/awsCloudControlDelete.ts
@@ -6,43 +6,80 @@ async function main(component: Input): Promise<Output> {
       message: "Unable to queue a delete action on a component without a resource",
     };
   }
-  const child = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "delete-resource",
-    "--region",
-    _.get(component, "properties.domain.extra.Region", ""),
-    "--type-name",
-    _.get(component, "properties.domain.extra.AwsResourceType", ""),
-    "--identifier",
-    resourceId,
-  ]);
-
-  if (child.exitCode !== 0) {
-    console.error(child.stderr);
-    return {
-      status: "error",
-      message:
-        `Unable to delete resource; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-    };
-  }
-
-  const progressEvent = JSON.parse(child.stdout);
-  console.log("Progress Event", progressEvent);
-
   const delay = (time: number) => {
     return new Promise((res) => {
       setTimeout(res, time);
     });
   };
 
+  let deleteAttempt = 0;
+  const baseDelay = 1000;
+  const maxDelay = 120000;
+  let progressEvent;
+
+  console.log(`Starting delete operation for resourceId: ${resourceId}, region: ${_.get(component, "properties.domain.extra.Region", "")}`);
+  
+  // Retry initial delete operation if rate limited
+  while (deleteAttempt < 10) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "delete-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      resourceId,
+    ]);
+
+    console.log(`Delete attempt ${deleteAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+    
+    if (child.exitCode !== 0) {
+      const isRateLimited = child.stderr.includes("Throttling") || 
+                           child.stderr.includes("TooManyRequests") ||
+                           child.stderr.includes("RequestLimitExceeded") ||
+                           child.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && deleteAttempt < 9) {
+        console.log(`Delete attempt ${deleteAttempt + 1} rate limited, will retry`);
+      } else {
+        console.error(`Delete attempt ${deleteAttempt + 1} failed:`, child.stderr);
+      }
+      
+      if (isRateLimited && deleteAttempt < 9) {
+        deleteAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, deleteAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[DELETE] Rate limited on attempt ${deleteAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        return {
+          status: "error",
+          message:
+            `Unable to delete resource; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      console.log(`[DELETE] Initial delete successful on attempt ${deleteAttempt + 1}`);
+      progressEvent = JSON.parse(child.stdout);
+      console.log(`[DELETE] Got progress event:`, JSON.stringify(progressEvent, null, 2));
+      break;
+    }
+  }
+
+  console.log(`[DELETE] Starting status polling for request token: ${_.get(progressEvent, ["ProgressEvent", "RequestToken"])}`);
+
   let finished = false;
   let success = false;
-  let wait = 1000;
-  const upperLimit = 10000;
+  let attempt = 0;
   let message = "";
   let identifier = "";
 
   while (!finished) {
+    console.log(`[DELETE] Status poll attempt ${attempt + 1}`);
     const child = await siExec.waitUntilEnd("aws", [
       "cloudcontrol",
       "get-resource-request-status",
@@ -50,50 +87,103 @@ async function main(component: Input): Promise<Output> {
       _.get(component, "properties.domain.extra.Region", ""),
       "--request-token",
       _.get(progressEvent, ["ProgressEvent", "RequestToken"]),
+      "--no-cli-pager",
     ]);
 
+    let shouldRetry = false;
+    console.log(`[DELETE] Status poll ${attempt + 1}: exit code ${child.exitCode}, stderr: ${child.stderr ? 'present' : 'none'}`);
+
+    // Check for rate limiting in stderr regardless of exit code
+    const hasStderrError = child.stderr && child.stderr.trim().length > 0;
+    const isRateLimited = hasStderrError && (
+      child.stderr.includes("Throttling") || 
+      child.stderr.includes("TooManyRequests") ||
+      child.stderr.includes("RequestLimitExceeded") ||
+      child.stderr.includes("ThrottlingException")
+    );
+
     if (child.exitCode !== 0) {
-      console.error(child.stderr);
-      return {
-        status: "error",
-        message:
-          `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-      };
-    }
-    const currentProgressEvent = JSON.parse(child.stdout);
-    console.log("Current Progress", currentProgressEvent);
-    const operationStatus =
-      currentProgressEvent["ProgressEvent"]["OperationStatus"];
-    if (operationStatus == "SUCCESS") {
-      finished = true;
-      success = true;
-      identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
-    } else if (operationStatus == "FAILED") {
-      finished = true;
-      success = false;
-      message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
-        currentProgressEvent["ProgressEvent"]["ErrorCode"];
-    } else if (operationStatus == "CANCEL_COMPLETE") {
-      finished = true;
-      success = false;
-      message = "Operation Canceled by API or AWS.";
+      if (isRateLimited && attempt < 10) {
+        console.log(`[DELETE] Status poll ${attempt + 1} rate limited, will retry`);
+        shouldRetry = true;
+      } else {
+        console.error(`[DELETE] Status poll ${attempt + 1} failed:`, child.stderr);
+      }
+      
+      if (!isRateLimited || attempt >= 10) {
+        return {
+          status: "error",
+          message:
+            `Unable to delete; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      try {
+        const currentProgressEvent = JSON.parse(child.stdout);
+        console.log(`[DELETE] Status poll ${attempt + 1} response:`, JSON.stringify(currentProgressEvent, null, 2));
+        
+        // Log stderr warnings but don't fail if we have valid JSON
+        if (hasStderrError) {
+          console.warn("AWS CLI stderr (non-fatal):", child.stderr);
+        }
+        
+        const operationStatus =
+          currentProgressEvent["ProgressEvent"]["OperationStatus"];
+        if (operationStatus == "SUCCESS") {
+          console.log(`[DELETE] Operation SUCCESS detected!`);
+          finished = true;
+          success = true;
+          identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
+        } else if (operationStatus == "FAILED") {
+          console.log(`[DELETE] Operation FAILED: ${currentProgressEvent["ProgressEvent"]["StatusMessage"] || currentProgressEvent["ProgressEvent"]["ErrorCode"]}`);
+          finished = true;
+          success = false;
+          message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
+            currentProgressEvent["ProgressEvent"]["ErrorCode"];
+        } else if (operationStatus == "CANCEL_COMPLETE") {
+          console.log(`[DELETE] Operation CANCELLED`);
+          finished = true;
+          success = false;
+          message = "Operation Canceled by API or AWS.";
+        }
+      } catch (parseError) {
+        console.error("Failed to parse AWS response:", parseError);
+        console.error("Raw stdout:", child.stdout);
+        console.error("Raw stderr:", child.stderr);
+        
+        if (isRateLimited && attempt < 10) {
+          console.log(`[DELETE] Parse error with rate limiting on attempt ${attempt + 1}, will retry after backoff`);
+          shouldRetry = true;
+        } else {
+          return {
+            status: "error",
+            message: "Unable to parse AWS CloudControl response",
+          };
+        }
+      }
     }
 
-    if (!finished) {
-      console.log("\nWaiting to check status!\n");
-      await delay(wait);
-      if (wait != upperLimit) {
-        wait = wait + 1000;
-      }
+    if (!finished || shouldRetry) {
+      attempt++;
+      const exponentialDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+      const jitter = Math.random() * 0.3 * exponentialDelay;
+      const finalDelay = exponentialDelay + jitter;
+      
+      console.log(`[DELETE] Waiting ${Math.round(finalDelay)}ms before status poll attempt ${attempt + 1}`);
+      await delay(finalDelay);
     }
   }
 
+  console.log(`[DELETE] Final result: success=${success}`);
+  
   if (success) {
+    console.log(`[DELETE] Returning success`);
     return {
       payload: null,
       status: "ok",
     };
   } else {
+    console.log(`[DELETE] Returning error: ${message}`);
     return {
       message,
       payload: null,

--- a/bin/clover/src/pipelines/aws/funcs/actions/awsCloudControlUpdate.ts
+++ b/bin/clover/src/pipelines/aws/funcs/actions/awsCloudControlUpdate.ts
@@ -8,37 +8,79 @@ async function main(component: Input): Promise<Output> {
 
   let resourceId = component.properties?.si?.resourceId;
 
-  const refreshChild = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "get-resource",
-    "--region",
-    _.get(component, "properties.domain.extra.Region", ""),
-    "--type-name",
-    _.get(component, "properties.domain.extra.AwsResourceType", ""),
-    "--identifier",
-    resourceId,
-  ]);
+  const delay = (time: number) => {
+    return new Promise((res) => {
+      setTimeout(res, time);
+    });
+  };
 
-  if (refreshChild.exitCode !== 0) {
-    console.log("Failed to refresh cloud control resource");
-    console.log(refreshChild.stdout);
-    console.error(refreshChild.stderr);
-    // FIXME: should track down what happens when the resource doesnt exist
-    //if (child.stderr.includes("ResourceNotFoundException")) {
-    //    console.log("EKS Cluster not found  upstream (ResourceNotFoundException) so removing the resource")
-    //    return {
-    //        status: "ok",
-    //        payload: null,
-    //    };
-    //}
-    return {
-      status: "error",
-      message:
-        `Update error while fetching current state; exit code ${refreshChild.exitCode}.\n\nSTDOUT:\n\n${refreshChild.stdout}\n\nSTDERR:\n\n${refreshChild.stderr}`,
-    };
+  const baseDelay = 1000;
+  const maxDelay = 120000;
+  let refreshAttempt = 0;
+  let resourceResponse;
+
+  console.log(`Starting update operation - initial refresh for resourceId: ${resourceId}, region: ${_.get(component, "properties.domain.extra.Region", "")}`);
+
+  // Retry initial refresh operation if rate limited
+  while (refreshAttempt < 10) {
+    const refreshChild = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "get-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      resourceId,
+    ]);
+
+    console.log(`Initial refresh attempt ${refreshAttempt + 1}: AWS CLI exit code: ${refreshChild.exitCode}`);
+
+    if (refreshChild.exitCode !== 0) {
+      const isRateLimited = refreshChild.stderr.includes("Throttling") || 
+                           refreshChild.stderr.includes("TooManyRequests") ||
+                           refreshChild.stderr.includes("RequestLimitExceeded") ||
+                           refreshChild.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && refreshAttempt < 9) {
+        console.log(`Initial refresh attempt ${refreshAttempt + 1} rate limited, will retry`);
+      } else {
+        console.log("Failed to refresh cloud control resource");
+        console.log(refreshChild.stdout);
+        console.error(`Initial refresh attempt ${refreshAttempt + 1} failed:`, refreshChild.stderr);
+      }
+      
+      if (isRateLimited && refreshAttempt < 9) {
+        refreshAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, refreshAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[UPDATE] Initial refresh rate limited on attempt ${refreshAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        // FIXME: should track down what happens when the resource doesnt exist
+        //if (child.stderr.includes("ResourceNotFoundException")) {
+        //    console.log("EKS Cluster not found  upstream (ResourceNotFoundException) so removing the resource")
+        //    return {
+        //        status: "ok",
+        //        payload: null,
+        //    };
+        //}
+        return {
+          status: "error",
+          message:
+            `Update error while fetching current state; exit code ${refreshChild.exitCode}.\n\nSTDOUT:\n\n${refreshChild.stdout}\n\nSTDERR:\n\n${refreshChild.stderr}`,
+        };
+      }
+    } else {
+      console.log(`[UPDATE] Initial refresh successful on attempt ${refreshAttempt + 1}`);
+      resourceResponse = JSON.parse(refreshChild.stdout);
+      break;
+    }
   }
 
-  const resourceResponse = JSON.parse(refreshChild.stdout);
   const currentState = JSON.parse(
     resourceResponse["ResourceDescription"]["Properties"],
   );
@@ -67,45 +109,74 @@ async function main(component: Input): Promise<Output> {
   }
   console.log("Computed patch", patch);
 
-  const child = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "update-resource",
-    "--region",
-    _.get(component, "properties.domain.extra.Region", ""),
-    "--type-name",
-    _.get(component, "properties.domain.extra.AwsResourceType", ""),
-    "--identifier",
-    resourceId,
-    "--patch-document",
-    JSON.stringify(patch),
-  ]);
+  let updateAttempt = 0;
+  let progressEvent;
 
-  if (child.exitCode !== 0) {
-    console.error(child.stderr);
-    return {
-      status: "error",
-      message:
-        `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-    };
+  console.log(`Starting update operation for resourceId: ${resourceId}`);
+
+  // Retry update operation if rate limited
+  while (updateAttempt < 10) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "update-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      resourceId,
+      "--patch-document",
+      JSON.stringify(patch),
+    ]);
+
+    console.log(`Update attempt ${updateAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+    if (child.exitCode !== 0) {
+      const isRateLimited = child.stderr.includes("Throttling") || 
+                           child.stderr.includes("TooManyRequests") ||
+                           child.stderr.includes("RequestLimitExceeded") ||
+                           child.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && updateAttempt < 9) {
+        console.log(`Update attempt ${updateAttempt + 1} rate limited, will retry`);
+      } else {
+        console.error(`Update attempt ${updateAttempt + 1} failed:`, child.stderr);
+      }
+      
+      if (isRateLimited && updateAttempt < 9) {
+        updateAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, updateAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[UPDATE] Update rate limited on attempt ${updateAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        return {
+          status: "error",
+          message:
+            `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      console.log(`[UPDATE] Update successful on attempt ${updateAttempt + 1}`);
+      progressEvent = JSON.parse(child.stdout);
+      console.log(`[UPDATE] Got progress event:`, JSON.stringify(progressEvent, null, 2));
+      break;
+    }
   }
 
-  const progressEvent = JSON.parse(child.stdout);
-  console.log("Progress Event", progressEvent);
-
-  const delay = (time: number) => {
-    return new Promise((res) => {
-      setTimeout(res, time);
-    });
-  };
+  console.log(`[UPDATE] Starting status polling for request token: ${_.get(progressEvent, ["ProgressEvent", "RequestToken"])}`);
 
   let finished = false;
   let success = false;
-  let wait = 1000;
-  const upperLimit = 10000;
+  let attempt = 0;
   let message = "";
   let identifier = "";
 
   while (!finished) {
+    console.log(`[UPDATE] Status poll attempt ${attempt + 1}`);
     const child = await siExec.waitUntilEnd("aws", [
       "cloudcontrol",
       "get-resource-request-status",
@@ -113,85 +184,171 @@ async function main(component: Input): Promise<Output> {
       _.get(component, "properties.domain.extra.Region", ""),
       "--request-token",
       _.get(progressEvent, ["ProgressEvent", "RequestToken"]),
+      "--no-cli-pager",
     ]);
 
+    let shouldRetry = false;
+    console.log(`[UPDATE] Status poll ${attempt + 1}: exit code ${child.exitCode}, stderr: ${child.stderr ? 'present' : 'none'}`);
+
+    // Check for rate limiting in stderr regardless of exit code
+    const hasStderrError = child.stderr && child.stderr.trim().length > 0;
+    const isRateLimited = hasStderrError && (
+      child.stderr.includes("Throttling") || 
+      child.stderr.includes("TooManyRequests") ||
+      child.stderr.includes("RequestLimitExceeded") ||
+      child.stderr.includes("ThrottlingException")
+    );
+
     if (child.exitCode !== 0) {
-      console.error(child.stderr);
-      return {
-        status: "error",
-        message:
-          `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-      };
-    }
-    const currentProgressEvent = JSON.parse(child.stdout);
-    console.log("Current Progress", currentProgressEvent);
-    const operationStatus =
-      currentProgressEvent["ProgressEvent"]["OperationStatus"];
-    if (operationStatus == "SUCCESS") {
-      finished = true;
-      success = true;
-      identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
-    } else if (operationStatus == "FAILED") {
-      finished = true;
-      success = false;
-      message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
-        currentProgressEvent["ProgressEvent"]["ErrorCode"];
-    } else if (operationStatus == "CANCEL_COMPLETE") {
-      finished = true;
-      success = false;
-      message = "Operation Canceled by API or AWS.";
+      if (isRateLimited && attempt < 10) {
+        console.log(`[UPDATE] Status poll ${attempt + 1} rate limited, will retry`);
+        shouldRetry = true;
+      } else {
+        console.error(`[UPDATE] Status poll ${attempt + 1} failed:`, child.stderr);
+      }
+      
+      if (!isRateLimited || attempt >= 10) {
+        return {
+          status: "error",
+          message:
+            `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      try {
+        const currentProgressEvent = JSON.parse(child.stdout);
+        console.log(`[UPDATE] Status poll ${attempt + 1} response:`, JSON.stringify(currentProgressEvent, null, 2));
+        
+        // Log stderr warnings but don't fail if we have valid JSON
+        if (hasStderrError) {
+          console.warn("AWS CLI stderr (non-fatal):", child.stderr);
+        }
+        
+        const operationStatus =
+          currentProgressEvent["ProgressEvent"]["OperationStatus"];
+        if (operationStatus == "SUCCESS") {
+          console.log(`[UPDATE] Operation SUCCESS detected! Resource ID: ${currentProgressEvent["ProgressEvent"]["Identifier"]}`);
+          finished = true;
+          success = true;
+          identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
+        } else if (operationStatus == "FAILED") {
+          console.log(`[UPDATE] Operation FAILED: ${currentProgressEvent["ProgressEvent"]["StatusMessage"] || currentProgressEvent["ProgressEvent"]["ErrorCode"]}`);
+          finished = true;
+          success = false;
+          message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
+            currentProgressEvent["ProgressEvent"]["ErrorCode"];
+        } else if (operationStatus == "CANCEL_COMPLETE") {
+          console.log(`[UPDATE] Operation CANCELLED`);
+          finished = true;
+          success = false;
+          message = "Operation Canceled by API or AWS.";
+        }
+      } catch (parseError) {
+        console.error("Failed to parse AWS response:", parseError);
+        console.error("Raw stdout:", child.stdout);
+        console.error("Raw stderr:", child.stderr);
+        
+        if (isRateLimited && attempt < 10) {
+          console.log(`[UPDATE] Parse error with rate limiting on attempt ${attempt + 1}, will retry after backoff`);
+          shouldRetry = true;
+        } else {
+          return {
+            status: "error",
+            message: "Unable to parse AWS CloudControl response",
+          };
+        }
+      }
     }
 
-    if (!finished) {
-      console.log("\nWaiting to check status!\n");
-      await delay(wait);
-      if (wait != upperLimit) {
-        wait = wait + 1000;
-      }
+    if (!finished || shouldRetry) {
+      attempt++;
+      const exponentialDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+      const jitter = Math.random() * 0.3 * exponentialDelay;
+      const finalDelay = exponentialDelay + jitter;
+      
+      console.log(`[UPDATE] Waiting ${Math.round(finalDelay)}ms before status poll attempt ${attempt + 1}`);
+      await delay(finalDelay);
     }
   }
 
+  console.log(`[UPDATE] Final result: success=${success}, identifier=${identifier}`);
+  
   if (success) {
-    const child = await siExec.waitUntilEnd("aws", [
-      "cloudcontrol",
-      "get-resource",
-      "--region",
-      _.get(component, "properties.domain.extra.Region", ""),
-      "--type-name",
-      _.get(component, "properties.domain.extra.AwsResourceType", ""),
-      "--identifier",
-      identifier,
-    ]);
+    console.log(`[UPDATE] Starting final refresh for updated resource`);
+    let finalRefreshAttempt = 0;
+    let finalResourceResponse;
 
-    if (child.exitCode !== 0) {
-      console.log("Failed to refresh cloud control resource");
-      console.log(child.stdout);
-      console.error(child.stderr);
-      // FIXME: should track down what happens when the resource doesnt exist
-      //if (child.stderr.includes("ResourceNotFoundException")) {
-      //    console.log("EKS Cluster not found  upstream (ResourceNotFoundException) so removing the resource")
-      //    return {
-      //        status: "ok",
-      //        payload: null,
-      //    };
-      //}
-      return {
-        status: "error",
-        payload: _.get(component, "properties.resource.payload"),
-        message:
-          `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-      };
+    // Retry final refresh operation if rate limited
+    while (finalRefreshAttempt < 10) {
+      const child = await siExec.waitUntilEnd("aws", [
+        "cloudcontrol",
+        "get-resource",
+        "--region",
+        _.get(component, "properties.domain.extra.Region", ""),
+        "--type-name",
+        _.get(component, "properties.domain.extra.AwsResourceType", ""),
+        "--identifier",
+        identifier,
+      ]);
+
+      console.log(`Final refresh attempt ${finalRefreshAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+      if (child.exitCode !== 0) {
+        const isRateLimited = child.stderr.includes("Throttling") || 
+                             child.stderr.includes("TooManyRequests") ||
+                             child.stderr.includes("RequestLimitExceeded") ||
+                             child.stderr.includes("ThrottlingException");
+        
+        if (isRateLimited && finalRefreshAttempt < 9) {
+          console.log(`Final refresh attempt ${finalRefreshAttempt + 1} rate limited, will retry`);
+        } else {
+          console.log("Failed to refresh cloud control resource");
+          console.log(child.stdout);
+          console.error(`Final refresh attempt ${finalRefreshAttempt + 1} failed:`, child.stderr);
+        }
+        
+        if (isRateLimited && finalRefreshAttempt < 9) {
+          finalRefreshAttempt++;
+          const exponentialDelay = Math.min(baseDelay * Math.pow(2, finalRefreshAttempt - 1), maxDelay);
+          const jitter = Math.random() * 0.3 * exponentialDelay;
+          const finalDelay = exponentialDelay + jitter;
+          
+          console.log(`[UPDATE] Final refresh rate limited on attempt ${finalRefreshAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+          await delay(finalDelay);
+          continue;
+        } else {
+          // FIXME: should track down what happens when the resource doesnt exist
+          //if (child.stderr.includes("ResourceNotFoundException")) {
+          //    console.log("EKS Cluster not found  upstream (ResourceNotFoundException) so removing the resource")
+          //    return {
+          //        status: "ok",
+          //        payload: null,
+          //    };
+          //}
+          return {
+            status: "error",
+            payload: _.get(component, "properties.resource.payload"),
+            message:
+              `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+          };
+        }
+      } else {
+        console.log(`[UPDATE] Final refresh successful on attempt ${finalRefreshAttempt + 1}`);
+        finalResourceResponse = JSON.parse(child.stdout);
+        break;
+      }
     }
 
-    const resourceResponse = JSON.parse(child.stdout);
     const payload = JSON.parse(
-      resourceResponse["ResourceDescription"]["Properties"],
+      finalResourceResponse["ResourceDescription"]["Properties"],
     );
+    console.log(`[UPDATE] Returning success with updated payload`);
     return {
       payload,
       status: "ok",
     };
   } else {
+    console.log(`[UPDATE] Returning error: ${message}`);
     return {
       message,
       payload: _.get(component, "properties.resource.payload"),

--- a/bin/clover/src/pipelines/aws/funcs/overrides/AWS::AutoScaling::AutoScalingGroup/actions/awsCloudControlUpdate.ts
+++ b/bin/clover/src/pipelines/aws/funcs/overrides/AWS::AutoScaling::AutoScalingGroup/actions/awsCloudControlUpdate.ts
@@ -9,29 +9,71 @@ async function main(component: Input): Promise<Output> {
 
   let resourceId = component.properties?.si?.resourceId;
 
-  const refreshChild = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "get-resource",
-    "--region",
-    _.get(component, "properties.domain.extra.Region", ""),
-    "--type-name",
-    _.get(component, "properties.domain.extra.AwsResourceType", ""),
-    "--identifier",
-    resourceId,
-  ]);
+  const delay = (time: number) => {
+    return new Promise((res) => {
+      setTimeout(res, time);
+    });
+  };
 
-  if (refreshChild.exitCode !== 0) {
-    console.log("Failed to refresh cloud control resource");
-    console.log(refreshChild.stdout);
-    console.error(refreshChild.stderr);
-    return {
-      status: "error",
-      message:
-        `Update error while fetching current state; exit code ${refreshChild.exitCode}.\n\nSTDOUT:\n\n${refreshChild.stdout}\n\nSTDERR:\n\n${refreshChild.stderr}`,
-    };
+  const baseDelay = 1000;
+  const maxDelay = 120000;
+  let refreshAttempt = 0;
+  let resourceResponse;
+
+  console.log(`Starting AutoScaling Group update operation - initial refresh for resourceId: ${resourceId}, region: ${_.get(component, "properties.domain.extra.Region", "")}`);
+
+  // Retry initial refresh operation if rate limited
+  while (refreshAttempt < 10) {
+    const refreshChild = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "get-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      resourceId,
+    ]);
+
+    console.log(`Initial refresh attempt ${refreshAttempt + 1}: AWS CLI exit code: ${refreshChild.exitCode}`);
+
+    if (refreshChild.exitCode !== 0) {
+      const isRateLimited = refreshChild.stderr.includes("Throttling") || 
+                           refreshChild.stderr.includes("TooManyRequests") ||
+                           refreshChild.stderr.includes("RequestLimitExceeded") ||
+                           refreshChild.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && refreshAttempt < 9) {
+        console.log(`Initial refresh attempt ${refreshAttempt + 1} rate limited, will retry`);
+      } else {
+        console.log("Failed to refresh cloud control resource");
+        console.log(refreshChild.stdout);
+        console.error(`Initial refresh attempt ${refreshAttempt + 1} failed:`, refreshChild.stderr);
+      }
+      
+      if (isRateLimited && refreshAttempt < 9) {
+        refreshAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, refreshAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[ASG-UPDATE] Initial refresh rate limited on attempt ${refreshAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        return {
+          status: "error",
+          message:
+            `Update error while fetching current state; exit code ${refreshChild.exitCode}.\n\nSTDOUT:\n\n${refreshChild.stdout}\n\nSTDERR:\n\n${refreshChild.stderr}`,
+        };
+      }
+    } else {
+      console.log(`[ASG-UPDATE] Initial refresh successful on attempt ${refreshAttempt + 1}`);
+      resourceResponse = JSON.parse(refreshChild.stdout);
+      break;
+    }
   }
 
-  const resourceResponse = JSON.parse(refreshChild.stdout);
   const currentState = JSON.parse(
     resourceResponse["ResourceDescription"]["Properties"],
   );
@@ -85,45 +127,74 @@ async function main(component: Input): Promise<Output> {
   }
   console.log("Computed patch", patch);
 
-  const child = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "update-resource",
-    "--region",
-    _.get(component, "properties.domain.extra.Region", ""),
-    "--type-name",
-    _.get(component, "properties.domain.extra.AwsResourceType", ""),
-    "--identifier",
-    resourceId,
-    "--patch-document",
-    JSON.stringify(patch),
-  ]);
+  let updateAttempt = 0;
+  let progressEvent;
 
-  if (child.exitCode !== 0) {
-    console.error(child.stderr);
-    return {
-      status: "error",
-      message:
-        `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-    };
+  console.log(`Starting AutoScaling Group update operation for resourceId: ${resourceId}`);
+
+  // Retry update operation if rate limited
+  while (updateAttempt < 10) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "update-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      resourceId,
+      "--patch-document",
+      JSON.stringify(patch),
+    ]);
+
+    console.log(`Update attempt ${updateAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+    if (child.exitCode !== 0) {
+      const isRateLimited = child.stderr.includes("Throttling") || 
+                           child.stderr.includes("TooManyRequests") ||
+                           child.stderr.includes("RequestLimitExceeded") ||
+                           child.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && updateAttempt < 9) {
+        console.log(`Update attempt ${updateAttempt + 1} rate limited, will retry`);
+      } else {
+        console.error(`Update attempt ${updateAttempt + 1} failed:`, child.stderr);
+      }
+      
+      if (isRateLimited && updateAttempt < 9) {
+        updateAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, updateAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[ASG-UPDATE] Update rate limited on attempt ${updateAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        return {
+          status: "error",
+          message:
+            `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      console.log(`[ASG-UPDATE] Update successful on attempt ${updateAttempt + 1}`);
+      progressEvent = JSON.parse(child.stdout);
+      console.log(`[ASG-UPDATE] Got progress event:`, JSON.stringify(progressEvent, null, 2));
+      break;
+    }
   }
 
-  const progressEvent = JSON.parse(child.stdout);
-  console.log("Progress Event", progressEvent);
-
-  const delay = (time: number) => {
-    return new Promise((res) => {
-      setTimeout(res, time);
-    });
-  };
+  console.log(`[ASG-UPDATE] Starting status polling for request token: ${_.get(progressEvent, ["ProgressEvent", "RequestToken"])}`);
 
   let finished = false;
   let success = false;
-  let wait = 1000;
-  const upperLimit = 10000;
+  let attempt = 0;
   let message = "";
   let identifier = "";
 
   while (!finished) {
+    console.log(`[ASG-UPDATE] Status poll attempt ${attempt + 1}`);
     const child = await siExec.waitUntilEnd("aws", [
       "cloudcontrol",
       "get-resource-request-status",
@@ -131,77 +202,163 @@ async function main(component: Input): Promise<Output> {
       _.get(component, "properties.domain.extra.Region", ""),
       "--request-token",
       _.get(progressEvent, ["ProgressEvent", "RequestToken"]),
+      "--no-cli-pager",
     ]);
 
+    let shouldRetry = false;
+    console.log(`[ASG-UPDATE] Status poll ${attempt + 1}: exit code ${child.exitCode}, stderr: ${child.stderr ? 'present' : 'none'}`);
+
+    // Check for rate limiting in stderr regardless of exit code
+    const hasStderrError = child.stderr && child.stderr.trim().length > 0;
+    const isRateLimited = hasStderrError && (
+      child.stderr.includes("Throttling") || 
+      child.stderr.includes("TooManyRequests") ||
+      child.stderr.includes("RequestLimitExceeded") ||
+      child.stderr.includes("ThrottlingException")
+    );
+
     if (child.exitCode !== 0) {
-      console.error(child.stderr);
-      return {
-        status: "error",
-        message:
-          `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-      };
-    }
-    const currentProgressEvent = JSON.parse(child.stdout);
-    console.log("Current Progress", currentProgressEvent);
-    const operationStatus =
-      currentProgressEvent["ProgressEvent"]["OperationStatus"];
-    if (operationStatus == "SUCCESS") {
-      finished = true;
-      success = true;
-      identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
-    } else if (operationStatus == "FAILED") {
-      finished = true;
-      success = false;
-      message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
-        currentProgressEvent["ProgressEvent"]["ErrorCode"];
-    } else if (operationStatus == "CANCEL_COMPLETE") {
-      finished = true;
-      success = false;
-      message = "Operation Canceled by API or AWS.";
+      if (isRateLimited && attempt < 10) {
+        console.log(`[ASG-UPDATE] Status poll ${attempt + 1} rate limited, will retry`);
+        shouldRetry = true;
+      } else {
+        console.error(`[ASG-UPDATE] Status poll ${attempt + 1} failed:`, child.stderr);
+      }
+      
+      if (!isRateLimited || attempt >= 10) {
+        return {
+          status: "error",
+          message:
+            `Unable to update; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      try {
+        const currentProgressEvent = JSON.parse(child.stdout);
+        console.log(`[ASG-UPDATE] Status poll ${attempt + 1} response:`, JSON.stringify(currentProgressEvent, null, 2));
+        
+        // Log stderr warnings but don't fail if we have valid JSON
+        if (hasStderrError) {
+          console.warn("AWS CLI stderr (non-fatal):", child.stderr);
+        }
+        
+        const operationStatus =
+          currentProgressEvent["ProgressEvent"]["OperationStatus"];
+        if (operationStatus == "SUCCESS") {
+          console.log(`[ASG-UPDATE] Operation SUCCESS detected! Resource ID: ${currentProgressEvent["ProgressEvent"]["Identifier"]}`);
+          finished = true;
+          success = true;
+          identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
+        } else if (operationStatus == "FAILED") {
+          console.log(`[ASG-UPDATE] Operation FAILED: ${currentProgressEvent["ProgressEvent"]["StatusMessage"] || currentProgressEvent["ProgressEvent"]["ErrorCode"]}`);
+          finished = true;
+          success = false;
+          message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
+            currentProgressEvent["ProgressEvent"]["ErrorCode"];
+        } else if (operationStatus == "CANCEL_COMPLETE") {
+          console.log(`[ASG-UPDATE] Operation CANCELLED`);
+          finished = true;
+          success = false;
+          message = "Operation Canceled by API or AWS.";
+        }
+      } catch (parseError) {
+        console.error("Failed to parse AWS response:", parseError);
+        console.error("Raw stdout:", child.stdout);
+        console.error("Raw stderr:", child.stderr);
+        
+        if (isRateLimited && attempt < 10) {
+          console.log(`[ASG-UPDATE] Parse error with rate limiting on attempt ${attempt + 1}, will retry after backoff`);
+          shouldRetry = true;
+        } else {
+          return {
+            status: "error",
+            message: "Unable to parse AWS CloudControl response",
+          };
+        }
+      }
     }
 
-    if (!finished) {
-      console.log("\nWaiting to check status!\n");
-      await delay(wait);
-      if (wait != upperLimit) {
-        wait = wait + 1000;
-      }
+    if (!finished || shouldRetry) {
+      attempt++;
+      const exponentialDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+      const jitter = Math.random() * 0.3 * exponentialDelay;
+      const finalDelay = exponentialDelay + jitter;
+      
+      console.log(`[ASG-UPDATE] Waiting ${Math.round(finalDelay)}ms before status poll attempt ${attempt + 1}`);
+      await delay(finalDelay);
     }
   }
 
+  console.log(`[ASG-UPDATE] Final result: success=${success}, identifier=${identifier}`);
+  
   if (success) {
-    const child = await siExec.waitUntilEnd("aws", [
-      "cloudcontrol",
-      "get-resource",
-      "--region",
-      _.get(component, "properties.domain.extra.Region", ""),
-      "--type-name",
-      _.get(component, "properties.domain.extra.AwsResourceType", ""),
-      "--identifier",
-      identifier,
-    ]);
+    console.log(`[ASG-UPDATE] Starting final refresh for updated AutoScaling Group`);
+    let finalRefreshAttempt = 0;
+    let finalResourceResponse;
 
-    if (child.exitCode !== 0) {
-      console.log("Failed to refresh cloud control resource");
-      console.log(child.stdout);
-      console.error(child.stderr);
-      return {
-        status: "error",
-        payload: _.get(component, "properties.resource.payload"),
-        message:
-          `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-      };
+    // Retry final refresh operation if rate limited
+    while (finalRefreshAttempt < 10) {
+      const child = await siExec.waitUntilEnd("aws", [
+        "cloudcontrol",
+        "get-resource",
+        "--region",
+        _.get(component, "properties.domain.extra.Region", ""),
+        "--type-name",
+        _.get(component, "properties.domain.extra.AwsResourceType", ""),
+        "--identifier",
+        identifier,
+      ]);
+
+      console.log(`Final refresh attempt ${finalRefreshAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+      if (child.exitCode !== 0) {
+        const isRateLimited = child.stderr.includes("Throttling") || 
+                             child.stderr.includes("TooManyRequests") ||
+                             child.stderr.includes("RequestLimitExceeded") ||
+                             child.stderr.includes("ThrottlingException");
+        
+        if (isRateLimited && finalRefreshAttempt < 9) {
+          console.log(`Final refresh attempt ${finalRefreshAttempt + 1} rate limited, will retry`);
+        } else {
+          console.log("Failed to refresh cloud control resource");
+          console.log(child.stdout);
+          console.error(`Final refresh attempt ${finalRefreshAttempt + 1} failed:`, child.stderr);
+        }
+        
+        if (isRateLimited && finalRefreshAttempt < 9) {
+          finalRefreshAttempt++;
+          const exponentialDelay = Math.min(baseDelay * Math.pow(2, finalRefreshAttempt - 1), maxDelay);
+          const jitter = Math.random() * 0.3 * exponentialDelay;
+          const finalDelay = exponentialDelay + jitter;
+          
+          console.log(`[ASG-UPDATE] Final refresh rate limited on attempt ${finalRefreshAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+          await delay(finalDelay);
+          continue;
+        } else {
+          return {
+            status: "error",
+            payload: _.get(component, "properties.resource.payload"),
+            message:
+              `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+          };
+        }
+      } else {
+        console.log(`[ASG-UPDATE] Final refresh successful on attempt ${finalRefreshAttempt + 1}`);
+        finalResourceResponse = JSON.parse(child.stdout);
+        break;
+      }
     }
 
-    const resourceResponse = JSON.parse(child.stdout);
     const payload = JSON.parse(
-      resourceResponse["ResourceDescription"]["Properties"],
+      finalResourceResponse["ResourceDescription"]["Properties"],
     );
+    console.log(`[ASG-UPDATE] Returning success with updated AutoScaling Group payload`);
     return {
       payload,
       status: "ok",
     };
   } else {
+    console.log(`[ASG-UPDATE] Returning error: ${message}`);
     return {
       message,
       payload: _.get(component, "properties.resource.payload"),

--- a/bin/clover/src/pipelines/aws/funcs/overrides/AWS::EC2::VPNConnection/actions/refresh.ts
+++ b/bin/clover/src/pipelines/aws/funcs/overrides/AWS::EC2::VPNConnection/actions/refresh.ts
@@ -16,30 +16,72 @@ async function main(component: Input): Promise<Output> {
     return output;
   }
 
-  const child = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "get-resource",
-    "--region",
-    _.get(component, "properties.domain.extra.Region", ""),
-    "--type-name",
-    _.get(component, "properties.domain.extra.AwsResourceType", ""),
-    "--identifier",
-    name,
-  ]);
+  const delay = (time: number) => {
+    return new Promise((res) => {
+      setTimeout(res, time);
+    });
+  };
 
-  if (child.exitCode !== 0) {
-    console.error("Failed to refresh cloud control resource");
-    console.log(child.stdout);
-    console.error(child.stderr);
-    return {
-      payload: resource,
-      status: "error",
-      message:
-        `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-    };
+  const baseDelay = 1000;
+  const maxDelay = 120000;
+  let refreshAttempt = 0;
+  let resourceResponse;
+
+  console.log(`Starting VPNConnection refresh operation for resourceId: ${name}, region: ${_.get(component, "properties.domain.extra.Region", "")}`);
+
+  // Retry refresh operation if rate limited
+  while (refreshAttempt < 10) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "get-resource",
+      "--region",
+      _.get(component, "properties.domain.extra.Region", ""),
+      "--type-name",
+      _.get(component, "properties.domain.extra.AwsResourceType", ""),
+      "--identifier",
+      name,
+    ]);
+
+    console.log(`Refresh attempt ${refreshAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+    if (child.exitCode !== 0) {
+      const isRateLimited = child.stderr.includes("Throttling") || 
+                           child.stderr.includes("TooManyRequests") ||
+                           child.stderr.includes("RequestLimitExceeded") ||
+                           child.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && refreshAttempt < 9) {
+        console.log(`Refresh attempt ${refreshAttempt + 1} rate limited, will retry`);
+      } else {
+        console.error("Failed to refresh cloud control resource");
+        console.log(child.stdout);
+        console.error(`Refresh attempt ${refreshAttempt + 1} failed:`, child.stderr);
+      }
+      
+      if (isRateLimited && refreshAttempt < 9) {
+        refreshAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, refreshAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[VPN-REFRESH] Rate limited on attempt ${refreshAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        return {
+          payload: resource,
+          status: "error",
+          message:
+            `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+        };
+      }
+    } else {
+      console.log(`[VPN-REFRESH] Refresh successful on attempt ${refreshAttempt + 1}`);
+      resourceResponse = JSON.parse(child.stdout);
+      break;
+    }
   }
 
-  const resourceResponse = JSON.parse(child.stdout);
   const payload = JSON.parse(
     resourceResponse["ResourceDescription"]["Properties"],
   );
@@ -52,32 +94,65 @@ async function main(component: Input): Promise<Output> {
   if (transitGatewayId) {
     try {
       const vpnConnectionId = payload.VpnConnectionId || name;
+      let attachmentAttempt = 0;
+      let attachmentSuccess = false;
 
-      const attachmentChild = await siExec.waitUntilEnd("aws", [
-        "ec2",
-        "describe-transit-gateway-attachments",
-        "--region",
-        _.get(component, "properties.domain.extra.Region", ""),
-        "--filters",
-        `Name=resource-type,Values=vpn`,
-        `Name=transit-gateway-id,Values=${transitGatewayId}`,
-        `Name=resource-id,Values=${vpnConnectionId}`,
-        "--query",
-        "TransitGatewayAttachments[0]",
-      ]);
+      console.log(`[VPN-REFRESH] Starting Transit Gateway attachment lookup for VPN: ${vpnConnectionId}`);
 
-      if (
-        attachmentChild.exitCode === 0 &&
-        attachmentChild.stdout &&
-        attachmentChild.stdout.trim() !== "null"
-      ) {
-        const attachment = JSON.parse(attachmentChild.stdout);
-        if (attachment?.TransitGatewayAttachmentId) {
-          console.log(
-            `Found Transit Gateway Attachment ID: ${attachment.TransitGatewayAttachmentId}`,
-          );
-          payload.TransitGatewayAttachmentId =
-            attachment.TransitGatewayAttachmentId;
+      // Retry attachment lookup if rate limited
+      while (attachmentAttempt < 10 && !attachmentSuccess) {
+        const attachmentChild = await siExec.waitUntilEnd("aws", [
+          "ec2",
+          "describe-transit-gateway-attachments",
+          "--region",
+          _.get(component, "properties.domain.extra.Region", ""),
+          "--filters",
+          `Name=resource-type,Values=vpn`,
+          `Name=transit-gateway-id,Values=${transitGatewayId}`,
+          `Name=resource-id,Values=${vpnConnectionId}`,
+          "--query",
+          "TransitGatewayAttachments[0]",
+        ]);
+
+        console.log(`Attachment lookup attempt ${attachmentAttempt + 1}: AWS CLI exit code: ${attachmentChild.exitCode}`);
+
+        if (attachmentChild.exitCode !== 0) {
+          const isRateLimited = attachmentChild.stderr.includes("Throttling") || 
+                               attachmentChild.stderr.includes("TooManyRequests") ||
+                               attachmentChild.stderr.includes("RequestLimitExceeded") ||
+                               attachmentChild.stderr.includes("ThrottlingException");
+          
+          if (isRateLimited && attachmentAttempt < 9) {
+            console.log(`Attachment lookup attempt ${attachmentAttempt + 1} rate limited, will retry`);
+            attachmentAttempt++;
+            const exponentialDelay = Math.min(baseDelay * Math.pow(2, attachmentAttempt - 1), maxDelay);
+            const jitter = Math.random() * 0.3 * exponentialDelay;
+            const finalDelay = exponentialDelay + jitter;
+            
+            console.log(`[VPN-REFRESH] Attachment lookup rate limited on attempt ${attachmentAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+            await delay(finalDelay);
+            continue;
+          } else {
+            console.error(`Attachment lookup attempt ${attachmentAttempt + 1} failed:`, attachmentChild.stderr);
+            break;
+          }
+        } else {
+          console.log(`[VPN-REFRESH] Attachment lookup successful on attempt ${attachmentAttempt + 1}`);
+          attachmentSuccess = true;
+          
+          if (
+            attachmentChild.stdout &&
+            attachmentChild.stdout.trim() !== "null"
+          ) {
+            const attachment = JSON.parse(attachmentChild.stdout);
+            if (attachment?.TransitGatewayAttachmentId) {
+              console.log(
+                `Found Transit Gateway Attachment ID: ${attachment.TransitGatewayAttachmentId}`,
+              );
+              payload.TransitGatewayAttachmentId =
+                attachment.TransitGatewayAttachmentId;
+            }
+          }
         }
       }
     } catch (error) {
@@ -85,6 +160,7 @@ async function main(component: Input): Promise<Output> {
     }
   }
 
+  console.log(`[VPN-REFRESH] Final result: success, returning VPN payload`);
   return {
     payload,
     status: "ok",

--- a/bin/clover/src/pipelines/aws/funcs/overrides/AWS::ECS::TaskDefinition/actions/update.ts
+++ b/bin/clover/src/pipelines/aws/funcs/overrides/AWS::ECS::TaskDefinition/actions/update.ts
@@ -21,41 +21,78 @@ async function main(component: Input): Promise<Output> {
   };
   const inputJson = JSON.stringify(inputObject);
 
-  const child = await siExec.waitUntilEnd("aws", [
-    "cloudcontrol",
-    "create-resource",
-    "--region",
-    domain?.extra?.Region || "",
-    "--cli-input-json",
-    inputJson || "",
-  ]);
-
-  if (child.exitCode !== 0) {
-    console.error(child.stderr);
-    return {
-      status: "error",
-      message:
-        `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-    };
-  }
-
-  const progressEvent = JSON.parse(child.stdout);
-  console.log("Progress Event", progressEvent);
-
   const delay = (time: number) => {
     return new Promise((res) => {
       setTimeout(res, time);
     });
   };
 
+  let createAttempt = 0;
+  const baseDelay = 1000;
+  const maxDelay = 120000;
+  let progressEvent;
+
+  console.log(`Starting ECS TaskDefinition update (create) operation for resource type: ${code["TypeName"]}, region: ${domain?.extra?.Region}`);
+
+  // Retry initial create operation if rate limited
+  while (createAttempt < 10) {
+    const child = await siExec.waitUntilEnd("aws", [
+      "cloudcontrol",
+      "create-resource",
+      "--region",
+      domain?.extra?.Region || "",
+      "--cli-input-json",
+      inputJson || "",
+    ]);
+
+    console.log(`Create attempt ${createAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+    if (child.exitCode !== 0) {
+      const isRateLimited = child.stderr.includes("Throttling") || 
+                           child.stderr.includes("TooManyRequests") ||
+                           child.stderr.includes("RequestLimitExceeded") ||
+                           child.stderr.includes("ThrottlingException");
+      
+      if (isRateLimited && createAttempt < 9) {
+        console.log(`Create attempt ${createAttempt + 1} rate limited, will retry`);
+      } else {
+        console.error(`Create attempt ${createAttempt + 1} failed:`, child.stderr);
+      }
+      
+      if (isRateLimited && createAttempt < 9) {
+        createAttempt++;
+        const exponentialDelay = Math.min(baseDelay * Math.pow(2, createAttempt - 1), maxDelay);
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        const finalDelay = exponentialDelay + jitter;
+        
+        console.log(`[ECS-TASKDEF-UPDATE] Create rate limited on attempt ${createAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+        await delay(finalDelay);
+        continue;
+      } else {
+        return {
+          status: "error",
+          message:
+            `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      console.log(`[ECS-TASKDEF-UPDATE] Initial create successful on attempt ${createAttempt + 1}`);
+      progressEvent = JSON.parse(child.stdout);
+      console.log(`[ECS-TASKDEF-UPDATE] Got progress event:`, JSON.stringify(progressEvent, null, 2));
+      break;
+    }
+  }
+
+  console.log(`[ECS-TASKDEF-UPDATE] Starting status polling for request token: ${_.get(progressEvent, ["ProgressEvent", "RequestToken"])}`);
+
   let finished = false;
   let success = false;
-  let wait = 1000;
-  const upperLimit = 10000;
+  let attempt = 0;
   let message = "";
   let identifier = "";
 
   while (!finished) {
+    console.log(`[ECS-TASKDEF-UPDATE] Status poll attempt ${attempt + 1}`);
     const child = await siExec.waitUntilEnd("aws", [
       "cloudcontrol",
       "get-resource-request-status",
@@ -63,75 +100,161 @@ async function main(component: Input): Promise<Output> {
       domain?.extra?.Region || "",
       "--request-token",
       _.get(progressEvent, ["ProgressEvent", "RequestToken"]),
+      "--no-cli-pager",
     ]);
 
-    if (child.exitCode !== 0) {
-      console.error(child.stderr);
-      return {
-        status: "error",
-        message:
-          `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
-      };
-    }
-    const currentProgressEvent = JSON.parse(child.stdout);
-    console.log("Current Progress", currentProgressEvent);
-    const operationStatus =
-      currentProgressEvent["ProgressEvent"]["OperationStatus"];
-    if (operationStatus == "SUCCESS") {
-      finished = true;
-      success = true;
-      identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
-    } else if (operationStatus == "FAILED") {
-      finished = true;
-      success = false;
-      message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
-        currentProgressEvent["ProgressEvent"]["ErrorCode"];
-    } else if (operationStatus == "CANCEL_COMPLETE") {
-      finished = true;
-      success = false;
-      message = "Operation Canceled by API or AWS.";
-    }
+    let shouldRetry = false;
+    console.log(`[ECS-TASKDEF-UPDATE] Status poll ${attempt + 1}: exit code ${child.exitCode}, stderr: ${child.stderr ? 'present' : 'none'}`);
 
-    if (!finished) {
-      console.log("\nWaiting to check status!\n");
-      await delay(wait);
-      if (wait != upperLimit) {
-        wait = wait + 1000;
+    // Check for rate limiting in stderr regardless of exit code
+    const hasStderrError = child.stderr && child.stderr.trim().length > 0;
+    const isRateLimited = hasStderrError && (
+      child.stderr.includes("Throttling") || 
+      child.stderr.includes("TooManyRequests") ||
+      child.stderr.includes("RequestLimitExceeded") ||
+      child.stderr.includes("ThrottlingException")
+    );
+
+    if (child.exitCode !== 0) {
+      if (isRateLimited && attempt < 10) {
+        console.log(`[ECS-TASKDEF-UPDATE] Status poll ${attempt + 1} rate limited, will retry`);
+        shouldRetry = true;
+      } else {
+        console.error(`[ECS-TASKDEF-UPDATE] Status poll ${attempt + 1} failed:`, child.stderr);
+      }
+      
+      if (!isRateLimited || attempt >= 10) {
+        return {
+          status: "error",
+          message:
+            `Unable to create; AWS CLI 2 exited with non zero code: ${child.exitCode}`,
+        };
+      }
+    } else {
+      try {
+        const currentProgressEvent = JSON.parse(child.stdout);
+        console.log(`[ECS-TASKDEF-UPDATE] Status poll ${attempt + 1} response:`, JSON.stringify(currentProgressEvent, null, 2));
+        
+        // Log stderr warnings but don't fail if we have valid JSON
+        if (hasStderrError) {
+          console.warn("AWS CLI stderr (non-fatal):", child.stderr);
+        }
+        
+        const operationStatus =
+          currentProgressEvent["ProgressEvent"]["OperationStatus"];
+        if (operationStatus == "SUCCESS") {
+          console.log(`[ECS-TASKDEF-UPDATE] Operation SUCCESS detected! Resource ID: ${currentProgressEvent["ProgressEvent"]["Identifier"]}`);
+          finished = true;
+          success = true;
+          identifier = currentProgressEvent["ProgressEvent"]["Identifier"];
+        } else if (operationStatus == "FAILED") {
+          console.log(`[ECS-TASKDEF-UPDATE] Operation FAILED: ${currentProgressEvent["ProgressEvent"]["StatusMessage"] || currentProgressEvent["ProgressEvent"]["ErrorCode"]}`);
+          finished = true;
+          success = false;
+          message = currentProgressEvent["ProgressEvent"]["StatusMessage"] ||
+            currentProgressEvent["ProgressEvent"]["ErrorCode"];
+        } else if (operationStatus == "CANCEL_COMPLETE") {
+          console.log(`[ECS-TASKDEF-UPDATE] Operation CANCELLED`);
+          finished = true;
+          success = false;
+          message = "Operation Canceled by API or AWS.";
+        }
+      } catch (parseError) {
+        console.error("Failed to parse AWS response:", parseError);
+        console.error("Raw stdout:", child.stdout);
+        console.error("Raw stderr:", child.stderr);
+        
+        if (isRateLimited && attempt < 10) {
+          console.log(`[ECS-TASKDEF-UPDATE] Parse error with rate limiting on attempt ${attempt + 1}, will retry after backoff`);
+          shouldRetry = true;
+        } else {
+          return {
+            status: "error",
+            message: "Unable to parse AWS CloudControl response",
+          };
+        }
       }
     }
-  }
-  if (success) {
-    const child = await siExec.waitUntilEnd("aws", [
-      "cloudcontrol",
-      "get-resource",
-      "--region",
-      _.get(component, "properties.domain.extra.Region", ""),
-      "--type-name",
-      _.get(component, "properties.domain.extra.AwsResourceType", ""),
-      "--identifier",
-      identifier,
-    ]);
 
-    if (child.exitCode !== 0) {
-      console.log("Failed to refresh cloud control resource");
-      console.log(child.stdout);
-      console.error(child.stderr);
-      return {
-        status: "error",
-        message:
-          `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
-      };
+    if (!finished || shouldRetry) {
+      attempt++;
+      const exponentialDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+      const jitter = Math.random() * 0.3 * exponentialDelay;
+      const finalDelay = exponentialDelay + jitter;
+      
+      console.log(`[ECS-TASKDEF-UPDATE] Waiting ${Math.round(finalDelay)}ms before status poll attempt ${attempt + 1}`);
+      await delay(finalDelay);
+    }
+  }
+  console.log(`[ECS-TASKDEF-UPDATE] Final result: success=${success}, identifier=${identifier}`);
+  
+  if (success) {
+    console.log(`[ECS-TASKDEF-UPDATE] Starting final refresh for created TaskDefinition`);
+    let finalRefreshAttempt = 0;
+    let finalResourceResponse;
+
+    // Retry final refresh operation if rate limited
+    while (finalRefreshAttempt < 10) {
+      const child = await siExec.waitUntilEnd("aws", [
+        "cloudcontrol",
+        "get-resource",
+        "--region",
+        _.get(component, "properties.domain.extra.Region", ""),
+        "--type-name",
+        _.get(component, "properties.domain.extra.AwsResourceType", ""),
+        "--identifier",
+        identifier,
+      ]);
+
+      console.log(`Final refresh attempt ${finalRefreshAttempt + 1}: AWS CLI exit code: ${child.exitCode}`);
+
+      if (child.exitCode !== 0) {
+        const isRateLimited = child.stderr.includes("Throttling") || 
+                             child.stderr.includes("TooManyRequests") ||
+                             child.stderr.includes("RequestLimitExceeded") ||
+                             child.stderr.includes("ThrottlingException");
+        
+        if (isRateLimited && finalRefreshAttempt < 9) {
+          console.log(`Final refresh attempt ${finalRefreshAttempt + 1} rate limited, will retry`);
+        } else {
+          console.log("Failed to refresh cloud control resource");
+          console.log(child.stdout);
+          console.error(`Final refresh attempt ${finalRefreshAttempt + 1} failed:`, child.stderr);
+        }
+        
+        if (isRateLimited && finalRefreshAttempt < 9) {
+          finalRefreshAttempt++;
+          const exponentialDelay = Math.min(baseDelay * Math.pow(2, finalRefreshAttempt - 1), maxDelay);
+          const jitter = Math.random() * 0.3 * exponentialDelay;
+          const finalDelay = exponentialDelay + jitter;
+          
+          console.log(`[ECS-TASKDEF-UPDATE] Final refresh rate limited on attempt ${finalRefreshAttempt}, waiting ${Math.round(finalDelay)}ms before retry`);
+          await delay(finalDelay);
+          continue;
+        } else {
+          return {
+            status: "error",
+            message:
+              `Refresh error; exit code ${child.exitCode}.\n\nSTDOUT:\n\n${child.stdout}\n\nSTDERR:\n\n${child.stderr}`,
+          };
+        }
+      } else {
+        console.log(`[ECS-TASKDEF-UPDATE] Final refresh successful on attempt ${finalRefreshAttempt + 1}`);
+        finalResourceResponse = JSON.parse(child.stdout);
+        break;
+      }
     }
 
-    const resourceResponse = JSON.parse(child.stdout);
     const payload = JSON.parse(
-      resourceResponse["ResourceDescription"]["Properties"],
+      finalResourceResponse["ResourceDescription"]["Properties"],
     );
+    console.log(`[ECS-TASKDEF-UPDATE] Returning success with TaskDefinition payload`);
     return {
       payload,
       status: "ok",
     };
   } else {
+    console.log(`[ECS-TASKDEF-UPDATE] Returning error: ${message}`);
     return {
       message,
       status: "error",


### PR DESCRIPTION
Adds exponential backoff and some jitter to the AWS functions in clover for Create/Delete/Update/Refresh + all overrides where AWS cloud control is called.

I've tested all the CRUD functions with a security group component and 30 create, update, refresh and delete cleanly which was completely impossible before due to rate limiting causing data-model/data issues in the model.

This test should be valid for all other AWS components that don't have an override, as they are CRUD'ed consistently/using the same functions.

For all the overrides I have individually tested the existing behaviour works with a single component, this includes:
- Update for AWS::ECS::TaskDefinition
- Refresh for AWS::EC2::VPNConnection
- Update for AWS::AutoScaling::AutoScalingGroup

Arguably for the above 3 there `could` be a bug in the exponential backoff logic as it wasn't used in my test, but the behaviour won't be any worse than the current resource abandonment/all the logic is an exact 1:1 map to the fully tested ones that aren't overrides, so I feel fairly confident I've covered enough ground here.