### PR TITLE
Prevent shortcut delete with mixed components

### DIFF
--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -547,6 +547,10 @@ const deleteComponentIds = ref<ComponentId[]>([]);
 const deleteModalRef = ref<InstanceType<typeof DeleteModal>>();
 
 const componentsStartDelete = (components: ComponentInList[]) => {
+  const atLeastOneGhostedComponent = components.some((c) => c.toDelete);
+  const atLeastOneNormalComponent = components.some((c) => !c.toDelete);
+  if (atLeastOneGhostedComponent && atLeastOneNormalComponent) return;
+  if (components.length < 1) return;
   deleteComponentIds.value = componentIds.value;
   deleteModalRef.value?.open(components);
   close();


### PR DESCRIPTION
## Description

This change aligns the deletion shortcut with the context menu option for deleting selecting components that include a mix of non-ghosted and ghosted components. This fixes scenarios where you can delete an unexpected selection of components (potentially unsafe) and aligns product behavior.

## Screenshot

Right click context menu behavior:

<img width="653" height="255" alt="Screenshot 2025-09-30 at 7 04 58 PM" src="https://github.com/user-attachments/assets/9c42ac6c-c342-4e7e-9ca5-16ea4b79dd0d" />