### PR TITLE
chore(sdf,luminork): skip loading snapshot when abandoning a change set

### DIFF
--- a/lib/sdf-server/src/service/v2/change_set/abandon.rs
+++ b/lib/sdf-server/src/service/v2/change_set/abandon.rs
@@ -26,8 +26,8 @@ pub async fn abandon(
 
     let mut change_set = ChangeSet::get_by_id(ctx, change_set_id).await?;
     let old_status = change_set.status;
-    ctx.update_visibility_and_snapshot_to_visibility(change_set.id)
-        .await?;
+    // Skipping the load of the snapshot here as it is not required and be expensive
+    ctx.update_visibility_deprecated(change_set.id.into());
     change_set.abandon(ctx).await?;
 
     ctx.write_audit_log(


### PR DESCRIPTION
This change attempts to reduce the chances error or long waits when abandoning a change set. Prior to this change the workspace snapshot for the target change set was loaded via the
`DalContext::update_visibility_and_snapshot_to_visibility` method. No code in either the SDF or Luminork API handler is using the loaded workspace snapshot, and in the case of another bug, this load led to an error which resulted in not being able to abandon a change set. Finally, the workspace snapshot load can take some time if it is not already in cache, and will take up to 10 seconds if the snapshot is no longer available in the layer cache database (this is due to the current layer cache spin lock retry logic).

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdldm55ZXZicHJwd2ZvdHpoOWRqYzJ3bDQxZ3Jva3djNHB0dG5mNWhocCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l2SpWfPcoeWOtHiZW/giphy.gif"/>