### PR TITLE
feat: Component search api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,15 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-convert"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
 name = "async-nats"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,32 +356,6 @@ dependencies = [
  "tracing",
  "tryhard",
  "url",
-]
-
-[[package]]
-name = "async-openai"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d226540b4ecf884b0fb4370008631ccbd9605cf82f98bb504ec8f2cee0810e8"
-dependencies = [
- "async-convert",
- "backoff",
- "base64 0.22.1",
- "bytes",
- "derive_builder",
- "eventsource-stream",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "reqwest-eventsource",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1201,20 +1166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.16",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,16 +1935,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3176,17 +3117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
- "pin-project-lite",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3428,7 @@ dependencies = [
  "futures",
  "nats-std",
  "remain",
+ "serde",
  "serde_json",
  "si-data-nats",
  "si-events",
@@ -3633,12 +3564,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -4183,7 +4108,6 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.29",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -4612,15 +4536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4973,7 +4888,6 @@ dependencies = [
 name = "luminork-server"
 version = "0.1.0"
 dependencies = [
- "async-openai",
  "async-trait",
  "audit-database",
  "auth-api-client",
@@ -4982,6 +4896,7 @@ dependencies = [
  "buck2-resources",
  "chrono",
  "clap",
+ "color-eyre",
  "convert_case 0.6.0",
  "dal",
  "dal-materialized-views",
@@ -5003,6 +4918,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "permissions",
+ "pretty_assertions_sorted",
  "rand 0.8.5",
  "rebaser-client",
  "regex",
@@ -7036,7 +6952,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.29",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7044,32 +6959,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.2",
- "tokio-util",
  "tower 0.5.2",
  "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7339,7 +7236,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -7352,19 +7249,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.2.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -7572,7 +7457,6 @@ dependencies = [
 name = "sdf-server"
 version = "0.1.0"
 dependencies = [
- "async-openai",
  "async-trait",
  "audit-database",
  "auth-api-client",
@@ -7926,36 +7810,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
-dependencies = [
- "bitflags 2.9.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -10514,19 +10375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,6 @@ publish = false
 [workspace.dependencies]
 askama = { version = "0.14.0", features = ["default", "serde_json"] }
 async-nats = { version = "0.39.0", features = ["service"] }
-async-openai = "0.26.0"
 async-recursion = "1.1.1"
 async-trait = "0.1.83"
 aws-config = { version = "=1.5.18", features = ["behavior-version-latest"] } # pinned because very next version (1.6.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code

--- a/app/web/src/newhotness/logic_composables/search.ts
+++ b/app/web/src/newhotness/logic_composables/search.ts
@@ -196,7 +196,7 @@ export function parseSearchTerms(search: string | undefined) {
  *       op: "and",
  *       conditions: [
  *          { op: "fuzzy", value: "MyComponent" },
- *          { op: "known", key: "schema", value: "AWS::EC2::Subnet" },
+ *          { op: "attr", key: "schema", value: "AWS::EC2::Subnet" },
  *          { op: "attr", key: "vpcId", value: "vpc-123" },
  *          { op: "exact", value: "AWS::EC2::Subnet" },
  *       ]

--- a/component/lambda/functions/si_types.py
+++ b/component/lambda/functions/si_types.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 Ulid = NewType("Ulid", str)
 OwnerPk = NewType("OwnerPk", Ulid)
+ChangeSetId = NewType("ChangeSetId", Ulid)
+ComponentId = NewType("ComponentId", Ulid)
 WorkspaceId = NewType("WorkspaceId", Ulid)
 # SQL datetime, i.e. 2024-04-03 12:00:00
 SqlDatetime = NewType("SqlDatetime", str)

--- a/lib/frigg/BUCK
+++ b/lib/frigg/BUCK
@@ -12,6 +12,7 @@ rust_library(
         "//third-party/rust:bytes",
         "//third-party/rust:futures",
         "//third-party/rust:remain",
+        "//third-party/rust:serde",
         "//third-party/rust:serde_json",
         "//third-party/rust:strum",
         "//third-party/rust:thiserror",

--- a/lib/frigg/Cargo.toml
+++ b/lib/frigg/Cargo.toml
@@ -13,6 +13,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 nats-std = { path = "../../lib/nats-std" }
 remain = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }

--- a/lib/luminork-server/BUCK
+++ b/lib/luminork-server/BUCK
@@ -38,7 +38,6 @@ rust_library(
         "//lib/telemetry-http-rs:telemetry-http",
         "//lib/telemetry-rs:telemetry",
         "//lib/veritech-client:veritech-client",
-        "//third-party/rust:async-openai",
         "//third-party/rust:async-trait",
         "//third-party/rust:axum",
         "//third-party/rust:base64",
@@ -81,4 +80,8 @@ rust_library(
     srcs = glob([
         "src/**/*.rs",
     ]),
+    test_unit_deps = [
+        "//third-party/rust:color-eyre",
+        "//third-party/rust:pretty_assertions_sorted",
+    ]
 )

--- a/lib/luminork-server/Cargo.toml
+++ b/lib/luminork-server/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-async-openai = { workspace = true }
 async-trait = { workspace = true }
 audit-database = { path = "../../lib/audit-database" }
 auth-api-client = { path = "../../lib/auth-api-client" }
@@ -82,3 +81,7 @@ url = { workspace = true }
 utoipa = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }
 y-sync = { workspace = true }
+
+[dev-dependencies]
+color-eyre = { workspace = true }
+pretty_assertions_sorted = { workspace = true }

--- a/lib/luminork-server/src/lib.rs
+++ b/lib/luminork-server/src/lib.rs
@@ -30,6 +30,7 @@ pub mod middleware;
 mod nats_multiplexer;
 pub mod routes;
 mod runnable;
+mod search;
 mod server;
 pub mod service;
 mod uds;

--- a/lib/luminork-server/src/search/component.rs
+++ b/lib/luminork-server/src/search/component.rs
@@ -1,0 +1,196 @@
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
+
+use futures::future::try_join_all;
+use itertools::Itertools as _;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_frontend_mv_types::{
+    index::change_set::ChangeSetMvIndexVersion,
+    reference::IndexReference,
+};
+use si_id::{
+    AttributeValueId,
+    ChangeSetId,
+    ComponentId,
+    WorkspacePk,
+};
+use telemetry::prelude::*;
+
+use crate::search::{
+    Error,
+    Result,
+    SearchQuery,
+    SearchTerm,
+};
+
+/// Search for components matching the given query in the given workspace and change set.
+pub async fn search(
+    frigg: &frigg::FriggStore,
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchQuery>,
+) -> Result<Vec<ComponentId>> {
+    // Grab the index first
+    let attribute_trees = attribute_tree_mv_index(frigg, workspace_id, change_set_id).await?;
+
+    // Spawn parallel fetch+match tasks for each component
+    let match_tasks = try_join_all(attribute_trees.map(|index_ref| {
+        tokio::spawn(match_component(
+            frigg.clone(),
+            workspace_id,
+            index_ref,
+            query.clone(),
+        ))
+    }))
+    .await?;
+
+    // Wait for them all to complete and collect the results
+    match_tasks.into_iter().flatten_ok().try_collect()
+}
+
+/// Fetch the AttributeTree MV for a component and match it against the query.
+#[instrument(level = "debug", skip_all, fields(id))]
+async fn match_component(
+    frigg: frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    index_ref: IndexReference,
+    query: Arc<SearchQuery>,
+) -> Result<Option<ComponentId>> {
+    let attribute_tree = attribute_tree_mv(frigg, workspace_pk, index_ref).await?;
+    if match_attribute_tree(&attribute_tree, &query) {
+        Ok(Some(attribute_tree.id))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Match a component against a query or sub-query.
+///
+/// This is called once for each term in the query, and the results are combined according to
+/// query rules (AND, OR, NOT).
+fn match_attribute_tree(attribute_tree: &AttributeTreeForSearch, query: &SearchQuery) -> bool {
+    match query {
+        SearchQuery::MatchValue(term) => {
+            term.match_str(&attribute_tree.component_name)
+                || term.match_str(&attribute_tree.schema_name)
+                || term.match_ulid(attribute_tree.id)
+        }
+        // TODO support schema:, category:, component: and id:
+        SearchQuery::MatchAttr { name, terms } => attribute_tree
+            .attribute_values
+            .values()
+            .filter(|av| match_attr_path(&av.path, name))
+            .any(|av| match_attr_value(&av.value, terms)),
+        SearchQuery::And(queries) => queries
+            .iter()
+            .all(|query| match_attribute_tree(attribute_tree, query)),
+        SearchQuery::Or(queries) => queries
+            .iter()
+            .any(|query| match_attribute_tree(attribute_tree, query)),
+        SearchQuery::Not(sub_query) => !match_attribute_tree(attribute_tree, sub_query),
+        SearchQuery::All => true,
+    }
+}
+
+// Match an attribute value's path against the attribute spec (i.e. Name:value,
+// SecurityGroup/Name:value or /domain/Name:value)
+fn match_attr_path(path: &str, pattern: &str) -> bool {
+    // If it's an absolute path, match the whole thing
+    if pattern.starts_with('/') {
+        return path.eq_ignore_ascii_case(pattern);
+    }
+
+    // Check for relative path:
+    // Name:value should match /domain/SecurityGroup/Name, but not /domain/DeadName.
+    let path = path.as_bytes();
+    let pattern = pattern.as_bytes();
+    if path.len() > pattern.len() {
+        let slash = path.len() - pattern.len() - 1;
+        path[slash] == b'/' && path[(slash + 1)..].eq_ignore_ascii_case(pattern)
+    } else {
+        // If the pattern is longer than the actual path (plus leading slash), it can't match
+        false
+    }
+}
+
+fn match_attr_value(value: &serde_json::Value, terms: &[SearchTerm]) -> bool {
+    // If it was attr: with no value, match anything with that attr.
+    if terms.is_empty() {
+        return true;
+    }
+
+    // Otherwise, match if any of the values match.
+    terms.iter().any(|term| term.match_value(value))
+}
+
+/// A pared-down version of the AttributeTree MV, containing only the fields we need for searching.
+/// That way we don't pay the cost of deserializing everything else.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+struct AttributeTreeForSearch {
+    id: ComponentId,
+    attribute_values: HashMap<AttributeValueId, AttributeValueForSearch>,
+    component_name: String,
+    schema_name: String,
+}
+
+/// A pared-down version of the AttributeTree MV, containing only the fields we need for searching.
+/// That way we don't pay the cost of deserializing everything else.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct AttributeValueForSearch {
+    // pub id: AttributeValueId,
+    // pub key: Option<String>,
+    path: String,
+    // pub prop_id: Option<PropId>,
+    value: serde_json::Value,
+    // pub external_sources: Option<Vec<ExternalSource>>, // this is the detail of where the subscriptions are from
+    // pub is_controlled_by_ancestor: bool, // if ancestor of prop is set by dynamic func, ID of ancestor that sets it
+    // pub is_controlled_by_dynamic_func: bool, // props driven by non-dynamic funcs have a statically set value
+    // pub overridden: bool, // true if this prop has a different controlling func id than the default for this asset
+    // pub validation: Option<ValidationOutput>,
+    // pub secret: Option<Secret>,
+    // TODO remove from here and frontend. Always false right now.
+    // pub has_socket_connection: bool,
+    // pub is_default_source: bool,
+}
+
+async fn attribute_tree_mv_index(
+    frigg: &frigg::FriggStore,
+    workspace_id: WorkspacePk,
+    change_set_id: ChangeSetId,
+) -> Result<impl Iterator<Item = IndexReference>> {
+    // Grab the index
+    // TODO don't convert to JSON and immediately convert to struct--convert straight to struct
+    let Some((index, _)) = frigg
+        .get_change_set_index(workspace_id, change_set_id)
+        .await?
+    else {
+        return Err(Error::ChangeSetIndexNotFound {
+            workspace_id,
+            change_set_id,
+        });
+    };
+    let all_mvs = match serde_json::from_value(index.data)? {
+        ChangeSetMvIndexVersion::V1(v1_index) => v1_index.mv_list,
+        ChangeSetMvIndexVersion::V2(v2_index) => v2_index.mv_list,
+    };
+    Ok(all_mvs.into_iter().filter(|mv| mv.kind == "AttributeTree"))
+}
+
+// Fetch a single AttributeTree MV
+async fn attribute_tree_mv(
+    frigg: frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    IndexReference { kind, id, checksum }: IndexReference,
+) -> Result<AttributeTreeForSearch> {
+    frigg
+        .get_workspace_object_data(workspace_pk, &kind, &id, &checksum)
+        .await?
+        .ok_or(Error::MvNotFound(kind, id, checksum))
+}

--- a/lib/luminork-server/src/search/mod.rs
+++ b/lib/luminork-server/src/search/mod.rs
@@ -1,0 +1,45 @@
+use si_id::{
+    ChangeSetId,
+    WorkspacePk,
+};
+use thiserror::Error;
+
+pub mod component;
+mod parser;
+mod query;
+
+pub use query::{
+    SearchQuery,
+    SearchTerm,
+};
+
+#[remain::sorted]
+#[derive(Debug, Error)]
+pub enum Error {
+    // TODO(jkeiser) this should be inside frigg, no?
+    #[error("change set index not found for workspace {workspace_id}, change set {change_set_id}")]
+    ChangeSetIndexNotFound {
+        workspace_id: WorkspacePk,
+        change_set_id: ChangeSetId,
+    },
+    #[error("frig error: {0}")]
+    Frigg(#[from] frigg::Error),
+    #[error("join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+    // TODO(jkeiser) this should be inside frigg, no?
+    #[error("mv item not found: {0}, {1}, {2} (kind, id, checksum)")]
+    MvNotFound(String, String, String), // kind, id, checksum
+    #[error(
+        "The search parser stopped unexpectedly at position {position} in query '{query_string}'"
+    )]
+    ParserFailed {
+        query_string: String,
+        position: usize,
+    },
+    #[error("serde json error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("workspace snapshot error: {0}")]
+    WorkspaceSnapshot(#[from] dal::WorkspaceSnapshotError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/lib/luminork-server/src/search/parser.rs
+++ b/lib/luminork-server/src/search/parser.rs
@@ -1,0 +1,556 @@
+use super::{
+    Error,
+    Result,
+    SearchQuery,
+    SearchTerm,
+};
+
+/// Parses a search query.
+pub fn parse(query_string: &str) -> Result<SearchQuery> {
+    let mut parser = SearchQueryParser {
+        remaining_query_string: query_string,
+    };
+
+    // Parse the top level query; if there are stray end parentheses, ignore them and continue parsing.
+    let mut queries = vec![];
+    loop {
+        // Parse the next subquery (up to the ) or end of string)
+        if let Some(query) = parser.parse_subquery() {
+            queries.push(query);
+        } else if parser.consume(')') {
+            // If there is a stray end paren, ignore it and continue parsing more exprssions.
+        } else if parser.finished() {
+            break;
+        } else {
+            // This should be impossible, but this avoids an infinite loop if we can't make
+            // progress.
+            return Err(Error::ParserFailed {
+                query_string: query_string.to_string(),
+                position: query_string.len() - parser.remaining_query_string.len(),
+            });
+        }
+    }
+
+    // If there are a bunch of conditions with stray parens between, AND them all together.
+    if queries.len() > 1 {
+        Ok(SearchQuery::And(queries))
+    } else {
+        Ok(queries.into_iter().next().unwrap_or(SearchQuery::All))
+    }
+}
+
+/// Holds state for parsing a search query string.
+struct SearchQueryParser<'a> {
+    remaining_query_string: &'a str,
+}
+
+impl<'a> SearchQueryParser<'a> {
+    /// Parse a sub-query
+    ///
+    /// Returns None if we're at ) or end of string
+    fn parse_subquery(&mut self) -> Option<SearchQuery> {
+        self.parse_or_condition()
+    }
+
+    /// Parse an sub-queries separated by "|"
+    ///
+    /// Consumes |, &/space, !, (), "", value, attr:value
+    ///
+    /// Returns None if we're at ) or end of string
+    fn parse_or_condition(&mut self) -> Option<SearchQuery> {
+        let mut queries = vec![];
+        loop {
+            if let Some(query) = self.parse_and_condition() {
+                queries.push(query);
+            }
+
+            if !self.consume('|') {
+                break;
+            }
+        }
+
+        // If there are multiple queries, OR them together
+        if queries.len() > 1 {
+            Some(SearchQuery::Or(queries))
+        } else {
+            queries.into_iter().next()
+        }
+    }
+
+    /// Parse sub-queries between & (or spaces between terms)
+    ///
+    /// Consumes &/space, !, (), "", value, attr:value
+    ///
+    /// Returns None if we're at |, ) or end of string
+    fn parse_and_condition(&mut self) -> Option<SearchQuery> {
+        let mut queries = vec![];
+        loop {
+            if let Some(query) = self.parse_atom() {
+                queries.push(query);
+            }
+
+            if !(self.consume(' ') || self.consume('&')) {
+                break;
+            }
+        }
+
+        // If there are multiple queries, AND them together
+        if queries.len() > 1 {
+            Some(SearchQuery::And(queries))
+        } else {
+            queries.into_iter().next()
+        }
+    }
+
+    /// Parse a single thing
+    ///
+    /// Consumes !, (), "", value, attr:value
+    ///
+    /// Returns None if we're at &/space, |, ), or end of string
+    fn parse_atom(&mut self) -> Option<SearchQuery> {
+        // Parse parens as a single term (...)
+        if self.consume('(') {
+            let condition = self.parse_subquery();
+            self.consume(')'); // Don't care if it's actually there; end of string closes all parens.
+            return condition;
+        }
+
+        // Parse !expression
+        if self.consume('!') {
+            // Skip whitespace (support ! <term>)
+            while self.consume(' ') {}
+            return self
+                .parse_atom()
+                .map(|term| SearchQuery::Not(Box::new(term)));
+        }
+
+        //
+        // Parse value or attr:value
+        //
+        self.parse_term()
+    }
+
+    /// Parse a value or attr:value term
+    ///
+    /// Consumes "", value, attr:value
+    ///
+    /// Returns None if we're at &/space, |, ), or end of string
+    fn parse_term(&mut self) -> Option<SearchQuery> {
+        // Parse quoted term "..."
+        if self.consume('"') {
+            return Some(SearchQuery::MatchValue(self.parse_quoted_term()));
+        }
+
+        // Read everything up to the next special character or : (first word)
+        // If this is attr:value:str, this will only read "attr" and we'll read "value:str" next.
+        let name_or_value = self
+            .consume_until([' ', '(', ')', '&', '|', '!', '"', ':'])
+            .to_string();
+
+        // Handle attr:value
+        if self.consume(':') {
+            // Special case "::"
+            // If the user types AWS::EC2::Instance, treat the whole thing as a single term
+            // instead of treating it like attr:value (attr="AWS", value=":EC2::Instance"
+            // doesn't seem right generally).
+            if self.consume(':') {
+                let remaining_value = self.consume_until([' ', '(', ')', '&', '|', '!', '"']);
+                return Some(SearchQuery::MatchValue(SearchTerm::Match(format!(
+                    "{name_or_value}::{remaining_value}"
+                ))));
+            }
+
+            let name = name_or_value;
+            let terms = self.parse_attr_terms();
+            return Some(SearchQuery::MatchAttr { name, terms });
+        }
+
+        let value = name_or_value;
+        if value.is_empty() {
+            None
+        } else {
+            Some(SearchQuery::MatchValue(SearchTerm::Match(value)))
+        }
+    }
+
+    /// Parse a quoted value
+    ///
+    /// Consumes until the next quote or end of string
+    ///
+    /// Returns Exact if there is a closing quote, StartsWith if not.
+    fn parse_quoted_term(&mut self) -> SearchTerm {
+        // Read until the next quote or end of string
+        let value = self.consume_until(['"']).to_string();
+        // Parse the final quote.
+        if self.consume('"') {
+            SearchTerm::Exact(value)
+        } else {
+            // unclosed quotes should still show the partial match!
+            SearchTerm::StartsWith(value)
+        }
+    }
+
+    /// Parse the attribute values with | or , immediately between them, as part of
+    /// attr:value1|value2|value3|...
+    ///
+    /// Consumes until &/space, (, ), !, or end of string
+    fn parse_attr_terms(&mut self) -> Vec<SearchTerm> {
+        let mut values = vec![];
+        loop {
+            if let Some(value) = self.parse_attr_value() {
+                values.push(value);
+            }
+
+            // If there's a | or ,, continue parsing more values
+            if !(self.consume('|') || self.consume(',')) {
+                break;
+            }
+        }
+        values
+    }
+
+    /// Parse a single attribute value alternative, like value1 in attr:value1|value2|value3|...
+    ///
+    /// Consumes until &/space, |/,, (, ), !, or end of string
+    ///
+    /// Returns None if we're at &/space, |/,, ), or end of string
+    fn parse_attr_value(&mut self) -> Option<SearchTerm> {
+        // If the string starts with ", we treat it as an exact match value (unless it's not closed, read below)
+        if self.consume('"') {
+            let value = self.consume_until(['"']).to_string();
+            // Consume the closing quote so we can move on
+            if self.consume('"') {
+                Some(SearchTerm::Exact(value))
+            } else {
+                // If there's no close quote, treat it as a startsWith match to improve UX while typing
+                Some(SearchTerm::StartsWith(value))
+            }
+        } else {
+            // No quotes, it's a normal match for the given value
+            let value = self.consume_until([' ', '(', ')', '&', '!', '"', '|', ',']);
+            if value.is_empty() {
+                None
+            } else {
+                Some(SearchTerm::Match(value.to_string()))
+            }
+        }
+    }
+
+    /// Consume the given char if it's next in the string, returning true if it was.
+    fn consume(&mut self, ch: char) -> bool {
+        match self.remaining_query_string.strip_prefix(ch) {
+            Some(remaining) => {
+                self.remaining_query_string = remaining;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Consume all characters until you reach one of the given chars, or end of string.
+    /// Does not consume the found char.
+    fn consume_until<const N: usize>(&mut self, chars: [char; N]) -> &str {
+        let index = self
+            .remaining_query_string
+            .find(chars)
+            .unwrap_or(self.remaining_query_string.len());
+        let (consumed, remaining) = self.remaining_query_string.split_at(index);
+        self.remaining_query_string = remaining;
+        consumed
+    }
+
+    /// Whether we're at the end of the query string.
+    fn finished(&self) -> bool {
+        self.remaining_query_string.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic_in_result_fn)]
+
+    // Test that we can parse the query string "Instance"
+    use color_eyre::Result;
+    use pretty_assertions_sorted::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn parse_simple() -> Result<()> {
+        assert_eq!(
+            parse("Instance")?,
+            SearchQuery::MatchValue(SearchTerm::Match("Instance".to_string()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_exact() -> Result<()> {
+        assert_eq!(
+            parse("\"Instance\"")?,
+            SearchQuery::MatchValue(SearchTerm::Exact("Instance".to_string()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_starts_with() -> Result<()> {
+        assert_eq!(
+            parse("\"Instance")?,
+            SearchQuery::MatchValue(SearchTerm::StartsWith("Instance".to_string()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_exact_without_spaces() -> Result<()> {
+        assert_eq!(
+            parse("ab\"cd\"ef\"gh")?,
+            SearchQuery::And(vec![
+                SearchQuery::MatchValue(SearchTerm::Match("ab".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Exact("cd".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("ef".to_string())),
+                SearchQuery::MatchValue(SearchTerm::StartsWith("gh".to_string())),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_attr() -> Result<()> {
+        assert_eq!(
+            parse("Name:me")?,
+            SearchQuery::MatchAttr {
+                name: "Name".to_string(),
+                terms: vec![SearchTerm::Match("me".to_string())]
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_empty_attr() -> Result<()> {
+        assert_eq!(
+            parse("Name:")?,
+            SearchQuery::MatchAttr {
+                name: "Name".to_string(),
+                terms: vec![]
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_attr_multi() -> Result<()> {
+        assert_eq!(
+            parse("Name:a|b")?,
+            SearchQuery::MatchAttr {
+                name: "Name".to_string(),
+                terms: vec![
+                    SearchTerm::Match("a".to_string()),
+                    SearchTerm::Match("b".to_string())
+                ]
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_attr_multi_varied() -> Result<()> {
+        assert_eq!(
+            parse("Name:a|\"b|c\"|d|e|\"f|g")?,
+            SearchQuery::MatchAttr {
+                name: "Name".to_string(),
+                terms: vec![
+                    SearchTerm::Match("a".to_string()),
+                    SearchTerm::Exact("b|c".to_string()),
+                    SearchTerm::Match("d".to_string()),
+                    SearchTerm::Match("e".to_string()),
+                    SearchTerm::StartsWith("f|g".to_string()),
+                ]
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_attr_exact() -> Result<()> {
+        assert_eq!(
+            parse("Name:\"a|b\"")?,
+            SearchQuery::MatchAttr {
+                name: "Name".to_string(),
+                terms: vec![SearchTerm::Exact("a|b".to_string())]
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_attr_starts_with() -> Result<()> {
+        assert_eq!(
+            parse("Name:\"a|b")?,
+            SearchQuery::MatchAttr {
+                name: "Name".to_string(),
+                terms: vec![SearchTerm::StartsWith("a|b".to_string())]
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_double_colon() -> Result<()> {
+        assert_eq!(
+            parse("AWS::EC2::Instance")?,
+            SearchQuery::MatchValue(SearchTerm::Match("AWS::EC2::Instance".to_string()))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_multiple() -> Result<()> {
+        assert_eq!(
+            parse("ABC D  EF")?,
+            SearchQuery::And(vec![
+                SearchQuery::MatchValue(SearchTerm::Match("ABC".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("D".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("EF".to_string())),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_and() -> Result<()> {
+        assert_eq!(
+            parse("A&B&&C & D& E F &G")?,
+            SearchQuery::And(vec![
+                SearchQuery::MatchValue(SearchTerm::Match("A".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("B".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("C".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("D".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("E".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("F".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("G".to_string())),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_or() -> Result<()> {
+        assert_eq!(
+            parse("A | B|C |D| E")?,
+            SearchQuery::Or(vec![
+                SearchQuery::MatchValue(SearchTerm::Match("A".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("B".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("C".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("D".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("E".to_string())),
+            ]),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_not() -> Result<()> {
+        assert_eq!(
+            parse("!abc")?,
+            SearchQuery::Not(Box::new(SearchQuery::MatchValue(SearchTerm::Match(
+                "abc".to_string()
+            )))),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_not_with_space() -> Result<()> {
+        assert_eq!(
+            parse("! abc")?,
+            SearchQuery::Not(Box::new(SearchQuery::MatchValue(SearchTerm::Match(
+                "abc".to_string()
+            )))),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_and_or_precedence() -> Result<()> {
+        assert_eq!(
+            parse("A&B&&C & D& E F &G | H & I | J")?,
+            SearchQuery::Or(vec![
+                SearchQuery::And(vec![
+                    SearchQuery::MatchValue(SearchTerm::Match("A".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("B".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("C".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("D".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("E".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("F".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("G".to_string())),
+                ]),
+                SearchQuery::And(vec![
+                    SearchQuery::MatchValue(SearchTerm::Match("H".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("I".to_string())),
+                ]),
+                SearchQuery::MatchValue(SearchTerm::Match("J".to_string())),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_attr_multi_or_precedence() -> Result<()> {
+        assert_eq!(
+            parse("a | b | Name:c|d | e | f")?,
+            SearchQuery::Or(vec![
+                SearchQuery::MatchValue(SearchTerm::Match("a".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("b".to_string())),
+                SearchQuery::MatchAttr {
+                    name: "Name".to_string(),
+                    terms: vec![
+                        SearchTerm::Match("c".to_string()),
+                        SearchTerm::Match("d".to_string())
+                    ]
+                },
+                SearchQuery::MatchValue(SearchTerm::Match("e".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("f".to_string())),
+            ]),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_groupings() -> Result<()> {
+        assert_eq!(
+            parse("a b (c|d) & (e|f | !(g|h))")?,
+            SearchQuery::And(vec![
+                SearchQuery::MatchValue(SearchTerm::Match("a".to_string())),
+                SearchQuery::MatchValue(SearchTerm::Match("b".to_string())),
+                SearchQuery::Or(vec![
+                    SearchQuery::MatchValue(SearchTerm::Match("c".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("d".to_string())),
+                ]),
+                SearchQuery::Or(vec![
+                    SearchQuery::MatchValue(SearchTerm::Match("e".to_string())),
+                    SearchQuery::MatchValue(SearchTerm::Match("f".to_string())),
+                    SearchQuery::Not(Box::new(SearchQuery::Or(vec![
+                        SearchQuery::MatchValue(SearchTerm::Match("g".to_string())),
+                        SearchQuery::MatchValue(SearchTerm::Match("h".to_string())),
+                    ]))),
+                ]),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_empty() -> Result<()> {
+        assert_eq!(parse("")?, SearchQuery::All);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_spaces() -> Result<()> {
+        assert_eq!(parse("   ")?, SearchQuery::All);
+        Ok(())
+    }
+}

--- a/lib/luminork-server/src/search/query.rs
+++ b/lib/luminork-server/src/search/query.rs
@@ -1,0 +1,315 @@
+use std::str::FromStr;
+
+use ulid::Ulid;
+
+use crate::search::{
+    Error,
+    Result,
+    parser,
+};
+
+/// A search query
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchQuery {
+    MatchValue(SearchTerm),
+    MatchAttr {
+        name: String,
+        terms: Vec<SearchTerm>,
+    },
+    And(Vec<SearchQuery>),
+    /// One of the sub-queries must match
+    Or(Vec<SearchQuery>),
+    /// The sub-query must not match
+    Not(Box<SearchQuery>),
+    /// Used for the empty query. Matches everything.
+    All,
+}
+
+/// A value to match
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchTerm {
+    /// Match the string, allowing * and such: Instance, AWS::*::*Group
+    Match(String),
+    /// Exact literal match: "AWS::EC2::Instance"
+    Exact(String),
+    /// Match starting with the given string: "AWS::EC2::Inst
+    StartsWith(String),
+}
+
+impl FromStr for SearchQuery {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        parser::parse(s)
+    }
+}
+
+impl SearchTerm {
+    /// Get the inner string, regardless of the type of match
+    pub fn as_str(&self) -> &str {
+        match self {
+            SearchTerm::Exact(s) | SearchTerm::StartsWith(s) | SearchTerm::Match(s) => s,
+        }
+    }
+
+    /// Match a query term against a JSON value (with case-insensitive string matching)
+    pub fn match_value(&self, value: &serde_json::Value) -> bool {
+        match value {
+            serde_json::Value::String(value) => self.match_str(value),
+            serde_json::Value::Bool(value) => self.match_bool(*value),
+            serde_json::Value::Number(value) => self.match_number(value),
+            serde_json::Value::Null => self.match_null(),
+            serde_json::Value::Object(_) | serde_json::Value::Array(_) => false,
+        }
+    }
+
+    /// Match a query term like Instance or "Instance" against a string, case insensitively
+    pub fn match_str(&self, value: &str) -> bool {
+        // TODO handle international case comparison as well. Library? icu? case_sensitive_string?
+        match self {
+            SearchTerm::Match(term) => {
+                // Rust doesn't have a `contains_ignore_ascii_case()` function, so we do it
+                // ourselves by checking if the any subset of bytes in the value *equal* the
+                // query string (ignoring case).
+                let term = term.as_bytes();
+                let value = value.as_bytes();
+                value
+                    .windows(term.len())
+                    .any(|window| window.eq_ignore_ascii_case(term))
+            }
+            SearchTerm::Exact(term) => term.eq_ignore_ascii_case(value),
+            SearchTerm::StartsWith(term) => {
+                // Rust doesn't have a `starts_with_ignore_ascii_case()` function, so we do it
+                // ourselves by checking if the first N bytes of the value *equal* the query string
+                // (ignoring case).
+                //
+                // We use as_bytes() here because s could potentially have multi-byte UTF-8
+                // characters. If you ask whether term="€" (3 bytes) starts with value="a" (1 byte),
+                // term[..value.len()] would panic because it would try to slice in the middle of
+                // the multi-byte character. Using as_bytes() avoids that, but still correctly
+                // checks equality, because it's a byte-by-byte comparison.
+                let term = term.as_bytes();
+                let value = value.as_bytes();
+                if value.len() >= term.len() {
+                    term.eq_ignore_ascii_case(&value[..term.len()])
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Match a query term like "1" or "3.14" against a number (e.g. "1.0" matches 1)
+    pub fn match_number(&self, value: &serde_json::Number) -> bool {
+        // We don't support partial matches for numbers, so we treat quotes and non-quotes the same.
+        let term = self.as_str();
+
+        // Try to parse the term as a number
+        // TODO perf: don't re-parse the term on every attribute we check against. Float parsing
+        // is actually really expensive.
+        // TODO(jkeiser) serde_json doesn't support comparing
+        term.parse().is_ok_and(|term| value == &term)
+    }
+
+    /// Match a query term like "true" or "false" against a bool
+    pub fn match_bool(&self, value: bool) -> bool {
+        // For bools, we only want to check true or false and don't care whether it's quoted or not.
+        let term = self.as_str();
+
+        // TODO t, tr, tru, f, fa, fal should also match given the incremental typing rule
+        if term.eq_ignore_ascii_case("true") {
+            value
+        } else if term.eq_ignore_ascii_case("false") {
+            !value
+        } else {
+            false
+        }
+    }
+
+    /// Match a query term like "null" against a bool
+    pub fn match_null(&self) -> bool {
+        // For null, we only want to check null and don't care whether it's quoted or not.
+        let term = self.as_str();
+
+        // TODO n, nu, nul should also match given the incremental typing rule
+        term.eq_ignore_ascii_case("null")
+    }
+
+    /// Match a query term like "01F8MECHZX3TBDSZ7XRADM79XE" against a ULID
+    pub fn match_ulid(&self, value: impl Into<Ulid>) -> bool {
+        let value = value.into();
+        match self {
+            SearchTerm::Exact(term) | SearchTerm::Match(term) | SearchTerm::StartsWith(term) => {
+                term.parse().is_ok_and(|u| value == u)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use serde_json::Number;
+
+    use super::*;
+
+    #[test]
+    fn match_str() {
+        let term = SearchTerm::Match("Instance".to_string());
+        assert!(term.match_str("Instance")); // exact
+        assert!(term.match_str("instance")); // case
+        assert!(term.match_str("Instances")); // suffix
+        assert!(term.match_str("AWS::EC2::Instance")); // prefix
+        assert!(term.match_str("AWS::EC2::Instances")); // prefix+suffix
+        assert!(!term.match_str("Inst")); // partial (start)
+        assert!(!term.match_str("stan")); // partial (middle)
+        assert!(!term.match_str("ance")); // partial (end)
+        assert!(!term.match_str("")); // empty
+        assert!(!term.match_str("foo")); // something else entirely
+        assert!(!term.match_str("foobario")); // something else entirely of the same length
+    }
+
+    #[test]
+    fn match_str_exact() {
+        let term = SearchTerm::Exact("Instance".to_string());
+        assert!(term.match_str("Instance")); // exact
+        assert!(term.match_str("instance")); // case
+        assert!(!term.match_str("Instances")); // suffix
+        assert!(!term.match_str("AWS::EC2::Instance")); // prefix
+        assert!(!term.match_str("AWS::EC2::Instances")); // prefix+suffix
+        assert!(!term.match_str("Inst")); // partial (start)
+        assert!(!term.match_str("stan")); // partial (middle)
+        assert!(!term.match_str("ance")); // partial (end)
+        assert!(!term.match_str("")); // empty
+        assert!(!term.match_str("foo")); // something else entirely
+        assert!(!term.match_str("foobario")); // something else entirely of the same length
+    }
+
+    #[test]
+    fn match_str_starts_with() {
+        let term = SearchTerm::StartsWith("Instance".to_string());
+        assert!(term.match_str("Instance")); // exact
+        assert!(term.match_str("instance")); // case
+        assert!(term.match_str("Instances")); // suffix
+        assert!(!term.match_str("AWS::EC2::Instance")); // prefix
+        assert!(!term.match_str("AWS::EC2::Instances")); // prefix+suffix
+        assert!(!term.match_str("Inst")); // partial (start)
+        assert!(!term.match_str("stan")); // partial (middle)
+        assert!(!term.match_str("ance")); // partial (end)
+        assert!(!term.match_str("")); // empty
+        assert!(!term.match_str("foo")); // something else entirely
+        assert!(!term.match_str("foobario")); // something else entirely of the same length
+    }
+
+    #[test]
+    fn match_null() {
+        assert!(SearchTerm::Match("null".to_string()).match_null());
+        assert!(SearchTerm::Match("NULL".to_string()).match_null());
+        // TODO These partial ones should eventually match!
+        assert!(!SearchTerm::Match("nul".to_string()).match_null());
+        assert!(!SearchTerm::Match("nu".to_string()).match_null());
+        assert!(!SearchTerm::Match("n".to_string()).match_null());
+
+        assert!(!SearchTerm::Match("nulll".to_string()).match_null());
+        assert!(!SearchTerm::Match("nnull".to_string()).match_null());
+        assert!(!SearchTerm::Match("true".to_string()).match_null());
+        assert!(!SearchTerm::Match("false".to_string()).match_null());
+        assert!(!SearchTerm::Match("0".to_string()).match_null());
+        assert!(!SearchTerm::Match("1".to_string()).match_null());
+    }
+
+    #[test]
+    fn match_bool() {
+        assert!(SearchTerm::Match("true".to_string()).match_bool(true));
+        assert!(SearchTerm::Match("TRUE".to_string()).match_bool(true));
+        // TODO These partial ones should eventually match!
+        assert!(!SearchTerm::Match("tru".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("tr".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("t".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("truee".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("ttrue".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("true".to_string()).match_bool(false));
+
+        assert!(SearchTerm::Match("false".to_string()).match_bool(false));
+        assert!(SearchTerm::Match("FALSE".to_string()).match_bool(false));
+        // TODO These partial ones should eventually match!
+        assert!(!SearchTerm::Match("fals".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("fal".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("fa".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("f".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("falsee".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("ffalse".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("false".to_string()).match_bool(true));
+
+        assert!(!SearchTerm::Match("null".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("null".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("0".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("0".to_string()).match_bool(false));
+        assert!(!SearchTerm::Match("1".to_string()).match_bool(true));
+        assert!(!SearchTerm::Match("1".to_string()).match_bool(false));
+    }
+
+    #[test]
+    fn match_number() {
+        assert!(SearchTerm::Match("0".to_string()).match_number(&0.into()));
+        // assert!(SearchTerm::Match("-0".to_string()).match_number(&0.into()));
+
+        assert!(SearchTerm::Match("1".to_string()).match_number(&1.into()));
+        // assert!(SearchTerm::Match("1.0".to_string()).match_number(&1.into()));
+        // assert!(SearchTerm::Match("1e0".to_string()).match_number(&1.into()));
+        // assert!(SearchTerm::Match("10e-1".to_string()).match_number(&1.into()));
+        // assert!(SearchTerm::Match("0.1e1".to_string()).match_number(&1.into()));
+        // assert!(SearchTerm::Match("01".to_string()).match_number(&1.into()));
+        // assert!(SearchTerm::Match("01.0e0".to_string()).match_number(&1.into()));
+        assert!(
+            !SearchTerm::Match("1".to_string()).match_number(&Number::from_f64(1.0001).unwrap())
+        );
+        assert!(!SearchTerm::Match("1".to_string()).match_number(&0.into()));
+        assert!(!SearchTerm::Match("1".to_string()).match_number(&(-1).into()));
+        assert!(!SearchTerm::Match("1".to_string()).match_number(&10.into()));
+
+        // assert!(SearchTerm::Match("1".to_string()).match_number(&Number::from_f64(1.0).unwrap()));
+        assert!(SearchTerm::Match("1.0".to_string()).match_number(&Number::from_f64(1.0).unwrap()));
+        assert!(SearchTerm::Match("1e0".to_string()).match_number(&Number::from_f64(1.0).unwrap()));
+        assert!(
+            SearchTerm::Match("10e-1".to_string()).match_number(&Number::from_f64(1.0).unwrap())
+        );
+        assert!(
+            SearchTerm::Match("0.1e1".to_string()).match_number(&Number::from_f64(1.0).unwrap())
+        );
+        // assert!(SearchTerm::Match("01".to_string()).match_number(&Number::from_f64(1.0).unwrap()));
+        // assert!(SearchTerm::Match("01.0e0".to_string()).match_number(&1.into()));
+        assert!(
+            !SearchTerm::Match("1".to_string()).match_number(&Number::from_f64(1.0001).unwrap())
+        );
+        assert!(!SearchTerm::Match("1".to_string()).match_number(&0.into()));
+        assert!(!SearchTerm::Match("1".to_string()).match_number(&(-1).into()));
+        assert!(!SearchTerm::Match("1".to_string()).match_number(&10.into()));
+
+        assert!(SearchTerm::Match("-1".to_string()).match_number(&(-1).into()));
+        // assert!(SearchTerm::Match("-1.0".to_string()).match_number(&(-1).into()));
+        assert!(!SearchTerm::Match("-1".to_string()).match_number(&0.into()));
+        assert!(!SearchTerm::Match("-1".to_string()).match_number(&1.into()));
+
+        assert!(SearchTerm::Match("123".to_string()).match_number(&123.into()));
+        assert!(!SearchTerm::Match("123".to_string()).match_number(&1.into()));
+        assert!(!SearchTerm::Match("123".to_string()).match_number(&124.into()));
+
+        assert!(SearchTerm::Match("1.2".to_string()).match_number(&Number::from_f64(1.2).unwrap()));
+        assert!(
+            SearchTerm::Match("1.20".to_string()).match_number(&Number::from_f64(1.2).unwrap())
+        );
+        assert!(
+            SearchTerm::Match("12e-1".to_string()).match_number(&Number::from_f64(1.2).unwrap())
+        );
+        assert!(!SearchTerm::Match("1.2".to_string()).match_number(&1.into()));
+        assert!(
+            !SearchTerm::Match("1.2".to_string()).match_number(&Number::from_f64(-1.2).unwrap())
+        );
+        assert!(
+            !SearchTerm::Match("1.2".to_string()).match_number(&Number::from_f64(1.2001).unwrap())
+        );
+        assert!(!SearchTerm::Match("1.2".to_string()).match_number(&1.into()));
+    }
+}

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -152,6 +152,8 @@ pub enum ComponentsError {
     SchemaVariant(#[from] dal::SchemaVariantError),
     #[error("schema variant upgrade not required")]
     SchemaVariantUpgradeSkipped,
+    #[error("search error: {0}")]
+    Search(#[from] crate::search::Error),
     #[error("secret error: {0}")]
     Secret(#[from] dal::SecretError),
     #[error("secret not found: {0}")]

--- a/lib/sdf-server/BUCK
+++ b/lib/sdf-server/BUCK
@@ -45,7 +45,6 @@ rust_library(
         "//lib/telemetry-http-rs:telemetry-http",
         "//lib/telemetry-rs:telemetry",
         "//lib/veritech-client:veritech-client",
-        "//third-party/rust:async-openai",
         "//third-party/rust:async-trait",
         "//third-party/rust:axum",
         "//third-party/rust:base64",

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-async-openai = { workspace = true }
 async-trait = { workspace = true }
 audit-database = { path = "../../lib/audit-database" }
 auth-api-client = { path = "../../lib/auth-api-client" }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -685,24 +685,6 @@ cargo.rust_library(
     ],
 )
 
-http_archive(
-    name = "async-convert-1.0.0.crate",
-    sha256 = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae",
-    strip_prefix = "async-convert-1.0.0",
-    urls = ["https://static.crates.io/crates/async-convert/1.0.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "async-convert-1.0.0",
-    srcs = [":async-convert-1.0.0.crate"],
-    crate = "async_convert",
-    crate_root = "async-convert-1.0.0.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-    deps = [":async-trait-0.1.88"],
-)
-
 alias(
     name = "async-nats",
     actual = ":async-nats-0.39.0",
@@ -773,53 +755,6 @@ cargo.rust_library(
         ":tracing-0.1.41",
         ":tryhard-0.5.2",
         ":url-2.5.4",
-    ],
-)
-
-alias(
-    name = "async-openai",
-    actual = ":async-openai-0.26.0",
-    visibility = ["PUBLIC"],
-)
-
-http_archive(
-    name = "async-openai-0.26.0.crate",
-    sha256 = "0d226540b4ecf884b0fb4370008631ccbd9605cf82f98bb504ec8f2cee0810e8",
-    strip_prefix = "async-openai-0.26.0",
-    urls = ["https://static.crates.io/crates/async-openai/0.26.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "async-openai-0.26.0",
-    srcs = [":async-openai-0.26.0.crate"],
-    crate = "async_openai",
-    crate_root = "async-openai-0.26.0.crate/src/lib.rs",
-    edition = "2021",
-    features = [
-        "default",
-        "rustls",
-    ],
-    visibility = [],
-    deps = [
-        ":async-convert-1.0.0",
-        ":backoff-0.4.0",
-        ":base64-0.22.1",
-        ":bytes-1.10.1",
-        ":derive_builder-0.20.2",
-        ":eventsource-stream-0.2.3",
-        ":futures-0.3.31",
-        ":rand-0.8.5",
-        ":reqwest-0.12.22",
-        ":reqwest-eventsource-0.6.0",
-        ":secrecy-0.8.0",
-        ":serde-1.0.219",
-        ":serde_json-1.0.141",
-        ":thiserror-1.0.69",
-        ":tokio-1.46.1",
-        ":tokio-stream-0.1.17",
-        ":tokio-util-0.7.15",
-        ":tracing-0.1.41",
     ],
 )
 
@@ -2421,41 +2356,6 @@ cargo.rust_library(
         ":proc-macro2-1.0.95",
         ":quote-1.0.40",
         ":syn-2.0.104",
-    ],
-)
-
-http_archive(
-    name = "backoff-0.4.0.crate",
-    sha256 = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1",
-    strip_prefix = "backoff-0.4.0",
-    urls = ["https://static.crates.io/crates/backoff/0.4.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "backoff-0.4.0",
-    srcs = [":backoff-0.4.0.crate"],
-    crate = "backoff",
-    crate_root = "backoff-0.4.0.crate/src/lib.rs",
-    edition = "2018",
-    features = [
-        "default",
-        "futures",
-        "futures-core",
-        "pin-project-lite",
-        "tokio",
-        "tokio_1",
-    ],
-    named_deps = {
-        "tokio_1": ":tokio-1.46.1",
-    },
-    visibility = [],
-    deps = [
-        ":futures-core-0.3.31",
-        ":getrandom-0.2.16",
-        ":instant-0.1.13",
-        ":pin-project-lite-0.2.16",
-        ":rand-0.8.5",
     ],
 )
 
@@ -6271,32 +6171,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "eventsource-stream-0.2.3.crate",
-    sha256 = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab",
-    strip_prefix = "eventsource-stream-0.2.3",
-    urls = ["https://static.crates.io/crates/eventsource-stream/0.2.3/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "eventsource-stream-0.2.3",
-    srcs = [":eventsource-stream-0.2.3.crate"],
-    crate = "eventsource_stream",
-    crate_root = "eventsource-stream-0.2.3.crate/src/lib.rs",
-    edition = "2018",
-    features = [
-        "default",
-        "std",
-    ],
-    visibility = [],
-    deps = [
-        ":futures-core-0.3.31",
-        ":nom-7.1.3",
-        ":pin-project-lite-0.2.16",
-    ],
-)
-
-http_archive(
     name = "eyre-0.6.12.crate",
     sha256 = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec",
     strip_prefix = "eyre-0.6.12",
@@ -7276,23 +7150,6 @@ cargo.rust_library(
         "alloc",
         "std",
     ],
-    visibility = [],
-)
-
-http_archive(
-    name = "futures-timer-3.0.3.crate",
-    sha256 = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24",
-    strip_prefix = "futures-timer-3.0.3",
-    urls = ["https://static.crates.io/crates/futures-timer/3.0.3/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "futures-timer-3.0.3",
-    srcs = [":futures-timer-3.0.3.crate"],
-    crate = "futures_timer",
-    crate_root = "futures-timer-3.0.3.crate/src/lib.rs",
-    edition = "2018",
     visibility = [],
 )
 
@@ -9228,24 +9085,6 @@ cargo.rust_library(
         ":similar-2.7.0",
         ":walkdir-2.5.0",
     ],
-)
-
-http_archive(
-    name = "instant-0.1.13.crate",
-    sha256 = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222",
-    strip_prefix = "instant-0.1.13",
-    urls = ["https://static.crates.io/crates/instant/0.1.13/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "instant-0.1.13",
-    srcs = [":instant-0.1.13.crate"],
-    crate = "instant",
-    crate_root = "instant-0.1.13.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-    deps = [":cfg-if-1.0.1"],
 )
 
 alias(
@@ -14580,11 +14419,8 @@ cargo.rust_library(
         "json",
         "multipart",
         "rustls-tls",
-        "rustls-tls-native-roots",
-        "rustls-tls-native-roots-no-provider",
         "rustls-tls-webpki-roots",
         "rustls-tls-webpki-roots-no-provider",
-        "stream",
     ],
     visibility = [],
     deps = [
@@ -14603,7 +14439,6 @@ cargo.rust_library(
         ":percent-encoding-2.3.1",
         ":pin-project-lite-0.2.16",
         ":rustls-0.23.29",
-        ":rustls-native-certs-0.8.1",
         ":rustls-pki-types-1.12.0",
         ":serde-1.0.219",
         ":serde_json-1.0.141",
@@ -14611,39 +14446,11 @@ cargo.rust_library(
         ":sync_wrapper-1.0.2",
         ":tokio-1.46.1",
         ":tokio-rustls-0.26.2",
-        ":tokio-util-0.7.15",
         ":tower-0.5.2",
         ":tower-http-0.6.6",
         ":tower-service-0.3.3",
         ":url-2.5.4",
         ":webpki-roots-1.0.2",
-    ],
-)
-
-http_archive(
-    name = "reqwest-eventsource-0.6.0.crate",
-    sha256 = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde",
-    strip_prefix = "reqwest-eventsource-0.6.0",
-    urls = ["https://static.crates.io/crates/reqwest-eventsource/0.6.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "reqwest-eventsource-0.6.0",
-    srcs = [":reqwest-eventsource-0.6.0.crate"],
-    crate = "reqwest_eventsource",
-    crate_root = "reqwest-eventsource-0.6.0.crate/src/lib.rs",
-    edition = "2018",
-    visibility = [],
-    deps = [
-        ":eventsource-stream-0.2.3",
-        ":futures-core-0.3.31",
-        ":futures-timer-3.0.3",
-        ":mime-0.3.17",
-        ":nom-7.1.3",
-        ":pin-project-lite-0.2.16",
-        ":reqwest-0.12.22",
-        ":thiserror-1.0.69",
     ],
 )
 
@@ -16097,10 +15904,10 @@ cargo.rust_library(
             deps = [":openssl-probe-0.1.6"],
         ),
         "macos-arm64": dict(
-            deps = [":security-framework-3.2.0"],
+            deps = [":security-framework-3.5.1"],
         ),
         "macos-x86_64": dict(
-            deps = [":security-framework-3.2.0"],
+            deps = [":security-framework-3.5.1"],
         ),
         "windows-gnu": dict(
             deps = [":schannel-0.1.27"],
@@ -16688,32 +16495,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "secrecy-0.8.0.crate",
-    sha256 = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e",
-    strip_prefix = "secrecy-0.8.0",
-    urls = ["https://static.crates.io/crates/secrecy/0.8.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "secrecy-0.8.0",
-    srcs = [":secrecy-0.8.0.crate"],
-    crate = "secrecy",
-    crate_root = "secrecy-0.8.0.crate/src/lib.rs",
-    edition = "2018",
-    features = [
-        "alloc",
-        "default",
-        "serde",
-    ],
-    visibility = [],
-    deps = [
-        ":serde-1.0.219",
-        ":zeroize-1.8.1",
-    ],
-)
-
-http_archive(
     name = "security-framework-2.11.1.crate",
     sha256 = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02",
     strip_prefix = "security-framework-2.11.1",
@@ -16740,23 +16521,23 @@ cargo.rust_library(
         ":core-foundation-0.9.4",
         ":core-foundation-sys-0.8.7",
         ":libc-0.2.174",
-        ":security-framework-sys-2.14.0",
+        ":security-framework-sys-2.15.0",
     ],
 )
 
 http_archive(
-    name = "security-framework-3.2.0.crate",
-    sha256 = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316",
-    strip_prefix = "security-framework-3.2.0",
-    urls = ["https://static.crates.io/crates/security-framework/3.2.0/download"],
+    name = "security-framework-3.5.1.crate",
+    sha256 = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef",
+    strip_prefix = "security-framework-3.5.1",
+    urls = ["https://static.crates.io/crates/security-framework/3.5.1/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "security-framework-3.2.0",
-    srcs = [":security-framework-3.2.0.crate"],
+    name = "security-framework-3.5.1",
+    srcs = [":security-framework-3.5.1.crate"],
     crate = "security_framework",
-    crate_root = "security-framework-3.2.0.crate/src/lib.rs",
+    crate_root = "security-framework-3.5.1.crate/src/lib.rs",
     edition = "2021",
     features = [
         "OSX_10_12",
@@ -16768,23 +16549,23 @@ cargo.rust_library(
         ":core-foundation-0.10.1",
         ":core-foundation-sys-0.8.7",
         ":libc-0.2.174",
-        ":security-framework-sys-2.14.0",
+        ":security-framework-sys-2.15.0",
     ],
 )
 
 http_archive(
-    name = "security-framework-sys-2.14.0.crate",
-    sha256 = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32",
-    strip_prefix = "security-framework-sys-2.14.0",
-    urls = ["https://static.crates.io/crates/security-framework-sys/2.14.0/download"],
+    name = "security-framework-sys-2.15.0.crate",
+    sha256 = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0",
+    strip_prefix = "security-framework-sys-2.15.0",
+    urls = ["https://static.crates.io/crates/security-framework-sys/2.15.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "security-framework-sys-2.14.0",
-    srcs = [":security-framework-sys-2.14.0.crate"],
+    name = "security-framework-sys-2.15.0",
+    srcs = [":security-framework-sys-2.15.0.crate"],
     crate = "security_framework_sys",
-    crate_root = "security-framework-sys-2.14.0.crate/src/lib.rs",
+    crate_root = "security-framework-sys-2.15.0.crate/src/lib.rs",
     edition = "2021",
     features = [
         "OSX_10_10",
@@ -19384,7 +19165,6 @@ cargo.rust_library(
         "futures-util",
         "hashbrown",
         "io",
-        "io-util",
         "rt",
     ],
     visibility = [],

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -283,15 +283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-convert"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
 name = "async-nats"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,32 +316,6 @@ dependencies = [
  "tracing",
  "tryhard",
  "url",
-]
-
-[[package]]
-name = "async-openai"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d226540b4ecf884b0fb4370008631ccbd9605cf82f98bb504ec8f2cee0810e8"
-dependencies = [
- "async-convert",
- "backoff",
- "base64 0.22.1",
- "bytes",
- "derive_builder",
- "eventsource-stream",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "reqwest-eventsource",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1124,20 +1089,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.16",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
 ]
 
 [[package]]
@@ -2594,17 +2545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
- "pin-project-lite",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,12 +2934,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3821,15 +3755,6 @@ dependencies = [
  "serde",
  "similar",
  "walkdir",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -5719,7 +5644,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.29",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5727,32 +5651,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.2",
- "tokio-util",
  "tower 0.5.2",
  "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6047,7 +5953,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -6302,16 +6208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6326,9 +6222,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
@@ -6339,9 +6235,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7168,7 +7064,6 @@ version = "0.0.0"
 dependencies = [
  "askama",
  "async-nats",
- "async-openai",
  "async-recursion",
  "async-trait",
  "aws-config",
@@ -8363,19 +8258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -30,7 +30,6 @@ publish = false
 [dependencies]
 askama = { version = "0.14.0", features = ["default", "serde_json"] }
 async-nats = { version = "0.39.0", features = ["service"] }
-async-openai = "0.26.0"
 async-recursion = "1.1.1"
 async-trait = "0.1.83"
 aws-config = { version = "=1.5.18", features = ["behavior-version-latest"] } # pinned because very next version (1.6.0) starts pulling in `aws-lc-rs`/`aws-lc-sys` which include native C code


### PR DESCRIPTION
This adds the ability to search for components using the same query syntax as the frontend. Right now, this is just an additional option on top of the Luminork component search, but we will quickly create a new API endpoint so we can deprecate this one.

```
POST /v1/w/:workspaceId/change-sets/:changeSetId/components/search
{ queryString: "Instance region:us-east-1" }

{ components: ['01K4T90DB8FKV6PTD9D85NV2T1', '01K4T90DDMQC17HG3JQ72KJKYB'] }
```

There are three major differences:
* Instead of fuzzy search, searching for bare words like `Instance` will only return things that *contain* the word Instance.
* Attribute path search is now case-insensitive
* Searching for `AWS::EC2::Instance` will now return EC2 instances (this did not work because it was considered an attr search for attributes named "AWS" with value ":EC2::Instance" in the frontend search)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZzJxcDZxbHF5dXh3cTk3NWs0aTIweG0yaGRoNDNoNG16cGdpejltcCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/izspP6uMbMeti/giphy.gif"/>

### How This PR Changes The System

* Adds `queryString` parameter to /components/search in Luminork, runs that to get the initial list of component IDs, and then runs the existing schemaName/category/componentName filters (no change to those).
* New `SearchQuery` module provides generic search string parsing and query utilities, with an eye toward applying search to other things in the future (such as schemas)
* Searches through AttributeTree MVs rather than the graph

#### Out of Scope:

* Wildcards: we support partial matches and exact matches, but we don't use the wildcards like the frontend does right now: you can't do `region:us-*-1`
* Unicode case comparison: right now, we only honor ASCII lower<->upper comparisons when searching for attributes and values.
* New endpoint: we are considering a new endpoint that can return more than just components, but this is a single-step to get the search infrastructure into an existing endpoint.
* Query syntax: no new syntax except the minor changes mentioned above. There is more we'd like to do, including possibilities tag search, schema: attribute search and upgradeable:true search, * in attribute paths, among others
* Perf: there is reason to believe that overhead (possibly from grabbing snapshots we don't use) accounts for most of the 500ms; the difference between searching 2 components vs. 1000 components is about 50ms. We can probably get this *well* within typing time.

## How was it tested?

- [X] Integration tests pass
- [X] New unit tests for syntax and value matching
- [X] Manual test: attribute and non-attribute searches against real components
- [X] Manual test: endpoint works the same when passing existing parameters
- [X] Manual test: endpoint produces correct results when passing a combination of existing parameters and queryString
- [X] Perf test: searching 1000 components takes ~500ms

