### PR TITLE
fix(typesript-sdk): Ensure we package EMS as part of the TypeScript SDK

### DIFF
--- a/bin/openapi-extractor/sdk-generators/generate-typescript-sdk.sh
+++ b/bin/openapi-extractor/sdk-generators/generate-typescript-sdk.sh
@@ -146,6 +146,7 @@ EOL
     "access": "public"
   },
   "files": [
+    "dist/esm",
     "dist/cjs",
     "README.md",
     "LICENSE",

--- a/generated-sdks/typescript/deno.json
+++ b/generated-sdks/typescript/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@systeminit/api-client",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "TypeScript/JavaScript SDK for the System Initiative Public API",
   "exports": {
     ".": "./index.ts"

--- a/generated-sdks/typescript/package.json
+++ b/generated-sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-initiative-api-client",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "TypeScript/JavaScript SDK for the System Initiative Public API",
   "author": "System Initiative <support@systeminit.com>",
   "repository": {
@@ -51,6 +51,7 @@
     "access": "public"
   },
   "files": [
+    "dist/esm",
     "dist/cjs",
     "README.md",
     "LICENSE",


### PR DESCRIPTION
the version going back to 1.0.0 is fine - we actually inject the version at deploy time as part of our deployment script