### PR TITLE
Prevent eviction of recently-created workspace snapshots

### DIFF
--- a/lib/dal-test/src/lib.rs
+++ b/lib/dal-test/src/lib.rs
@@ -818,6 +818,7 @@ pub async fn rebaser_server(
         config.quiescent_period(),
         shutdown_token,
         config.features(),
+        config.snapshot_eviction_grace_period(),
     )
     .await
     .wrap_err("failed to create Rebaser server")?;

--- a/lib/rebaser-server/src/app_state.rs
+++ b/lib/rebaser-server/src/app_state.rs
@@ -35,6 +35,7 @@ pub(crate) struct AppState {
     pub(crate) token: CancellationToken,
     pub(crate) server_tracker: TaskTracker,
     pub(crate) features: Features,
+    pub(crate) snapshot_eviction_grace_period: Duration,
 }
 
 impl AppState {
@@ -52,6 +53,7 @@ impl AppState {
         token: CancellationToken,
         server_tracker: TaskTracker,
         features: Features,
+        snapshot_eviction_grace_period: Duration,
     ) -> Self {
         Self {
             metadata,
@@ -65,6 +67,7 @@ impl AppState {
             token,
             server_tracker,
             features,
+            snapshot_eviction_grace_period,
         }
     }
 }

--- a/lib/rebaser-server/src/handlers.rs
+++ b/lib/rebaser-server/src/handlers.rs
@@ -112,6 +112,7 @@ pub(crate) async fn default(State(state): State<AppState>, subject: Subject) -> 
         token: server_token,
         server_tracker,
         features,
+        snapshot_eviction_grace_period,
     } = state;
     let subject_prefix = nats.metadata().subject_prefix();
 
@@ -172,6 +173,7 @@ pub(crate) async fn default(State(state): State<AppState>, subject: Subject) -> 
         tasks_token.clone(),
         server_tracker,
         features,
+        snapshot_eviction_grace_period,
     );
 
     let dvu_task_result = tracker.spawn(dvu_task.try_run());

--- a/lib/rebaser-server/src/server.rs
+++ b/lib/rebaser-server/src/server.rs
@@ -172,6 +172,7 @@ impl Server {
             config.quiescent_period(),
             shutdown_token,
             config.features(),
+            config.snapshot_eviction_grace_period(),
         )
         .await
     }
@@ -185,6 +186,7 @@ impl Server {
         quiescent_period: Duration,
         shutdown_token: CancellationToken,
         features: Features,
+        snapshot_eviction_grace_period: Duration,
     ) -> Result<Self> {
         let metadata = Arc::new(ServerMetadata {
             instance_id: instance_id.into(),
@@ -227,6 +229,7 @@ impl Server {
             shutdown_token.clone(),
             server_tracker.clone(),
             features,
+            snapshot_eviction_grace_period,
         );
 
         let app = ServiceBuilder::new()


### PR DESCRIPTION
Add configurable grace period to protect newly-created snapshots from
premature eviction. Previously,
snapshots could be evicted immediately after creation if no change sets
referenced them, but there is a race condition, especially around
creating new change sets while updates are happening.

If there was a single change set (`A`) referencing a snapshot with
updates queued for the rebaser, when we go to create a new change set
(`B`), it was possible for the new change set entry to reference the
snapshot that had been referenced by `A`, but had already been evicted
when the update went through before `B` is actually created to make a
second reference to the snapshot.

Modify evict_unused_snapshot() to check both usage status and recency
before evicting. A snapshot is only evicted if it's both unused AND
outside the grace period window. Default grace period is 5 minutes,
matching the existing quiescent period default.

This does not address the issue if the snapshot referenced by `A` in the
above scenario was originally created outside of the grace period, but
this tends to be a problem during busy periods in a workspace where the
likelihood of the snapshot being an older one is much less likely. We
would need recency-of-reference tracking to address this more fully, but
that is a much larger change, and we already know that we want/need to
make much larger changes to the snapshot garbage collection logic.

<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI
- [X] Manual test: (regression check) creating a component still works

## In short: [:link:](https://giphy.com/)

![](put .gif link here - click the :link: besides the gif on giphy to copy it)
