### PR TITLE
feat(edda): Deployment MVs can be built incrementally

### DIFF
--- a/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
+++ b/app/web/src/components/Workspace/WorkspaceAdminDashboard.vue
@@ -21,6 +21,18 @@
               @click="updateModuleCache"
             />
           </div>
+          <div class="flex flex-row-reverse gap-sm">
+            <VButton
+              :disabled="adminStore.updatingModuleCacheOperationRunning"
+              class="flex-grow"
+              icon="plus-circle"
+              label="Update module cache and FORCE REBUILD"
+              loadingText="Updating module cache"
+              :loading="adminStore.updatingModuleCacheOperationRunning"
+              tone="success"
+              @click="updateAndRebuildModuleCache"
+            />
+          </div>
         </Stack>
         <Stack class="max-w-xl">
           <h2 class="font-bold text-lg">CLEAR INNIT PARAMETER CACHE</h2>
@@ -114,6 +126,10 @@ onBeforeMount(async () => {
 
 const updateModuleCache = async () => {
   await adminStore.UPDATE_MODULE_CACHE();
+};
+
+const updateAndRebuildModuleCache = async () => {
+  await adminStore.UPDATE_MODULE_CACHE(true);
 };
 
 const clearInnitCache = async () => {

--- a/app/web/src/store/admin.store.ts
+++ b/app/web/src/store/admin.store.ts
@@ -141,14 +141,14 @@ export const useAdminStore = () => {
             url: `${API_PREFIX}/func/runs/${funcRunId}/kill_execution`,
           });
         },
-        async UPDATE_MODULE_CACHE() {
+        async UPDATE_MODULE_CACHE(forceRebuild = false) {
           this.updatingModuleCacheOperationRunning = true;
           this.updatingModuleCacheOperationId = null;
           this.updatingModuleCacheOperationError = undefined;
 
           return new ApiRequest<{ id: string }>({
             method: "post",
-            url: `${API_PREFIX}/update_module_cache`,
+            url: `${API_PREFIX}/update_module_cache?forceRebuild=${forceRebuild}`,
             onSuccess: (response) => {
               this.updatingModuleCacheOperationId = response.id;
             },

--- a/lib/dal-materialized-views/src/cached/schema.rs
+++ b/lib/dal-materialized-views/src/cached/schema.rs
@@ -52,21 +52,10 @@ pub async fn assemble(ctx: DalContext, id: SchemaId) -> crate::Result<CachedSche
         .parse::<SchemaVariantId>()
         .map_err(|_| crate::Error::Schema(dal::SchemaError::UninstalledSchemaNotFound(id)))?;
 
-    // Collect all variant IDs from their unique_ids
-    let mut variant_ids = Vec::new();
-    for variant in &variants {
-        if let Some(unique_id) = variant.unique_id() {
-            if let Ok(variant_id) = unique_id.parse::<SchemaVariantId>() {
-                variant_ids.push(variant_id);
-            }
-        }
-    }
-
     Ok(CachedSchemaMv::new(
         id,
         module.schema_name,
         default_variant_id,
-        variant_ids,
     ))
 }
 

--- a/lib/dal-materialized-views/src/cached/schema/variant.rs
+++ b/lib/dal-materialized-views/src/cached/schema/variant.rs
@@ -191,7 +191,6 @@ pub async fn assemble(
     ctx: DalContext,
     id: SchemaVariantId,
 ) -> crate::Result<CachedSchemaVariantMv> {
-    info!("Assembling CachedSchemaVariantMv: {id}");
     // Find the cached module containing this variant by storing the module info
     for mut module in CachedModule::latest_modules(&ctx).await? {
         let si_pkg = module.si_pkg(&ctx).await?;

--- a/lib/edda-core/src/api_types.rs
+++ b/lib/edda-core/src/api_types.rs
@@ -1,6 +1,7 @@
 pub mod new_change_set_request;
 pub mod rebuild_changed_definitions_request;
 pub mod rebuild_request;
+pub mod rebuild_specific_request;
 pub mod update_request;
 
 pub use acceptable::*;

--- a/lib/edda-core/src/api_types/rebuild_specific_request.rs
+++ b/lib/edda-core/src/api_types/rebuild_specific_request.rs
@@ -1,0 +1,153 @@
+use acceptable::{
+    AllVersions,
+    Container,
+    CurrentContainer,
+    IntoContainer,
+    UpgradeError,
+};
+use serde::Deserialize;
+
+mod v1;
+
+pub use self::v1::RebuildSpecificRequestV1;
+
+#[remain::sorted]
+#[derive(AllVersions, CurrentContainer, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum RebuildSpecificRequestAllVersions {
+    #[acceptable(current)]
+    V1(RebuildSpecificRequestV1),
+}
+
+impl IntoContainer for RebuildSpecificRequestAllVersions {
+    type Container = RebuildSpecificRequest;
+
+    fn into_container(self) -> Result<Self::Container, UpgradeError> {
+        match self {
+            Self::V1(inner) => Ok(Self::Container::new(inner)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        error::Error,
+        fmt,
+        fs::File,
+        io::{
+            self,
+            BufRead as _,
+            BufReader,
+            Read as _,
+        },
+        path::Path,
+    };
+
+    use serde::{
+        Serialize,
+        de::DeserializeOwned,
+    };
+
+    /// Tests that a versioned object will always serialize to the same representation, no matter
+    /// what future versions or changes to the object.
+    ///
+    /// NOTE: It is imperative that incremental refactorings do not lead to a version-incompatible
+    /// or serialize-incompatible change. If a test fails and it's because there is a diff to the
+    /// commiteed `.snap` file, this should be considered a failed refactoring. The remediation is
+    /// to *not* update the `.snap` file but rather to fix the code so that the `.snap` format is
+    /// 100% preserved.
+    pub fn assert_serialize(name: &str, version: u64, serialize: impl Serialize) {
+        insta::with_settings!({
+            snapshot_path => format!("rebuild_specific_request/snapshots-v{version}"),
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+            description => concat!(
+                "\n",
+                "\n",
+                "!!!\n",
+                "!!! System Initiative Developers:\n",
+                "!!!\n",
+                "!!! IMPORTANT:\n",
+                "!!!\n",
+                "!!!     The contents of this snapshot should *never* be modified as it\n",
+                "!!!     represents the serialization of a versioned Rust type. If a tests fails\n",
+                "!!!     with this warning, then something about a Rust type has changed\n",
+                "!!!     the wire serialization of this type and would represent a potential\n",
+                "!!!     production outage or data corruption.\n",
+                "!!!\n",
+                "!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n",
+                "!!!     an out-of-date snapshot or fixture!\n",
+                "!!!\n",
+                "\n",
+                "\n",
+            ),
+        }, {
+            insta::assert_json_snapshot!(name, serialize);
+        });
+    }
+
+    pub fn assert_deserialize<T>(snapshot_name: &str, version: u64, expected: T)
+    where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let actual: T = read_from_snapshot(
+            snapshot_name,
+            &format!("rebuild_specific_request/snapshots-v{version}"),
+        )
+        .expect("failed to deserialize from snapshot");
+
+        assert_eq!(actual, expected);
+    }
+
+    fn read_from_snapshot<T>(name: &str, path: &str) -> Result<T, Box<dyn Error>>
+    where
+        T: fmt::Debug + DeserializeOwned + PartialEq,
+    {
+        let glob = format!("{path}/{name}.snap");
+
+        let mut maybe_obj_result = None;
+        insta::glob!(&glob, |path| {
+            let bytes = read_snapshot_content(path).unwrap();
+
+            maybe_obj_result = Some(serde_json::from_slice(&bytes).map_err(Into::into));
+        });
+
+        match maybe_obj_result {
+            Some(object_result) => object_result,
+            None => Err(Box::new(io::Error::other(format!(
+                "snapshot not found: {glob}"
+            )))),
+        }
+    }
+
+    // Implementation is adapted from the [`insta::Snapshot::from_file`] function.
+    //
+    // See: <https://github.com/mitsuhiko/insta/blob/62bb0a3/insta/src/snapshot.rs#L339-L421>
+    fn read_snapshot_content(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+        let mut f = BufReader::new(File::open(path)?);
+
+        // Skip through the snapshot metadata, that being the first YAML document, where YAML
+        // documents are delimited with a `"---"` line
+        {
+            let mut buf = String::new();
+            f.read_line(&mut buf)?;
+            if buf.trim_end() == "---" {
+                loop {
+                    let read = f.read_line(&mut buf)?;
+                    if read == 0 {
+                        break;
+                    }
+                    if buf[buf.len() - read..].trim_end() == "---" {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf)?;
+
+        Ok(buf)
+    }
+}

--- a/lib/edda-core/src/api_types/rebuild_specific_request/snapshots-v1/serialized.snap
+++ b/lib/edda-core/src/api_types/rebuild_specific_request/snapshots-v1/serialized.snap
@@ -1,0 +1,13 @@
+---
+source: lib/edda-core/src/api_types/rebuild_request.rs
+description: "\n\n!!!\n!!! System Initiative Developers:\n!!!\n!!! IMPORTANT:\n!!!\n!!!     The contents of this snapshot should *never* be modified as it\n!!!     represents the serialization of a versioned Rust type. If a tests fails\n!!!     with this warning, then something about a Rust type has changed\n!!!     the wire serialization of this type and would represent a potential\n!!!     production outage or data corruption.\n!!!\n!!!     Consider this an erroneous behavioral change of the Rust code and *not*\n!!!     an out-of-date snapshot or fixture!\n!!!\n\n\n"
+---
+{
+  "id": "01JQCVVDHXYX6S9YCV773R13MG",
+  "removedSchemaIds": [
+    "01JQCVVDHXYX6S9YCV773R13MG"
+  ],
+  "newModules": {
+    "01JQCVVDHXYX6S9YCV773R13MG": "01JQCVVDHXYX6S9YCV773R13MG"
+  }
+}

--- a/lib/edda-core/src/api_types/rebuild_specific_request/v1.rs
+++ b/lib/edda-core/src/api_types/rebuild_specific_request/v1.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+
+use acceptable::{
+    RequestId,
+    Versioned,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_events::{
+    CachedModuleId,
+    SchemaId,
+};
+
+#[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq, Versioned)]
+#[serde(rename_all = "camelCase")]
+#[acceptable(version = 1)]
+// NOTE: **do not modify this datatype--it represents a historically stable, versioned request**
+pub struct RebuildSpecificRequestV1 {
+    pub id: RequestId,
+    pub removed_schema_ids: Vec<SchemaId>,
+    pub new_modules: HashMap<CachedModuleId, SchemaId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::test::*,
+        *,
+    };
+
+    const SNAPSHOT_NAME: &str = "serialized";
+    const VERSION: u64 = 1;
+
+    fn msg() -> RebuildSpecificRequestV1 {
+        RebuildSpecificRequestV1 {
+            id: "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            removed_schema_ids: vec!["01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap()],
+            new_modules: HashMap::from_iter([(
+                "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+                "01JQCVVDHXYX6S9YCV773R13MG".parse().unwrap(),
+            )]),
+        }
+    }
+
+    #[test]
+    fn serialize() {
+        assert_serialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+
+    #[test]
+    fn deserialize() {
+        assert_deserialize(SNAPSHOT_NAME, VERSION, msg());
+    }
+}

--- a/lib/edda-server/src/api_types/deployment_request.rs
+++ b/lib/edda-server/src/api_types/deployment_request.rs
@@ -1,8 +1,13 @@
 use std::{
-    collections::VecDeque,
+    collections::{
+        HashMap,
+        HashSet,
+        VecDeque,
+    },
     result,
 };
 
+use dal::SchemaId;
 use edda_core::api_types::{
     Container,
     ContentInfo,
@@ -10,12 +15,14 @@ use edda_core::api_types::{
     NegotiateError,
     rebuild_changed_definitions_request::RebuildChangedDefinitionsRequest,
     rebuild_request::RebuildRequest,
+    rebuild_specific_request::RebuildSpecificRequest,
 };
 use naxum::async_trait;
 use serde::{
     Deserialize,
     Serialize,
 };
+use si_id::CachedModuleId;
 use strum::AsRefStr;
 use telemetry::prelude::*;
 
@@ -29,6 +36,7 @@ use super::{
 pub enum DeploymentRequest {
     Rebuild(RebuildRequest),
     RebuildChangedDefinitions(RebuildChangedDefinitionsRequest),
+    RebuildSpecific(RebuildSpecificRequest),
 }
 
 impl Negotiate for DeploymentRequest {
@@ -48,6 +56,9 @@ impl Negotiate for DeploymentRequest {
                     RebuildChangedDefinitionsRequest::negotiate(content_info, bytes)?,
                 ))
             }
+            RebuildSpecificRequest::MESSAGE_TYPE => Ok(DeploymentRequest::RebuildSpecific(
+                RebuildSpecificRequest::negotiate(content_info, bytes)?,
+            )),
             unsupported => Err(NegotiateError::UnsupportedContentType(
                 unsupported.to_string(),
             )),
@@ -56,10 +67,19 @@ impl Negotiate for DeploymentRequest {
 }
 
 #[remain::sorted]
-#[derive(AsRefStr, Clone, Debug, Deserialize, Serialize)]
+#[derive(AsRefStr, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum CompressedDeploymentRequest {
-    Rebuild { src_requests_count: usize },
-    RebuildChangedDefinitions { src_requests_count: usize },
+    Rebuild {
+        src_requests_count: usize,
+    },
+    RebuildChangedDefinitions {
+        src_requests_count: usize,
+    },
+    RebuildSpecific {
+        src_requests_count: usize,
+        removed_schema_ids: Vec<SchemaId>,
+        new_modules: HashMap<CachedModuleId, SchemaId>,
+    },
 }
 
 #[async_trait]
@@ -90,6 +110,7 @@ impl CompressFromRequests for CompressedDeploymentRequest {
 
         match Self::inner_from_requests(requests).await {
             Ok(compressed) => {
+                info!("Compressed deployment requests {:?}", compressed);
                 if !span.is_disabled() {
                     span.record(
                         "si.edda.compressed_deployment_request.output",
@@ -109,6 +130,11 @@ impl CompressedDeploymentRequest {
         match self {
             Self::Rebuild { src_requests_count } => *src_requests_count,
             Self::RebuildChangedDefinitions { src_requests_count } => *src_requests_count,
+            Self::RebuildSpecific {
+                src_requests_count,
+                removed_schema_ids: _,
+                new_modules: _,
+            } => *src_requests_count,
         }
     }
 
@@ -132,28 +158,102 @@ impl CompressedDeploymentRequest {
             let has_rebuild_changed_definitions = requests
                 .iter()
                 .any(|r| matches!(r, DeploymentRequest::RebuildChangedDefinitions(_)));
+            let has_rebuild_for_specific = requests
+                .iter()
+                .any(|r| matches!(r, DeploymentRequest::RebuildSpecific(_)));
 
-            match (has_rebuild, has_rebuild_changed_definitions) {
+            match (
+                has_rebuild,
+                has_rebuild_changed_definitions,
+                has_rebuild_for_specific,
+            ) {
                 // If we have any full rebuild requests, prioritize those (full rebuild will also fix out-of-sync definitions)
-                (true, _) => {
+                (true, _, _) => {
                     // `cr_tc02_`
                     // `cr_tc03_`
+                    // `cr_tc06_`
                     Ok(Self::Rebuild { src_requests_count })
                 }
                 // If we only have changed definitions rebuild requests
-                (false, true) => {
+                (false, true, false) => {
                     // `cr_tc04_`
                     Ok(Self::RebuildChangedDefinitions { src_requests_count })
                 }
+                // If we only have specific rebuild requests, merge them into a single one
+                (false, false, true) => {
+                    // `cr_tc07_`
+                    Self::all_specific_updates(requests, src_requests_count)
+                }
+                // If we have a mix of changed definitions and specific rebuild requests, return the specific
+                (false, true, true) => {
+                    // `cr_tc08_`
+                    // `cr_tc09_`
+                    // `cr_tc10_`
+                    Self::all_specific_updates(requests, src_requests_count)
+                }
                 // This case shouldn't happen since we've already checked for empty requests
-                (false, false) => unreachable!(),
+                (false, false, false) => unreachable!(),
             }
         }
+    }
+
+    fn all_specific_updates(
+        requests: VecDeque<DeploymentRequest>,
+        src_requests_count: usize,
+    ) -> Result<CompressedDeploymentRequest> {
+        // Collect all removed schema_ids and new module_ids from the requests
+        let mut removed_schema_ids: HashSet<SchemaId> = HashSet::new();
+        let mut new_modules: HashMap<CachedModuleId, SchemaId> = HashMap::new();
+
+        for request in requests {
+            match request {
+                DeploymentRequest::RebuildSpecific(inner) => {
+                    match inner {
+                        RebuildSpecificRequest::V1(inner_v1) => {
+                            // When processing removals, check if we've previously added a module that contains
+                            // any of the removed schema ids--if so, remove that module from the new_modules list
+                            for removed_schema_id in &inner_v1.removed_schema_ids {
+                                // if we've already said this is a new module/schema, and now we've said to remove it
+                                // add to the removed list and remove the module from the list to build
+                                if new_modules
+                                    .values()
+                                    .any(|schema_id| schema_id == removed_schema_id)
+                                {
+                                    new_modules
+                                        .retain(|_, schema_id| schema_id != removed_schema_id);
+                                }
+                                removed_schema_ids.insert(*removed_schema_id);
+                            }
+
+                            // When processing new modules, check if any of their schema ids are in the removed list--if so,
+                            // remove them from the list to remove as we do in fact want that Id built
+                            for (module_id, new_schema_id) in &inner_v1.new_modules {
+                                // check if we previously said to remove this schema. If so, remove that removal :)
+                                if removed_schema_ids.contains(new_schema_id) {
+                                    removed_schema_ids.remove(new_schema_id);
+                                }
+                                new_modules.insert(*module_id, *new_schema_id);
+                            }
+                        }
+                    }
+                }
+                DeploymentRequest::RebuildChangedDefinitions(_) | DeploymentRequest::Rebuild(_) => {
+                    continue;
+                } // Ignore other types
+            }
+        }
+
+        Ok(Self::RebuildSpecific {
+            src_requests_count,
+            removed_schema_ids: removed_schema_ids.iter().copied().collect(),
+            new_modules,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use si_id::CachedModuleId;
     use test_log::test;
 
     use self::helpers::*;
@@ -286,7 +386,332 @@ mod tests {
         }
     }
 
+    #[allow(clippy::disallowed_methods)] // `$RUST_LOG` is checked for in macro
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    async fn cr_tc07_only_specific_rebuilds() {
+        let first_input_schema_ids = vec![SchemaId::new()];
+        let first_input_module_ids = HashMap::new();
+        let second_input_schema_ids = vec![SchemaId::new()];
+        let second_input_module_ids =
+            HashMap::from_iter([(CachedModuleId::new(), SchemaId::new())]);
+
+        let inputs = vec![
+            rebuild_specific_request(
+                first_input_schema_ids.clone(),
+                first_input_module_ids.clone(),
+            ),
+            rebuild_specific_request(
+                second_input_schema_ids.clone(),
+                second_input_module_ids.clone(),
+            ),
+        ];
+        let requests: Vec<_> = inputs
+            .clone()
+            .into_iter()
+            .map(DeploymentRequest::RebuildSpecific)
+            .collect();
+
+        let compressed = CompressedDeploymentRequest::compress_from_requests(requests.clone())
+            .await
+            .expect("failed to compress requests");
+
+        match compressed {
+            CompressedDeploymentRequest::Rebuild {
+                src_requests_count: _,
+            } => {
+                panic!("there should no mass rebuild requests");
+            }
+            CompressedDeploymentRequest::RebuildChangedDefinitions {
+                src_requests_count: _,
+            } => {
+                panic!("there should no changed definitions rebuild requests");
+            }
+            CompressedDeploymentRequest::RebuildSpecific {
+                src_requests_count,
+                removed_schema_ids: mut schema_ids,
+                new_modules: module_ids,
+            } => {
+                let mut all_input_schema_ids = Vec::new();
+                all_input_schema_ids.extend(first_input_schema_ids);
+                all_input_schema_ids.extend(second_input_schema_ids);
+
+                let mut all_input_module_ids = HashMap::new();
+                all_input_module_ids.extend(first_input_module_ids);
+                all_input_module_ids.extend(second_input_module_ids);
+
+                // Sort the vecs!
+                all_input_schema_ids.sort();
+                schema_ids.sort();
+
+                assert_eq!(requests.len(), src_requests_count);
+                assert_eq!(all_input_schema_ids, schema_ids);
+                assert_eq!(all_input_module_ids, module_ids);
+            }
+        }
+    }
+    #[allow(clippy::disallowed_methods)] // `$RUST_LOG` is checked for in macro
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    async fn cr_tc08_mixed_definition_specific_rebuilds() {
+        let first_input_schema_ids = vec![SchemaId::new()];
+        let first_input_module_ids = HashMap::new();
+        let second_input_schema_ids = vec![SchemaId::new()];
+        let second_input_module_ids =
+            HashMap::from_iter([(CachedModuleId::new(), SchemaId::new())]);
+        let requests = vec![
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                first_input_schema_ids.clone(),
+                first_input_module_ids.clone(),
+            )),
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                second_input_schema_ids.clone(),
+                second_input_module_ids.clone(),
+            )),
+            DeploymentRequest::RebuildChangedDefinitions(rebuild_changed_definitions_request()),
+        ];
+
+        let compressed = CompressedDeploymentRequest::compress_from_requests(requests.clone())
+            .await
+            .expect("failed to compress requests");
+
+        match compressed {
+            CompressedDeploymentRequest::Rebuild {
+                src_requests_count: _,
+            } => {
+                panic!("there should no mass rebuild requests");
+            }
+            CompressedDeploymentRequest::RebuildChangedDefinitions {
+                src_requests_count: _,
+            } => {
+                panic!("there should no changed definitions rebuild requests");
+            }
+            CompressedDeploymentRequest::RebuildSpecific {
+                src_requests_count,
+                removed_schema_ids: mut schema_ids,
+                new_modules: module_ids,
+            } => {
+                let mut all_input_schema_ids = Vec::new();
+                all_input_schema_ids.extend(first_input_schema_ids);
+                all_input_schema_ids.extend(second_input_schema_ids);
+
+                let mut all_input_module_ids = HashMap::new();
+                all_input_module_ids.extend(first_input_module_ids);
+                all_input_module_ids.extend(second_input_module_ids);
+
+                // Sort the vecs!
+                all_input_schema_ids.sort();
+                schema_ids.sort();
+
+                assert_eq!(requests.len(), src_requests_count);
+                assert_eq!(all_input_schema_ids, schema_ids);
+                assert_eq!(all_input_module_ids, module_ids);
+            }
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)] // `$RUST_LOG` is checked for in macro
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    async fn cr_tc09_many_duplicate_specific_rebuilds() {
+        // Create shared IDs that will be duplicated across requests
+        let shared_removed_schema_id1 = SchemaId::new();
+        let shared_removed_schema_id2 = SchemaId::new();
+        let shared_module_id1 = CachedModuleId::new();
+        let shared_module_id2 = CachedModuleId::new();
+        let shared_schema_id1 = SchemaId::new();
+        let shared_schema_id2 = SchemaId::new();
+
+        // Create unique IDs for each request
+        let unique_removed_schema_id1 = SchemaId::new();
+        let unique_removed_schema_id2 = SchemaId::new();
+        let unique_module_id1 = CachedModuleId::new();
+        let unique_module_id2 = CachedModuleId::new();
+        let unique_schema_id1 = SchemaId::new();
+        let unique_schema_id2 = SchemaId::new();
+
+        let requests = vec![
+            // Request 1: Mix of shared and unique removed schemas/variants, and new modules
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![shared_removed_schema_id1, unique_removed_schema_id1],
+                HashMap::from_iter([
+                    (shared_module_id1, shared_schema_id1),
+                    (unique_module_id1, unique_schema_id1),
+                ]),
+            )),
+            // Request 2: Overlapping with request 1, plus new unique IDs
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![
+                    shared_removed_schema_id1,
+                    shared_removed_schema_id2,
+                    unique_removed_schema_id2,
+                ],
+                HashMap::from_iter([
+                    (shared_module_id1, shared_schema_id1), // Duplicate module
+                    (shared_module_id2, shared_schema_id2),
+                ]),
+            )),
+            // Request 3: All shared IDs (should all be duplicates)
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![shared_removed_schema_id1, shared_removed_schema_id2],
+                HashMap::from_iter([
+                    (shared_module_id1, shared_schema_id1),
+                    (shared_module_id2, shared_schema_id2),
+                ]),
+            )),
+            // Request 4: Mix with one more unique ID
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![shared_removed_schema_id2],
+                HashMap::from_iter([(unique_module_id2, unique_schema_id2)]),
+            )),
+        ];
+
+        let compressed = CompressedDeploymentRequest::compress_from_requests(requests.clone())
+            .await
+            .expect("failed to compress requests");
+
+        match compressed {
+            CompressedDeploymentRequest::RebuildSpecific {
+                src_requests_count,
+                mut removed_schema_ids,
+                new_modules,
+            } => {
+                // Expected deduplicated results
+                let mut expected_removed_schema_ids = vec![
+                    shared_removed_schema_id1,
+                    shared_removed_schema_id2,
+                    unique_removed_schema_id1,
+                    unique_removed_schema_id2,
+                ];
+                let mut expected_new_modules: Vec<(CachedModuleId, SchemaId)> = vec![
+                    (shared_module_id1, shared_schema_id1),
+                    (shared_module_id2, shared_schema_id2),
+                    (unique_module_id1, unique_schema_id1),
+                    (unique_module_id2, unique_schema_id2),
+                ];
+
+                // Sort for comparison
+                expected_removed_schema_ids.sort();
+                removed_schema_ids.sort();
+                expected_new_modules.sort();
+                let mut new_modules_vec: Vec<(CachedModuleId, SchemaId)> =
+                    new_modules.into_iter().collect();
+                new_modules_vec.sort();
+
+                assert_eq!(requests.len(), src_requests_count);
+                assert_eq!(
+                    expected_removed_schema_ids, removed_schema_ids,
+                    "Removed schema IDs should be properly deduplicated"
+                );
+                assert_eq!(
+                    expected_new_modules, new_modules_vec,
+                    "New modules should be properly deduplicated"
+                );
+            }
+            _ => panic!("Expected RebuildSpecific variant for specific rebuild requests"),
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)] // `$RUST_LOG` is checked for in macro
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    async fn cr_tc10_conflicting_specific_rebuilds() {
+        // Create schema IDs that will be in conflict scenarios
+        let schema_id_a = SchemaId::new();
+        let schema_id_b = SchemaId::new();
+        let schema_id_c = SchemaId::new();
+        let schema_id_d = SchemaId::new(); // New schema for addition → removal test
+
+        let module_id_1 = CachedModuleId::new();
+        let module_id_2 = CachedModuleId::new();
+        let module_id_3 = CachedModuleId::new();
+        let module_id_4 = CachedModuleId::new();
+
+        let requests = vec![
+            // Request 1: Remove schema_id_a and its variants, add new modules for schema_id_b and schema_id_d
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![schema_id_a], // Remove schema A
+                HashMap::from_iter([
+                    (module_id_1, schema_id_b), // Add module for schema B
+                    (module_id_4, schema_id_d), // Add module for schema D
+                ]),
+            )),
+            // Request 2: Add new modules for schema_id_a (which was previously marked for removal) and schema_id_c
+            // This should CANCEL the removal of schema_id_a from request 1
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![], // No removals in this request
+                HashMap::from_iter([
+                    (module_id_2, schema_id_a), // Add module for schema A (conflicts with removal!)
+                    (module_id_3, schema_id_c), // Add module for schema C
+                ]),
+            )),
+            // Request 3: Try to remove schema_id_b (which has a module from request 1)
+            // This should CANCEL the addition of module for schema_id_b from request 1
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![schema_id_b], // Remove schema B
+                HashMap::new(),    // No new modules
+            )),
+            // Request 4: Remove schema_id_d (which was added in request 1) - Addition → Removal scenario
+            // This should CANCEL the addition of module for schema_id_d from request 1
+            DeploymentRequest::RebuildSpecific(rebuild_specific_request(
+                vec![schema_id_d], // Remove schema D
+                HashMap::new(),    // No new modules
+            )),
+        ];
+
+        let compressed = CompressedDeploymentRequest::compress_from_requests(requests.clone())
+            .await
+            .expect("failed to compress requests");
+
+        match compressed {
+            CompressedDeploymentRequest::RebuildSpecific {
+                src_requests_count,
+                removed_schema_ids,
+                new_modules,
+            } => {
+                // Build the expected final request shape after conflict resolution
+                // Expected results after conflict resolution:
+                // - schema_id_a: Was removed in req1, but added back in req2 -> should NOT be in removed list
+                // - schema_id_b: Module added in req1, but schema removed in req3 -> schema should be removed
+                //   and module addition canceled
+                // - schema_id_d: Module added in req1, but schema removed in req4 -> schema should be removed
+                // - New modules: should contain modules for schema_id_a and schema_id_c only
+                //   (modules for schema_id_b and schema_id_d should be canceled by their respective removals)
+
+                let expected_request = CompressedDeploymentRequest::RebuildSpecific {
+                    src_requests_count: requests.len(),
+                    removed_schema_ids: {
+                        let mut ids = vec![schema_id_b, schema_id_d];
+                        ids.sort();
+                        ids
+                    },
+                    new_modules: HashMap::from_iter([
+                        (module_id_2, schema_id_a),
+                        (module_id_3, schema_id_c),
+                    ]),
+                };
+
+                // Construct the actual result in the same format for comparison
+                let actual_request = CompressedDeploymentRequest::RebuildSpecific {
+                    src_requests_count,
+                    removed_schema_ids: {
+                        let mut ids = removed_schema_ids;
+                        ids.sort();
+                        ids
+                    },
+                    new_modules,
+                };
+
+                // Assert that the computed result matches our expected shape exactly
+                assert_eq!(
+                    actual_request, expected_request,
+                    "Computed request should match expected shape after conflict resolution"
+                );
+            }
+            _ => panic!("Expected RebuildSpecific variant for specific rebuild requests"),
+        }
+    }
+
     mod helpers {
+        use std::collections::HashMap;
+
+        use dal::SchemaId;
         use edda_core::api_types::{
             Container,
             RequestId,
@@ -298,7 +723,12 @@ mod tests {
                 RebuildRequest,
                 RebuildRequestVCurrent,
             },
+            rebuild_specific_request::{
+                RebuildSpecificRequest,
+                RebuildSpecificRequestVCurrent,
+            },
         };
+        use si_id::CachedModuleId;
 
         pub fn rebuild_request() -> RebuildRequest {
             RebuildRequest::new(RebuildRequestVCurrent {
@@ -309,6 +739,17 @@ mod tests {
         pub fn rebuild_changed_definitions_request() -> RebuildChangedDefinitionsRequest {
             RebuildChangedDefinitionsRequest::new(RebuildChangedDefinitionsRequestV1 {
                 id: RequestId::new(),
+            })
+        }
+
+        pub fn rebuild_specific_request(
+            removed_schema_ids: Vec<SchemaId>,
+            new_modules: HashMap<CachedModuleId, SchemaId>,
+        ) -> RebuildSpecificRequest {
+            RebuildSpecificRequest::new(RebuildSpecificRequestVCurrent {
+                id: RequestId::new(),
+                removed_schema_ids,
+                new_modules,
             })
         }
     }

--- a/lib/edda-server/src/deployment_processor_task.rs
+++ b/lib/edda-server/src/deployment_processor_task.rs
@@ -385,6 +385,20 @@ mod handlers {
                 .await
                 .map_err(Into::into)
             }
+            CompressedDeploymentRequest::RebuildSpecific {
+                src_requests_count: _,
+                removed_schema_ids,
+                new_modules,
+            } => materialized_view::build_specific_for_deployment(
+                ctx,
+                frigg,
+                edda_updates,
+                parallel_build_limit,
+                Some((removed_schema_ids, new_modules)),
+                "selective build based on changes",
+            )
+            .await
+            .map_err(Into::into),
         }
         .inspect(|_| span.record_ok())
         .map_err(|err| span.record_err(err))

--- a/lib/edda-server/src/materialized_view.rs
+++ b/lib/edda-server/src/materialized_view.rs
@@ -104,6 +104,7 @@ pub use change_set::{
 pub use deployment::{
     build_all_mvs_for_deployment,
     build_outdated_mvs_for_deployment,
+    build_specific_for_deployment,
 };
 
 #[remain::sorted]
@@ -360,7 +361,7 @@ where
 
 pub type MvBuilderResult =
     Result<(Option<ObjectPatch>, Option<FrontendObject>), MaterializedViewError>;
-
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum BuildMvOp {
     Create,
     Delete { id: String, checksum: String },

--- a/lib/edda-server/src/materialized_view/deployment.rs
+++ b/lib/edda-server/src/materialized_view/deployment.rs
@@ -1,14 +1,23 @@
 use std::{
-    collections::BinaryHeap,
+    collections::{
+        BinaryHeap,
+        HashMap,
+        HashSet,
+    },
     sync::Arc,
     time::Duration,
 };
 
 use dal::{
     DalContext,
-    cached_module::CachedModuleError,
+    SchemaId,
+    cached_module::{
+        CachedModule,
+        CachedModuleError,
+    },
 };
 use frigg::FriggStore;
+use si_events::CachedModuleId;
 use si_frontend_mv_types::{
     index::deployment::DeploymentMvIndexV2,
     materialized_view::MaterializedView,
@@ -27,6 +36,10 @@ use tokio::{
     task::JoinSet,
     time::Instant,
 };
+use tracing::{
+    Instrument,
+    Span,
+};
 
 use crate::{
     materialized_view::{
@@ -39,6 +52,14 @@ use crate::{
     },
     updates::EddaUpdates,
 };
+
+/// Currently, the client is determining what needs to be deleted or built. This encapsulates that intent
+/// so we don't need to look it up again as we process the build tasks.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Copy)]
+pub enum DeploymentSyncOp {
+    Build,
+    Delete,
+}
 
 /// This function builds all Materialized Views (MVs) this deployment environment
 #[instrument(
@@ -61,9 +82,9 @@ pub async fn build_all_mvs_for_deployment(
     reason_message: &'static str,
 ) -> Result<(), MaterializedViewError> {
     let span = current_span_for_instrument_at!("info");
-
+    info!("Started full rebuild of deployment MVs");
     // Discover all deployment MVs that need to be built
-    let deployment_tasks = discover_deployment_mvs(ctx).await?;
+    let deployment_tasks = all_deployment_mv_tasks(ctx).await?;
 
     // Use the deployment MV parallel processing system
     let (
@@ -116,7 +137,190 @@ pub async fn build_all_mvs_for_deployment(
     edda_updates
         .publish_deployment_index_update(index_update)
         .await?;
+    info!("Finished full rebuild of deployment MVs");
+    Ok(())
+}
 
+type CachedModuleChanges = (Vec<SchemaId>, HashMap<CachedModuleId, SchemaId>);
+/// This function builds all Materialized Views (MVs) this deployment environment
+#[instrument(
+    name = "materialized_view.build_specific_for_deployment",
+    level = "info",
+    skip_all,
+    fields(
+        si.materialized_view.reason = reason_message,
+        si.edda.mv.count = Empty,
+        si.edda.mv.avg_build_elapsed_ms = Empty,
+        si.edda.mv.max_build_elapsed_ms = Empty,
+        si.edda.mv.slowest_kind = Empty,
+        si.edda.mv.combined_changes.count = Empty,
+        si.edda.mv.outdated_mv.kind_count = Empty,
+        si.edda.mv.outdated_mv.total_discovered = Empty,
+    ),
+)]
+pub async fn build_specific_for_deployment(
+    ctx: &DalContext,
+    frigg: &FriggStore,
+    edda_updates: &EddaUpdates,
+    parallel_build_limit: usize,
+    mv_ids: Option<CachedModuleChanges>,
+    reason_message: &'static str,
+) -> Result<(), MaterializedViewError> {
+    let span = current_span_for_instrument_at!("info");
+    info!("Started building outdated deployment MVs");
+    // Get existing deployment index to compare checksums
+    let existing_deployment_index_frontend_object = frigg.get_deployment_index().await?;
+    let existing_deployment_index = match existing_deployment_index_frontend_object {
+        Some((deployment_index_obj, _)) => {
+            // Parse the deployment index to get the stored definition checksums
+            match serde_json::from_value::<
+                si_frontend_mv_types::index::deployment::DeploymentMvIndexVersion,
+            >(deployment_index_obj.data)
+            {
+                Ok(si_frontend_mv_types::index::deployment::DeploymentMvIndexVersion::V1(_)) => {
+                    // We don't have enough information to determine which MV kinds have had definition changes.
+                    return build_all_mvs_for_deployment(
+                        ctx,
+                        frigg,
+                        edda_updates,
+                        parallel_build_limit,
+                        "fallback because of index upgrade while building specific MVs",
+                    )
+                    .await;
+                }
+                Err(_) => {
+                    return build_all_mvs_for_deployment(
+                        ctx,
+                        frigg,
+                        edda_updates,
+                        parallel_build_limit,
+                        "fallback because of index parsing error while building specific MVs",
+                    )
+                    .await;
+                }
+                Ok(si_frontend_mv_types::index::deployment::DeploymentMvIndexVersion::V2(
+                    deployment_index,
+                )) => deployment_index,
+            }
+        }
+        None => {
+            // No existing index, so rebuild everything
+            debug!("No existing deployment index found, rebuilding all MVs");
+            return build_all_mvs_for_deployment(
+                ctx,
+                frigg,
+                edda_updates,
+                parallel_build_limit,
+                "fallback because of missing index while building specific MVs",
+            )
+            .await;
+        }
+    };
+
+    // Determine or discover all deployment MVs that need to be built.
+    let deployment_tasks = match mv_ids {
+        Some((removed_schema_ids, new_modules)) => {
+            specific_deployment_mv_tasks(ctx, removed_schema_ids.as_slice(), &new_modules).await?
+        }
+        None => {
+            return build_all_mvs_for_deployment(
+                ctx,
+                frigg,
+                edda_updates,
+                parallel_build_limit,
+                "fallback because of missing details for specific rebuild",
+            )
+            .await;
+        }
+    };
+
+    // Also always see if there are any outdated definition MVs to build
+    let (outdated_deployment_mvs, outdated_mv_kind_count) =
+        get_changes_for_outdated_definitions(ctx, &existing_deployment_index).await?;
+    span.record("si.edda.mv.outdated_mv.kind_count", outdated_mv_kind_count);
+    span.record(
+        "si.edda.mv.outdated_mv.total_discovered",
+        outdated_deployment_mvs.len(),
+    );
+
+    // Combine and deduplicate changes by (mv_kind, mv_id)
+    let mut combined_tasks_map: HashMap<(ReferenceKind, String), DeploymentMvTask> = HashMap::new();
+
+    // Add explicit changes
+    for task in deployment_tasks {
+        combined_tasks_map.insert((task.mv_kind, task.mv_id.clone()), task);
+    }
+
+    // Add outdated definition changes (this will deduplicate by (mv_kind, mv_id))
+    for task in outdated_deployment_mvs {
+        combined_tasks_map.insert((task.mv_kind, task.mv_id.clone()), task);
+    }
+
+    let combined_tasks: Vec<DeploymentMvTask> = combined_tasks_map.into_values().collect();
+    span.record("si.edda.mv.combined_changes.count", combined_tasks.len());
+
+    debug!("combined deduplicated changes: {:?}", combined_tasks);
+
+    // If no changes after deduplication, we are done
+    if combined_tasks.is_empty() {
+        info!(
+            "No changes to process after deduplicating specific and outdated MVs, skipping rebuild"
+        );
+        return Ok(());
+    }
+
+    // Use the deployment MV parallel processing system
+    let (
+        frontend_objects,
+        patches,
+        build_count,
+        build_total_elapsed,
+        build_max_elapsed,
+        build_slowest_mv_kind,
+    ) = build_deployment_mv_inner(ctx, frigg, parallel_build_limit, &combined_tasks).await?;
+    span.record("si.edda.mv.count", build_count);
+    if build_count > 0 {
+        span.record(
+            "si.edda.mv.avg_build_elapsed_ms",
+            build_total_elapsed.as_millis() / build_count,
+        );
+        span.record(
+            "si.edda.mv.max_build_elapsed_ms",
+            build_max_elapsed.as_millis(),
+        );
+        span.record("si.edda.mv.slowest_kind", build_slowest_mv_kind);
+    }
+
+    // Build the deployment index from all the frontend objects
+    let mut index_entries: Vec<_> = frontend_objects.into_iter().map(Into::into).collect();
+    index_entries.sort();
+
+    debug!("index_entries {:?}", index_entries);
+    let mv_index = DeploymentMvIndexV2::new(index_entries);
+    let mv_index_frontend_object = FrontendObject::try_from(mv_index)?;
+    let from_index_checksum = mv_index_frontend_object.checksum.to_owned();
+    let to_index_checksum = from_index_checksum.clone();
+    let meta = DeploymentUpdateMeta {
+        from_index_checksum,
+        to_index_checksum,
+    };
+    let patch_batch = DeploymentPatchBatch::new(meta.clone(), patches);
+    let index_update =
+        DeploymentIndexUpdate::new(meta, mv_index_frontend_object.checksum.to_owned());
+
+    // Store the index on frigg
+    frigg
+        .put_deployment_index(&mv_index_frontend_object)
+        .await?;
+
+    // publish updates
+    edda_updates
+        .publish_deployment_patch_batch(patch_batch)
+        .await?;
+    edda_updates
+        .publish_deployment_index_update(index_update)
+        .await?;
+    info!("Finished building specific deployment MVs");
     Ok(())
 }
 
@@ -144,7 +348,7 @@ pub async fn build_outdated_mvs_for_deployment(
     reason_message: &'static str,
 ) -> Result<(), MaterializedViewError> {
     let span = current_span_for_instrument_at!("info");
-
+    info!("Started building outdated deployment MVs");
     // Get current definition checksums from the registry
     let current_definition_checksums =
         si_frontend_mv_types::definition_checksum::materialized_view_definition_checksums();
@@ -199,7 +403,7 @@ pub async fn build_outdated_mvs_for_deployment(
     };
 
     // Discover all deployment MVs that could be built
-    let all_deployment_tasks = discover_deployment_mvs(ctx).await?;
+    let all_deployment_tasks = all_deployment_mv_tasks(ctx).await?;
     span.record("si.edda.mv.total_discovered", all_deployment_tasks.len());
 
     // Filter to only tasks where checksums differ or are missing
@@ -307,18 +511,19 @@ pub async fn build_outdated_mvs_for_deployment(
     edda_updates
         .publish_deployment_index_update(index_update)
         .await?;
-
+    info!("Finished building outdated deployment MVs");
     Ok(())
 }
 
 /// A deployment MV task that needs to be built for the deployment environment.
 /// Unlike changeset MVs, these are not triggered by graph changes but by deployment-scoped
 /// data that exists outside the workspace graph (e.g., cached modules, global configuration, etc.).
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct DeploymentMvTask {
     pub mv_kind: ReferenceKind,
     pub mv_id: String,
     pub priority: si_events::materialized_view::BuildPriority,
+    pub op: DeploymentSyncOp,
 }
 
 impl Ord for DeploymentMvTask {
@@ -344,8 +549,8 @@ impl PartialOrd for DeploymentMvTask {
 
 /// Discovers all deployment-scoped MVs that need to be built.
 /// This function examines deployment-scoped data sources and creates tasks
-/// for all individual objects and collections that should be built.
-async fn discover_deployment_mvs(
+/// for all individual objects and collections that should be built by looking at the CachedModules table.
+async fn all_deployment_mv_tasks(
     ctx: &DalContext,
 ) -> Result<Vec<DeploymentMvTask>, MaterializedViewError> {
     use dal::cached_module::CachedModule;
@@ -357,6 +562,7 @@ async fn discover_deployment_mvs(
         mv_kind: ReferenceKind::CachedSchemas,
         mv_id: "cached_schemas".to_string(), // Collection has a fixed ID
         priority: <si_frontend_mv_types::cached_schemas::CachedSchemas as MaterializedView>::build_priority(),
+        op: DeploymentSyncOp::Build,
     });
 
     // Discover individual CachedSchema and CachedSchemaVariant objects from cached modules
@@ -364,12 +570,13 @@ async fn discover_deployment_mvs(
     for mut module in modules {
         let si_pkg = module.si_pkg(ctx).await?;
         let schemas = si_pkg.schemas().map_err(CachedModuleError::SiPkg)?;
-        for schema in schemas {
+        for _schema in schemas {
             // Add individual CachedSchema MV task
             tasks.push(DeploymentMvTask {
                 mv_kind: ReferenceKind::CachedSchema,
                 mv_id: module.schema_id.to_string(),
                 priority: <si_frontend_mv_types::cached_schema::CachedSchema as MaterializedView>::build_priority(),
+               op: DeploymentSyncOp::Build,
             });
 
             // Add CachedDefaultVariant MV task
@@ -377,22 +584,84 @@ async fn discover_deployment_mvs(
                 mv_kind: ReferenceKind::CachedDefaultVariant,
                 mv_id: module.schema_id.to_string(),
                 priority: <si_frontend_mv_types::cached_default_variant::CachedDefaultVariant as MaterializedView>::build_priority(),
+               op: DeploymentSyncOp::Build,
+            });
+        }
+    }
+
+    Ok(tasks)
+}
+/// Determines all deployment-scoped MVs that need to be built from specific parameter(s).
+async fn specific_deployment_mv_tasks(
+    ctx: &DalContext,
+    removed_schema_ids: &[SchemaId],
+    new_modules: &HashMap<CachedModuleId, SchemaId>,
+) -> Result<Vec<DeploymentMvTask>, MaterializedViewError> {
+    if removed_schema_ids.is_empty() && new_modules.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut tasks = vec![DeploymentMvTask {
+        mv_kind: ReferenceKind::CachedSchemas,
+        mv_id: "cached_schemas".to_string(), // Collection has a fixed ID
+        priority: <si_frontend_mv_types::cached_schemas::CachedSchemas as MaterializedView>::build_priority(),
+        op: DeploymentSyncOp::Build,
+    }];
+
+    let mut seen_schema_ids = HashSet::new();
+    // Start with the modules, as they will lead us to the schemas and variants
+    let modules = CachedModule::latest_user_independent_modules(ctx).await?;
+    for mut module in modules {
+        if !new_modules.contains_key(&module.id) {
+            debug!(
+                "Skipping module with schema name {:?} and module id {:?} as it is not in the new_modules list, so we weren't asked to build it yet",
+                module.schema_name, module.id
+            );
+            continue;
+        }
+        let si_pkg = module.si_pkg(ctx).await?;
+        let schemas = si_pkg.schemas().map_err(CachedModuleError::SiPkg)?;
+        for _schema in schemas {
+            seen_schema_ids.insert(module.schema_id);
+
+            // Add individual CachedSchema MV task
+            tasks.push(DeploymentMvTask {
+                mv_kind: ReferenceKind::CachedSchema,
+                mv_id: module.schema_id.to_string(),
+                priority: <si_frontend_mv_types::cached_schema::CachedSchema as MaterializedView>::build_priority(),
+                op: DeploymentSyncOp::Build,
             });
 
-            // Add individual CachedSchemaVariant MV tasks
-            let variants = schema.variants().map_err(CachedModuleError::SiPkg)?;
-            for variant in variants {
-                if let Some(unique_id) = variant.unique_id() {
-                    if let Ok(variant_id) = unique_id.parse::<dal::SchemaVariantId>() {
-                        tasks.push(DeploymentMvTask {
-                            mv_kind: ReferenceKind::CachedSchemaVariant,
-                            mv_id: variant_id.to_string(),
-                            priority: <si_frontend_mv_types::cached_schema_variant::CachedSchemaVariant as MaterializedView>::build_priority(),
-                        });
-                    }
-                }
-            }
+            // Add CachedDefaultVariant MV task
+            tasks.push(DeploymentMvTask {
+                mv_kind: ReferenceKind::CachedDefaultVariant,
+                mv_id: module.schema_id.to_string(),
+                priority: <si_frontend_mv_types::cached_default_variant::CachedDefaultVariant as MaterializedView>::build_priority(),
+
+                op: DeploymentSyncOp::Build,
+            });
         }
+    }
+
+    for schema_id in removed_schema_ids {
+        if seen_schema_ids.contains(schema_id) {
+            // We got a delete request for a schema that we've already determined we need to build, so ignore the delete
+            continue;
+        }
+        seen_schema_ids.insert(*schema_id);
+        // The schema is being removed, enqueue Delete tasks for the Schema keyed MVs
+        tasks.push(DeploymentMvTask {
+            mv_kind: ReferenceKind::CachedSchema,
+            mv_id: schema_id.to_string(),
+            priority: <si_frontend_mv_types::cached_schema::CachedSchema as MaterializedView>::build_priority(),
+            op: DeploymentSyncOp::Delete,
+        });
+        tasks.push(DeploymentMvTask {
+            mv_kind: ReferenceKind::CachedDefaultVariant,
+            mv_id: schema_id.to_string(),
+            priority: <si_frontend_mv_types::cached_default_variant::CachedDefaultVariant as MaterializedView>::build_priority(),
+            op: DeploymentSyncOp::Delete,
+        });
     }
 
     Ok(tasks)
@@ -439,7 +708,10 @@ async fn build_deployment_mv_inner(
 
         // Spawn as many of the queued build tasks as we can, up to the concurrency limit.
         while !queued_mv_builds.is_empty() && build_tasks.len() < parallel_build_limit {
-            let Some(DeploymentMvTask { mv_kind, mv_id, .. }) = queued_mv_builds.pop() else {
+            let Some(DeploymentMvTask {
+                mv_kind, mv_id, op, ..
+            }) = queued_mv_builds.pop()
+            else {
                 // This _really_ shouldn't ever return `None` as we just checked that
                 // `queued_mv_builds` is not empty.
                 break;
@@ -451,6 +723,7 @@ async fn build_deployment_mv_inner(
                 mv_kind,
                 mv_id,
                 maybe_deployment_mv_index.clone(),
+                op,
             )
             .await?;
         }
@@ -479,7 +752,7 @@ async fn build_deployment_mv_inner(
                     build_total_elapsed += build_duration;
                 }
                 Err(err) => {
-                    error!(name = "deployment_mv_build_error", si.error.message = err.to_string(), kind = %kind, id = %mv_id);
+                    error!(name = "deployment_mv_build_error", si.error.message = err.to_string(), si.edda.mv.kind = %kind, si.edda.mv.id = %mv_id);
                     return Err(err);
                 }
             }
@@ -504,64 +777,88 @@ async fn spawn_deployment_mv_task(
     mv_kind: ReferenceKind,
     mv_id: String,
     maybe_deployment_mv_index: Arc<Option<FrontendObject>>,
+    op: DeploymentSyncOp,
 ) -> Result<(), MaterializedViewError> {
     // Record the currently running number of MV build tasks
     telemetry_utils::metric!(counter.edda.mv_build = 1, label = mv_kind.to_string());
-
+    // Info span for the spawned task
+    let span = info_span!(
+        "si.edda.deployment.mv.build",
+        si.edda.mv.kind = %mv_kind,
+        si.edda.mv.id = %mv_id,
+        si.edda.deployment.op = ?op,
+    )
+    .or_current();
     match mv_kind {
         ReferenceKind::CachedSchemas => {
-            build_tasks.spawn(build_mv_for_deployment_task(
-                ctx.clone(),
-                frigg.clone(),
-                mv_id,
-                mv_kind,
-                dal_materialized_views::cached::schemas::assemble(ctx.clone()),
-                maybe_deployment_mv_index,
-            ));
+            let frigg = frigg.clone();
+            let ctx = ctx.clone();
+
+            build_tasks.spawn(
+                async move {
+                    build_mv_for_deployment_task(
+                        frigg,
+                        mv_id,
+                        mv_kind,
+                        dal_materialized_views::cached::schemas::assemble(ctx),
+                        maybe_deployment_mv_index,
+                        op,
+                    )
+                    .await
+                }
+                .instrument(span),
+            );
         }
         ReferenceKind::CachedSchema => {
             let schema_id: dal::SchemaId = mv_id.parse().map_err(|_| {
                 dal::SchemaError::UninstalledSchemaNotFound(dal::SchemaId::from(ulid::Ulid::nil()))
             })?;
-            build_tasks.spawn(build_mv_for_deployment_task(
-                ctx.clone(),
-                frigg.clone(),
-                mv_id,
-                mv_kind,
-                dal_materialized_views::cached::schema::assemble(ctx.clone(), schema_id),
-                maybe_deployment_mv_index,
-            ));
+            let frigg = frigg.clone();
+            let ctx = ctx.clone();
+
+            build_tasks.spawn(
+                async move {
+                    build_mv_for_deployment_task(
+                        frigg,
+                        mv_id,
+                        mv_kind,
+                        dal_materialized_views::cached::schema::assemble(ctx, schema_id),
+                        maybe_deployment_mv_index,
+                        op,
+                    )
+                    .await
+                }
+                .instrument(span),
+            );
         }
         ReferenceKind::CachedSchemaVariant => {
-            let variant_id: dal::SchemaVariantId = mv_id.parse().map_err(|_| {
-                dal::SchemaVariantError::NotFound(dal::SchemaVariantId::from(ulid::Ulid::nil()))
-            })?;
-
-            build_tasks.spawn(build_mv_for_deployment_task(
-                ctx.clone(),
-                frigg.clone(),
-                mv_id,
-                mv_kind,
-                dal_materialized_views::cached::schema::variant::assemble(ctx.clone(), variant_id),
-                maybe_deployment_mv_index,
-            ));
+            // we don't build individual CachedSchemaVariant MVs for deployments
+            // as they are not currently used by anything and just add extra build time.
+            return Ok(());
         }
         ReferenceKind::CachedDefaultVariant => {
             let schema_id: dal::SchemaId = mv_id.parse().map_err(|_| {
                 dal::SchemaError::UninstalledSchemaNotFound(dal::SchemaId::from(ulid::Ulid::nil()))
             })?;
+            let frigg = frigg.clone();
+            let ctx = ctx.clone();
 
-            build_tasks.spawn(build_mv_for_deployment_task(
-                ctx.clone(),
-                frigg.clone(),
-                mv_id,
-                mv_kind,
-                dal_materialized_views::cached::schema::variant::default::assemble(
-                    ctx.clone(),
-                    schema_id,
-                ),
-                maybe_deployment_mv_index,
-            ));
+            build_tasks.spawn(
+                async move {
+                    build_mv_for_deployment_task(
+                        frigg,
+                        mv_id,
+                        mv_kind,
+                        dal_materialized_views::cached::schema::variant::default::assemble(
+                            ctx, schema_id,
+                        ),
+                        maybe_deployment_mv_index,
+                        op,
+                    )
+                    .await
+                }
+                .instrument(span),
+            );
         }
         _ => {
             // This shouldn't happen for deployment MVs, but we'll handle it gracefully
@@ -573,14 +870,14 @@ async fn spawn_deployment_mv_task(
     Ok(())
 }
 
-/// Builds an MV task specifically for deployment (no Change context needed).
+/// Builds an MV task specifically for deployment (based on the Deployment Op and current state).
 async fn build_mv_for_deployment_task<F, T, E>(
-    _ctx: DalContext,
     frigg: FriggStore,
     mv_id: String,
     mv_kind: ReferenceKind,
     build_mv_future: F,
     maybe_deployment_mv_index: Arc<Option<FrontendObject>>,
+    op: DeploymentSyncOp,
 ) -> BuildMvTaskResult
 where
     F: std::future::Future<Output = Result<T, E>> + Send + 'static,
@@ -602,6 +899,7 @@ where
         mv_kind,
         build_mv_future,
         maybe_deployment_mv_index,
+        op,
     )
     .await;
 
@@ -615,6 +913,7 @@ async fn build_mv_for_deployment_task_inner<F, T, E>(
     mv_kind: ReferenceKind,
     build_mv_future: F,
     maybe_deployment_mv_index: Arc<Option<FrontendObject>>,
+    op: DeploymentSyncOp,
 ) -> MvBuilderResult
 where
     F: std::future::Future<Output = Result<T, E>> + Send + 'static,
@@ -639,22 +938,90 @@ where
         {
             Ok(maybe_previous) => maybe_previous,
             Err(err) => {
-                warn!(
+                warn!(si.error.message = %err,
                     "Unable to retreive previous deployment MV version; proceeding without: {err}"
                 );
                 None
             }
         };
 
-        if let Some(previous_version) = maybe_previous_version {
-            BuildMvOp::UpdateFrom {
+        match (maybe_previous_version, op) {
+            // We have a previous version and want to delete it
+            (Some(previous_version), DeploymentSyncOp::Delete) => BuildMvOp::Delete {
+                id: mv_id,
+                checksum: previous_version.checksum,
+            },
+            // We have a previous version and want to build again, which is an update
+            (Some(previous_version), DeploymentSyncOp::Build) => BuildMvOp::UpdateFrom {
                 checksum: previous_version.checksum,
                 data: previous_version.data,
+            },
+            // We don't have a previous version and want to delete, which is a no-op
+            (None, DeploymentSyncOp::Delete) => {
+                // If we want to delete but there's no previous version, just skip building.
+                warn!(
+                    "Unable to delete an unknown deployment MV; proceeding without: Kind: {mv_kind} Id: {mv_id}"
+                );
+                return Ok((None, None));
             }
-        } else {
-            BuildMvOp::Create
+            // We don't have a previous version and want to build, which is a create
+            (None, DeploymentSyncOp::Build) => BuildMvOp::Create,
         }
     };
 
     build_mv(op, mv_kind, build_mv_future).await
+}
+
+/// Helper function to determine which entities need MaterializedView rebuilds
+/// due to outdated definition checksums. Returns DeploymentMvTasks
+/// for those entities and the count of outdated MV kinds. This is inlined into build_all_mvs_for_deployment.
+/// Only works with V2 indexes - V1 indexes should be handled by the caller with a fallback to build_all_mvs_for_deployment.
+async fn get_changes_for_outdated_definitions(
+    ctx: &DalContext,
+    mv_index: &si_frontend_mv_types::index::deployment::DeploymentMvIndexV2,
+) -> Result<(Vec<DeploymentMvTask>, usize), MaterializedViewError> {
+    // Get current definition checksums from the registry
+    let current_definition_checksums =
+        si_frontend_mv_types::definition_checksum::materialized_view_definition_checksums();
+
+    // Get the stored definition checksums from the V2 index
+    let existing_definition_checksums = mv_index.definition_checksums.clone();
+
+    // Check which MV types have outdated definitions
+    let outdated_mv_types: std::collections::HashSet<String> = current_definition_checksums
+        .iter()
+        .filter_map(|(mv_kind_str, current_checksum)| {
+            let existing_checksum = existing_definition_checksums.get(mv_kind_str);
+            match existing_checksum {
+                Some(existing) if existing != current_checksum => Some(mv_kind_str.clone()),
+                None => {
+                    // New MV type
+                    Some(mv_kind_str.clone())
+                }
+                _ => None, // Checksum matches, no update needed
+            }
+        })
+        .collect();
+
+    let outdated_mv_kind_count = outdated_mv_types.len();
+    // Discover all deployment MVs that could be built
+    let all_deployment_tasks = all_deployment_mv_tasks(ctx).await?;
+
+    // Filter to only tasks where checksums differ or are missing
+    let outdated_tasks: Vec<DeploymentMvTask> = all_deployment_tasks
+        .into_iter()
+        .filter(|task| {
+            let mv_kind_str = task.mv_kind.to_string();
+            let current_checksum = current_definition_checksums.get(&mv_kind_str);
+            let existing_checksum = mv_index.definition_checksums.get(&mv_kind_str);
+
+            match (current_checksum, existing_checksum) {
+                (Some(current), Some(existing)) => current != existing,
+                (Some(_), None) => true,  // New MV type
+                (None, Some(_)) => false, // MV type no longer exists (shouldn't happen but handle gracefully)
+                (None, None) => false,    // Neither exists (shouldn't happen)
+            }
+        })
+        .collect();
+    Ok((outdated_tasks, outdated_mv_kind_count))
 }

--- a/lib/edda-server/tests/compressing_stream/deployment_request.rs
+++ b/lib/edda-server/tests/compressing_stream/deployment_request.rs
@@ -78,6 +78,13 @@ async fn multiple_rebuilds() {
         CompressedDeploymentRequest::RebuildChangedDefinitions { .. } => {
             panic!("Received unexpected RebuildChangedDefinitions.");
         }
+        CompressedDeploymentRequest::RebuildSpecific {
+            src_requests_count: _,
+            removed_schema_ids: _,
+            new_modules: _,
+        } => {
+            panic!("specific rebuild requests are not expected");
+        }
     }
 }
 
@@ -113,6 +120,9 @@ mod helpers {
                 }
                 DeploymentRequest::RebuildChangedDefinitions { .. } => {
                     panic!("Received unexpected RebuildChangeDefinitions.");
+                }
+                DeploymentRequest::RebuildSpecific(_) => {
+                    panic!("specific rebuild requests are not expected");
                 }
             };
 

--- a/lib/luminork-server/src/service/v1/schemas/get_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_variant.rs
@@ -9,7 +9,7 @@ use sdf_extract::{
 };
 use serde_json::json;
 use si_frontend_mv_types::{
-    cached_schema_variant::CachedSchemaVariant,
+    cached_default_variant::CachedDefaultVariant,
     luminork_schema_variant::LuminorkSchemaVariant,
     reference::ReferenceKind,
 };
@@ -133,16 +133,16 @@ pub async fn get_variant(
         }
     }
 
-    // Phase 1 Fallback: Try CachedSchemaVariant MV (deployment-level, for uninstalled modules)
+    // Phase 1 Fallback: Try CachedDefaultVariant MV (deployment-level, for uninstalled modules)
     match frigg
         .get_current_deployment_object(
-            ReferenceKind::CachedSchemaVariant,
+            ReferenceKind::CachedDefaultVariant,
             &schema_variant_id.to_string(),
         )
         .await?
     {
         Some(obj) => {
-            if let Ok(cached_variant) = serde_json::from_value::<CachedSchemaVariant>(obj.data) {
+            if let Ok(cached_variant) = serde_json::from_value::<CachedDefaultVariant>(obj.data) {
                 // Clone values for logging before moving them
                 let display_name_for_log = cached_variant.display_name.clone();
                 let category_for_log = cached_variant.category.clone();
@@ -157,7 +157,7 @@ pub async fn get_variant(
                     link: cached_variant.link,
                     asset_func_id: cached_variant.asset_func_id,
                     variant_func_ids: cached_variant.variant_func_ids,
-                    is_default_variant: cached_variant.is_default_variant,
+                    is_default_variant: true, // only ever return default variants
                     domain_props: cached_variant.domain_props.map(Into::into),
                 };
 
@@ -177,10 +177,10 @@ pub async fn get_variant(
             }
         }
         None => {
-            // CachedSchemaVariant not found - check if schema exists in cached_modules DB table
+            // CachedDefaultVariant not found - check if schema exists in cached_modules DB table
             match CachedModule::find_latest_for_schema_id(ctx, schema_id).await {
                 Ok(Some(_)) => {
-                    // Schema exists in cached_modules but CachedSchemaVariant MV not built yet
+                    // Schema exists in cached_modules but CachedDefaultVariant MV not built yet
                     return Ok(SchemaVariantResponseV1::Building(BuildingResponseV1 {
                         status: "building".to_string(),
                         message: "Schema variant data is being generated from cached modules, please retry shortly".to_string(),

--- a/lib/sdf-server/src/migrations.rs
+++ b/lib/sdf-server/src/migrations.rs
@@ -12,10 +12,7 @@ use dal::{
     slow_rt::SlowRuntimeError,
     workspace_snapshot::migrator::SnapshotGraphMigrator,
 };
-use edda_client::{
-    ClientError as EddaClientError,
-    EddaClient,
-};
+use edda_client::ClientError as EddaClientError;
 use telemetry::prelude::*;
 use thiserror::Error;
 use tokio::task::JoinError;
@@ -147,10 +144,7 @@ impl Migrator {
         }
 
         if update_module_cache {
-            let nats_connection = self.services_context.nats_conn().clone();
-            let edda_client = EddaClient::new(nats_connection).await?;
-
-            self.migrate_module_cache(edda_client)
+            self.migrate_module_cache()
                 .await
                 .map_err(|err| span.record_err(err))?;
         }
@@ -206,17 +200,18 @@ impl Migrator {
     }
 
     #[instrument(name = "sdf.migrator.migrate_module_cache", level = "info", skip_all)]
-    async fn migrate_module_cache(&self, edda_client: EddaClient) -> MigratorResult<()> {
-        async fn update_cached_modules(
-            ctx: DalContext,
-            edda_client: EddaClient,
-        ) -> MigratorResult<()> {
-            let new_modules = CachedModule::update_cached_modules(&ctx, edda_client)
+    async fn migrate_module_cache(&self) -> MigratorResult<()> {
+        async fn update_cached_modules(ctx: DalContext) -> MigratorResult<()> {
+            let report = CachedModule::update_cached_modules(&ctx)
                 .await
                 .map_err(MigratorError::migrate_cached_modules)?;
             info!(
                 "{} new builtin assets found in module index",
-                new_modules.len()
+                report.new_modules.len()
+            );
+            info!(
+                "{} deleted modules that are no longer builtins or have been deleted",
+                report.removed_module_ids.len()
             );
             Ok::<(), MigratorError>(())
         }
@@ -230,7 +225,7 @@ impl Migrator {
         info!("Updating local module cache");
 
         tokio::spawn(async move {
-            match update_cached_modules(ctx, edda_client).await {
+            match update_cached_modules(ctx).await {
                 Ok(()) => {
                     info!("Module cache updated successfully");
                 }

--- a/lib/si-events-rs/src/lib.rs
+++ b/lib/si-events-rs/src/lib.rs
@@ -15,7 +15,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-pub use si_id::ulid;
+pub use si_id::{
+    CachedModuleId,
+    ulid,
+};
 use split_snapshot_rebase_batch_address::SplitSnapshotRebaseBatchAddress;
 
 mod action;

--- a/lib/si-events-rs/src/materialized_view.rs
+++ b/lib/si-events-rs/src/materialized_view.rs
@@ -1,6 +1,16 @@
 #[remain::sorted]
 #[derive(
-    Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Default, strum::Display, strum::EnumString,
+    Debug,
+    Copy,
+    Clone,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Default,
+    strum::Display,
+    strum::EnumString,
+    Hash,
 )]
 /// The build priority for MVs is:
 ///   * List

--- a/lib/si-frontend-mv-types-rs/src/cached_schema.rs
+++ b/lib/si-frontend-mv-types-rs/src/cached_schema.rs
@@ -36,17 +36,12 @@ pub struct CachedSchema {
 }
 
 impl CachedSchema {
-    pub fn new(
-        id: SchemaId,
-        name: String,
-        default_variant_id: SchemaVariantId,
-        variant_ids: Vec<SchemaVariantId>,
-    ) -> Self {
+    pub fn new(id: SchemaId, name: String, default_variant_id: SchemaVariantId) -> Self {
         Self {
             id,
             name,
             default_variant_id,
-            variant_ids,
+            variant_ids: vec![default_variant_id],
         }
     }
 }


### PR DESCRIPTION
## How does this PR change the system?

### New Edda Request for incrementally building Deployment MVs
This new request kind is used by SDF only.  When we update cached modules, we record the `schema_id`s (if any) that have been removed as well as which `module_id`s have been added and send them in the request. This allows `Edda` to only build the MVs impacted by any newly rejected/published builtins.

If necessary, these requests get compressed down as with the Change Set update requests and the compression logic follows 'last write wins'. For example, if we reject, then re-promote the same module, and both of those requests get compressed, it'll get rebuilt and we'll ignore the initial rejection

### Stop building `CachedSchemaVariant` MV as we only ever want to expose the latest variant, which is the default
This has a **significantly positive** impact on performance, but was not the driving reason. When dealing with uninstalled schemas, we only ever want to expose the latest default variant, so no reason to even iterate and see if there are any more.  A few supporting notes: when we contribute a module, we only ever ship the default anyways and cached modules assumes modules are 1:1 with schemas, which means our Deployment MVs also become 1:1:1 for Module:Schema:Variant. 

I also updated `Luminork` to only find/return the `CachedDefaultSchemaVariant` as opposed to using the `CachedSchemaVariant`. 

I didn't fully rip out `CachedSchemaVariant` as I don't want to couple this change with MV changes. For now, we're not building them, and when building the `CachedSchema` we're still returning a list of `variant_id`s, but the list will only include the default. 

###  Expose a button in the admin panel to force rebuild all deployment MVs
There are now two buttons available in the admin panel (screenshot below).  One will only send the request to edda if we've removed or added cached modules, the other will force a full rebuild regardless.  Hopefully we don't have to use this, but it made testing easier, so might as well ship it. 

### When rebuilding only specific Deployment MVs, always check if any of the shapes have changed, and also rebuild those
Following on @jhelwig 's work here: https://github.com/systeminit/si/pull/7187 - we are now taking advantage of this mechanism for Deployment MVs.  This means, every time we rebuild only changed MVs, we will also check if we need to rebuild any other kinds because their shape has changed (`DefinitionChecksum`).  

### Telemetry
I've added much more instrumentation to this loop compared to what we have for building Change Set Mvs. It runs far less often, and we want to know about errors immediately. I can pair it back if it becomes too noisy. 
1. `info` messages when the processes kicks off/ends
2. wrapped each individual MV build with telemetry so we can better see the timings
3. SDF logs the update report so if things go haywire, we can compare what SDF thought it was doing, to what Edda did. 

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:
<img width="354" height="149" alt="image" src="https://github.com/user-attachments/assets/fb0f1b08-67b1-48ae-bb89-c563ef41d912" />

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:

Refactoring this whole flow....... despite all of the temptation......

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Added new unit tests to Edda for decompression logic
- [X] Manual tests: 
 -  Locally filter down to only 10 builtins being sent from the module index, see that the rebuild works as expected, and subsequent updates result in no messages as there are no changes
 - Update the filter to remove a few, and add a few, see that the update works as expected

## In short: [:link:](https://giphy.com/)
<div><img src="https://media2.giphy.com/media/Vf4Tu8M2flVAiOe2A1/200w.gif?cid=5a38a5a2lgcq112esjtsb6va8jm7rbv8xbjmmkfg7v7dje3u&amp;ep=v1_gifs_search&amp;rid=200w.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/abcnetwork/">ABC Network</a> on <a href="https://giphy.com/gifs/abcnetwork-the-good-doctor-abc-doctorabc-Vf4Tu8M2flVAiOe2A1">GIPHY</a></div>
