### PR TITLE
feat(clover): set names correctly

### DIFF
--- a/bin/clover/src/pipelines/dummy/spec.ts
+++ b/bin/clover/src/pipelines/dummy/spec.ts
@@ -170,3 +170,4 @@ export function pkgSpecFromDummy(): ExpandedPkgSpec[] {
 function dummyCategory(schema: SuperSchema): string {
   return schema.typeName;
 }
+

--- a/bin/clover/src/pipelines/hetzner/funcs/management/discover.ts
+++ b/bin/clover/src/pipelines/hetzner/funcs/management/discover.ts
@@ -7,9 +7,14 @@ async function main({ thisComponent }: Input): Promise<Output> {
   }
 
   const endpoint = _.get(thisComponent.properties, ["domain", "extra", "endpoint"], "");
+  const resourceType = _.get(thisComponent.properties, ["domain", "extra", "HetznerResourceType"], "");
 
   if (!endpoint) {
     throw new Error("Endpoint not found in extra properties");
+  }
+
+  if (!resourceType) {
+    throw new Error("HetznerResourceType not found in extra properties");
   }
 
   const create: Output["ops"]["create"] = {};
@@ -40,7 +45,7 @@ async function main({ thisComponent }: Input): Promise<Output> {
     const properties = {
       si: {
         resourceId,
-        type: endpoint,
+        type: resourceType,
       },
       domain: {
         ...resource,
@@ -56,7 +61,7 @@ async function main({ thisComponent }: Input): Promise<Output> {
     }
 
     create[resourceId] = {
-      kind: endpoint,
+      kind: resourceType,
       properties,
       attributes: newAttributes,
     };

--- a/bin/clover/src/pipelines/hetzner/funcs/management/import.ts
+++ b/bin/clover/src/pipelines/hetzner/funcs/management/import.ts
@@ -14,10 +14,19 @@ async function main({
     ["domain", "extra", "endpoint"],
     "",
   );
+  const resourceType = _.get(
+    component.properties,
+    ["domain", "extra", "HetznerResourceType"],
+    "",
+  );
   const resourceId = _.get(component.properties, ["si", "resourceId"], "");
 
   if (!endpoint) {
     throw new Error("Endpoint not found in extra properties");
+  }
+
+  if (!resourceType) {
+    throw new Error("HetznerResourceType not found in extra properties");
   }
 
   if (!resourceId) {
@@ -49,7 +58,7 @@ async function main({
   const properties = {
     si: {
       resourceId,
-      type: endpoint,
+      type: resourceType,
     },
     domain: {
       ...resource,
@@ -65,7 +74,7 @@ async function main({
   }
 
   create[resourceId] = {
-    kind: endpoint,
+    kind: resourceType,
     properties,
     attributes: newAttributes,
   };

--- a/bin/clover/src/pipelines/hetzner/pipeline-steps/addDefaultProps.ts
+++ b/bin/clover/src/pipelines/hetzner/pipeline-steps/addDefaultProps.ts
@@ -7,6 +7,7 @@ import {
   ExpandedPropSpec,
   findPropByName,
 } from "../../../spec/props.ts";
+import { HetznerSchema, SuperSchema } from "../../types.ts";
 
 export interface PropUsageMap {
   createOnly: string[];
@@ -31,6 +32,8 @@ export function addDefaultProps(
       true,
     );
 
+    extraProp.data.hidden = true;
+
     // Create Endpoint prop
     {
       const endpointProp = createScalarProp(
@@ -40,9 +43,26 @@ export function addDefaultProps(
         false,
       );
 
-      endpointProp.data.defaultValue = schema.name;
+      // Get endpoint from the HetznerSchema stored in the variant's superSchema
+      const hSchema = schemaVariant.superSchema as HetznerSchema;
+      endpointProp.data.defaultValue = hSchema?.endpoint || schema.name;
 
       extraProp.entries.push(endpointProp);
+    }
+
+    // Create HetznerResourceType prop
+    {
+      const resourceTypeProp = createScalarProp(
+        "HetznerResourceType",
+        "string",
+        extraProp.metadata.propPath,
+        false,
+      );
+
+      resourceTypeProp.data.defaultValue = schema.name;
+      resourceTypeProp.data.hidden = true;
+
+      extraProp.entries.push(resourceTypeProp);
     }
 
     // Create PropUsageMap

--- a/bin/clover/src/pipelines/hetzner/spec.ts
+++ b/bin/clover/src/pipelines/hetzner/spec.ts
@@ -389,13 +389,17 @@ export function mergeResourceOperations(
     ]),
   );
 
+  // Convert noun to PascalCase for the resource name (e.g., "certificates" -> "Certificate")
+  const resourceName = _.startCase(_.camelCase(noun)).replace(/ /g, "");
+
   const schema: HetznerSchema = {
-    typeName: noun,
+    typeName: `Hetzner::Resource::${resourceName}`,
     description,
-    properties: mergedProperties as Record<string, CfProperty>,
+    properties: normalizedProperties as Record<string, CfProperty>,
     requiredProperties,
     primaryIdentifier: ["id"],
     handlers,
+    endpoint: noun,
   };
 
   return { schema, onlyProperties };
@@ -428,8 +432,12 @@ export function createDocLink(
 }
 
 export function hCategory(schema: SuperSchema): string {
-  const name = _.camelCase(schema.typeName.replace("_", " "));
-  return `Hetzner::${name}`;
+  // Split by :: to extract the category (e.g., "Hetzner::Resource::Certificate" -> "Hetzner::Resource")
+  const parts = schema.typeName.split("::");
+  if (parts.length >= 2) {
+    return `${parts[0]}::${parts[1]}`;
+  }
+  return schema.typeName;
 }
 
 function normalizeOnlyProperties(props: string[]): string[] {

--- a/bin/clover/src/pipelines/types.ts
+++ b/bin/clover/src/pipelines/types.ts
@@ -137,6 +137,7 @@ export type HetznerSchema = {
   requiredProperties: Set<string>;
   primaryIdentifier: JSONPointer[];
   handlers?: Record<CfHandlerKind, CfHandler>;
+  endpoint?: string;
 };
 
 export type HDB = Record<string, HetznerSchema>;

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -67,8 +67,8 @@ export interface PropSuggestion {
 function isPropSuggestionArray(value: unknown): value is PropSuggestion[] {
   return Array.isArray(value) &&
     (value.length === 0 ||
-     (typeof value[0] === 'object' && value[0] !== null &&
-      'schema' in value[0] && 'prop' in value[0]));
+      (typeof value[0] === "object" && value[0] !== null &&
+        "schema" in value[0] && "prop" in value[0]));
 }
 
 interface PropSpecOverrides {
@@ -433,7 +433,10 @@ export function createPropFromCf(
 
     return prop;
   } else if (normalizedCfProp.type === "object") {
-    if (normalizedCfProp.patternProperties || normalizedCfProp.additionalProperties) {
+    if (
+      normalizedCfProp.patternProperties ||
+      normalizedCfProp.additionalProperties
+    ) {
       const prop = partialProp as ExpandedPropSpecFor["map"];
       prop.kind = "map";
       prop.data.widgetKind = "Map";
@@ -461,7 +464,9 @@ export function createPropFromCf(
       }
 
       if (!cfItemProp) {
-        throw new Error("could not extract type from pattern prop or additionalProperties");
+        throw new Error(
+          "could not extract type from pattern prop or additionalProperties",
+        );
       }
 
       queue.push({


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

* Set the asset names to things like `Hetzner::Credential::ApiToken` and `Hetzner::Resource::Certificate`
* Ensure the Extra prop has the name and the endpoint correct

#### Screenshots:

<img width="1414" height="497" alt="image" src="https://github.com/user-attachments/assets/69ea3f52-a6c9-414e-898d-95879df491d4" />


## How was it tested?

Manually! You know the drill by now.
<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdldnh2ZG1mbWlmbnR0NjY4dm5mNjhwZnpiaTlvc2dyMjkxcGdvcTZnYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/FrXjlfNc8Ye7EizoPU/giphy.gif"/>
- [X] Integration tests pass
- [X] Manual test: new functionality works in UI


## In short: [:link:](https://giphy.com/)

