### PR TITLE
feat(auth-api): Allow getting workspace details with api token

### DIFF
--- a/bin/auth-api/src/routes/workspace.routes.ts
+++ b/bin/auth-api/src/routes/workspace.routes.ts
@@ -37,7 +37,7 @@ import {
 } from "../services/auth.service";
 import { tracker } from "../lib/tracker";
 import { findLatestTosForUser } from "../services/tos.service";
-import { extractAuthUser, router } from ".";
+import { automationApiRouter, extractAuthUser, router } from ".";
 
 router.get("/workspaces", async (ctx) => {
   const authUser = extractAuthUser(ctx);
@@ -93,7 +93,7 @@ export async function authorizeWorkspaceRoute(
   };
 }
 
-router.get("/workspaces/:workspaceId", async (ctx) => {
+automationApiRouter.get("/workspaces/:workspaceId", async (ctx) => {
   const { workspace } = await authorizeWorkspaceRoute(ctx);
   ctx.body = workspace;
 });


### PR DESCRIPTION
Move the workspace details call to the automation router, which means it can be acessed by web tokens AND api tokens
I need this to get the workspace url from the token, so we can generate nice urls for our users.

Me and @jkeiser  tested it by running locally and ensuring that the api call workspace for both types of tokens
 