### PR TITLE
fix(edda): Stop building CachedSchemaVariant MVs

### DIFF
--- a/lib/dal-materialized-views/src/cached/schema.rs
+++ b/lib/dal-materialized-views/src/cached/schema.rs
@@ -52,21 +52,10 @@ pub async fn assemble(ctx: DalContext, id: SchemaId) -> crate::Result<CachedSche
         .parse::<SchemaVariantId>()
         .map_err(|_| crate::Error::Schema(dal::SchemaError::UninstalledSchemaNotFound(id)))?;
 
-    // Collect all variant IDs from their unique_ids
-    let mut variant_ids = Vec::new();
-    for variant in &variants {
-        if let Some(unique_id) = variant.unique_id() {
-            if let Ok(variant_id) = unique_id.parse::<SchemaVariantId>() {
-                variant_ids.push(variant_id);
-            }
-        }
-    }
-
     Ok(CachedSchemaMv::new(
         id,
         module.schema_name,
         default_variant_id,
-        variant_ids,
     ))
 }
 

--- a/lib/dal/src/cached_module.rs
+++ b/lib/dal/src/cached_module.rs
@@ -389,7 +389,11 @@ impl CachedModule {
 
         Ok(())
     }
-    #[instrument(name = "cached_module.install_from_module", level = "info", skip_all)]
+    #[instrument(
+        name = "cached_module.find_latest_for_schema_id",
+        level = "debug",
+        skip_all
+    )]
     pub async fn find_latest_for_schema_id(
         ctx: &DalContext,
         schema_id: SchemaId,

--- a/lib/si-frontend-mv-types-rs/src/cached_schema.rs
+++ b/lib/si-frontend-mv-types-rs/src/cached_schema.rs
@@ -36,17 +36,12 @@ pub struct CachedSchema {
 }
 
 impl CachedSchema {
-    pub fn new(
-        id: SchemaId,
-        name: String,
-        default_variant_id: SchemaVariantId,
-        variant_ids: Vec<SchemaVariantId>,
-    ) -> Self {
+    pub fn new(id: SchemaId, name: String, default_variant_id: SchemaVariantId) -> Self {
         Self {
             id,
             name,
             default_variant_id,
-            variant_ids,
+            variant_ids: vec![default_variant_id],
         }
     }
 }


### PR DESCRIPTION

<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
Currently, when modules are promoted as builtins, they only contain a single schema, and a single variant (the default variant, which is the latest).  When exposing builtins as uninstalled, we only ever want to show the latest variant as we don’t want users to install old builtins.

We decided to stop building these while working on supporting incremental builds of the Deployment MVs, and at that time, we found that if we simply stop building the CachedSchemaVariantMV alltogether, it brings the total build time down to 16s (locally) for all current builtins. 

Given this, we likely don’t need to support incremental builds for some time, so we’ll ship this as a stand alone improvement and wait for our needs to grow again to revist incremental builds<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

Locally ran the sync, see that it finishes very quickly! (14s!)

## In short: [:link:](https://giphy.com/)

<div><img src="https://media3.giphy.com/media/J1M6o5U4M7LmoSYEYl/giphy.gif?cid=5a38a5a2ogb4xp5q05bahomhv93y41klwndvgpxenl7tf42h&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:300px;width:300px"/><br/>via <a href="https://giphy.com/cbc/">CBC</a> on <a href="https://giphy.com/gifs/cbc-schitts-creek-J1M6o5U4M7LmoSYEYl">GIPHY</a></div>
