### PR TITLE
feat(luminork): When unlocking a schema ensure that it's installed

### DIFF
--- a/lib/luminork-server/src/service/v1/schemas/create_schema.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_schema.rs
@@ -92,6 +92,7 @@ pub async fn create_schema(
         name: payload.name,
         default_variant_id: created_schema_variant.id,
         variant_ids: variants.into_iter().map(|v| v.id).collect(),
+        schema_id: schema.id(),
     }))
 }
 

--- a/lib/luminork-server/src/service/v1/schemas/get_schema.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_schema.rs
@@ -71,6 +71,7 @@ pub async fn get_schema(
         );
 
         return Ok(SchemaResponseV1::Success(GetSchemaV1Response {
+            schema_id,
             name: schema.name,
             default_variant_id,
             variant_ids: variants.into_iter().map(|v| v.id).collect_vec(),
@@ -96,6 +97,7 @@ pub async fn get_schema(
                 );
 
                 return Ok(SchemaResponseV1::Success(GetSchemaV1Response {
+                    schema_id,
                     name: cached_schema.name,
                     default_variant_id: cached_schema.default_variant_id,
                     variant_ids: cached_schema.variant_ids,

--- a/lib/luminork-server/src/service/v1/schemas/mod.rs
+++ b/lib/luminork-server/src/service/v1/schemas/mod.rs
@@ -553,6 +553,8 @@ impl From<CachedPropSchemaV1> for PropSchemaV1 {
 #[derive(Serialize, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSchemaV1Response {
+    #[schema(value_type = String)]
+    pub schema_id: SchemaId,
     #[schema(value_type = String, example = "AWS::EC2::Instance")]
     pub name: String,
     #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]


### PR DESCRIPTION
There’s a specific usecase that if you have a schemaId and want to unlock it then we should ensure that it’s installed

Also return the SchemaId from the create_schema endpoint