### PR TITLE
Search spike [temp discussion pr]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,6 +3498,7 @@ dependencies = [
  "futures",
  "nats-std",
  "remain",
+ "serde",
  "serde_json",
  "si-data-nats",
  "si-events",

--- a/component/lambda/functions/searchtest.py
+++ b/component/lambda/functions/searchtest.py
@@ -1,0 +1,45 @@
+import time
+from typing import Optional, cast
+from si_types import ChangeSetId, ComponentId, WorkspaceId
+from si_luminork_api import SiLuminorkApi
+import os
+import sys
+
+if len(sys.argv) < 4:
+    raise Exception("Usage: searchtest.py <attr_name> <attr_value> <search_method>")
+attr_name = sys.argv[1]
+attr_value = sys.argv[2]
+search_method = sys.argv[3]
+
+SI_API_URL = os.getenv("SI_API_URL", "http://localhost:5380")
+SI_API_TOKEN = os.getenv("SI_API_TOKEN")
+if not SI_API_TOKEN:
+    raise Exception("SI_API_TOKEN must be set")
+SI_WORKSPACE_ID = cast(Optional[WorkspaceId], os.getenv("SI_WORKSPACE_ID"))
+if not SI_WORKSPACE_ID:
+    raise Exception("SI_WORKSPACE_ID must be set")
+SI_CHANGE_SET_ID = cast(Optional[ChangeSetId], os.getenv("SI_CHANGE_SET_ID"))
+if not SI_CHANGE_SET_ID:
+    raise Exception("SI_CHANGE_SET_ID must be set")
+
+api = SiLuminorkApi(SI_API_URL, SI_API_TOKEN, SI_WORKSPACE_ID, SI_CHANGE_SET_ID)
+
+# for i in range(998):
+#     component_name = f"test-component-{i:03}"
+#     print(f"Creating component {component_name} ...")
+#     component_id = api.create_component("AWS::EC2::Instance", component_name)
+
+# print(api.get_component(cast(ComponentId, "01K6BWP9X9B1Q0HSZAYVMYF3C1")))
+best_elapsed = 10000000
+for i in range(30):
+    start_time = time.perf_counter()
+    component_ids = api.search_spike(attr_name, attr_value, search_method)
+    # Truncate to integer
+    elapsed = int((time.perf_counter() - start_time) * 1000)
+    if len(component_ids) == 0:
+        raise Exception("No components found")
+    if elapsed < best_elapsed:
+        best_elapsed = elapsed
+    print(f"attempt #{i}: {elapsed} milliseconds")
+print(f"{best_elapsed} milliseconds")
+# print(f"Results: {component_ids}")

--- a/component/lambda/functions/si_luminork_api.py
+++ b/component/lambda/functions/si_luminork_api.py
@@ -1,0 +1,75 @@
+from typing import Literal, TypedDict, cast
+from pip._vendor import requests
+from si_types import ChangeSetId, ComponentId, WorkspaceId
+
+import logging
+import urllib.parse
+
+class SiLuminorkApi:
+    def __init__(self, api_url: str, token: str, workspace_id: WorkspaceId, change_set_id: ChangeSetId):
+        self.api_url = api_url
+        self.token = token
+        self.workspace_id = workspace_id
+        self.change_set_id = change_set_id
+
+    def request(self, method: str, path: str, **kwargs):
+        logging.debug(f"Auth API request: {method} {path}")
+        response = requests.api.request(
+            method,
+            urllib.parse.urljoin(self.api_url, path),
+            headers={"Authorization": f"Bearer {self.token}"},
+            **kwargs,
+        )
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            try:
+                json = e.response.json()
+            except Exception:
+                json = None
+            raise self.HTTPError(
+                f"{e.response.status_code} for {method} {path}: {e.response.text}",
+                json=json,
+            ) from e
+
+        return response
+
+    def get(self, path: str):
+        return self.request("GET", path)
+
+    def delete(self, path: str):
+        return self.request("DELETE", path)
+
+    def put(self, path: str, json):
+        return self.request("PUT", path, json=json)
+
+    def post(self, path: str, json):
+        return self.request("POST", path, json=json)
+    
+    def search_spike(self, attr_name: str, attr_value: str, search_method: str):
+        response = self.post(f"/v1/w/{self.workspace_id}/change-sets/{self.change_set_id}/components/search_spike", {
+            "attrName": attr_name,
+            "attrValue": attr_value,
+            "searchMethod": search_method,
+        })
+        return cast(SearchSpikeResults, response.json())["componentIds"]
+
+    def get_component(self, component_id: ComponentId):
+        response = self.get(f"/v1/w/{self.workspace_id}/change-sets/{self.change_set_id}/components/{component_id}")
+        return response.json()
+
+    def create_component(self, schema_name: str, component_name: str):
+        response = self.post(f"/v1/w/{self.workspace_id}/change-sets/{self.change_set_id}/components", {
+            "schemaName": schema_name,
+            "name": component_name,
+            "attributes": {}
+        })
+        return cast(ComponentId, response.json()["component"]["id"])
+
+    class HTTPError(Exception):
+        def __init__(self, *args, json, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.json = json
+
+class SearchSpikeResults(TypedDict):
+    componentIds: list[ComponentId]

--- a/component/lambda/functions/si_types.py
+++ b/component/lambda/functions/si_types.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 Ulid = NewType("Ulid", str)
 OwnerPk = NewType("OwnerPk", Ulid)
+ChangeSetId = NewType("ChangeSetId", Ulid)
+ComponentId = NewType("ComponentId", Ulid)
 WorkspaceId = NewType("WorkspaceId", Ulid)
 # SQL datetime, i.e. 2024-04-03 12:00:00
 SqlDatetime = NewType("SqlDatetime", str)

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -112,10 +112,10 @@ def si_buck2_resource(
 
     # Get Buck2 build command
     mode_and_targets = buck2_mode_and_targets([target])
-    cmd = "buck2 build {}".format(mode_and_targets)
+    cmd = "buck2 build {} --local-only".format(mode_and_targets)
 
     # Get Buck2 run command
-    serve_cmd = "buck2 run {}".format(mode_and_targets)
+    serve_cmd = "buck2 run {} --local-only".format(mode_and_targets)
     if buck2_serve_args != None:
         serve_cmd += " -- {}".format(buck2_serve_args)
 
@@ -418,7 +418,7 @@ local_resource(
     "rust-initial-build",
     allow_parallel = True,
     labels = resource_labels("rust-initial-build"),
-    cmd = "buck2 build {}".format(buck2_mode_and_targets(rust_build_targets)),
+    cmd = "buck2 build {} --local-only".format(buck2_mode_and_targets(rust_build_targets)),
     deps = buck2_build_deps(rust_build_targets),
     **RUST_RESOURCE_ARGS
 )

--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -2196,7 +2196,7 @@ impl AttributeValue {
         Ok(prop_id_opt)
     }
 
-    async fn fetch_value_from_store(
+    pub async fn fetch_value_from_store(
         ctx: &DalContext,
         maybe_content_address: Option<ContentAddress>,
     ) -> AttributeValueResult<Option<serde_json::Value>> {

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -255,6 +255,8 @@ pub enum ComponentError {
     InputSocketNotFoundForComponentId(InputSocketId, ComponentId),
     #[error("input socket {0} has more than one attribute value")]
     InputSocketTooManyAttributeValues(InputSocketId),
+    #[error("si layer cache error: {0}")]
+    Join(#[from] tokio::task::JoinError),
     #[error("layer db error: {0}")]
     LayerDb(#[from] si_layer_cache::LayerDbError),
     #[error("component {0} missing attribute value for code")]

--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_value_node_weight.rs
@@ -47,7 +47,7 @@ pub struct AttributeValueNodeWeight {
     unprocessed_value: Option<ContentAddress>,
     /// The processed return value.
     /// Example: empty array.
-    value: Option<ContentAddress>,
+    pub value: Option<ContentAddress>,
 }
 
 impl AttributeValueNodeWeight {

--- a/lib/dal/src/workspace_snapshot/selector.rs
+++ b/lib/dal/src/workspace_snapshot/selector.rs
@@ -79,15 +79,18 @@ use crate::{
     entity_kind::EntityKindResult,
     func::FuncResult,
     prop::PropResult,
-    workspace_snapshot::traits::{
-        approval_requirement::ApprovalRequirementExt,
-        attribute_prototype::AttributePrototypeExt,
-        attribute_prototype_argument::AttributePrototypeArgumentExt,
-        attribute_value::AttributeValueExt,
-        component::ComponentExt,
-        diagram::view::ViewExt,
-        func::FuncExt,
-        prop::PropExt,
+    workspace_snapshot::{
+        node_weight::AttributeValueNodeWeight,
+        traits::{
+            approval_requirement::ApprovalRequirementExt,
+            attribute_prototype::AttributePrototypeExt,
+            attribute_prototype_argument::AttributePrototypeArgumentExt,
+            attribute_value::AttributeValueExt,
+            component::ComponentExt,
+            diagram::view::ViewExt,
+            func::FuncExt,
+            prop::PropExt,
+        },
     },
 };
 
@@ -605,6 +608,32 @@ impl WorkspaceSnapshotSelector {
         match self {
             Self::LegacySnapshot(snapshot) => snapshot.dvu_root_check(root).await,
             Self::SplitSnapshot(snapshot) => snapshot.dvu_root_check(root).await,
+        }
+    }
+
+    pub async fn matching_avs(
+        &self,
+        component_id: ComponentId,
+        attr_name: &str,
+    ) -> ComponentResult<Vec<AttributeValueNodeWeight>> {
+        match self {
+            Self::LegacySnapshot(snapshot) => snapshot.matching_avs(component_id, attr_name).await,
+            Self::SplitSnapshot(_) => Ok(vec![]),
+        }
+    }
+
+    pub async fn matching_avs_with_async(
+        &self,
+        component_id: ComponentId,
+        attr_name: &str,
+    ) -> ComponentResult<Vec<AttributeValueNodeWeight>> {
+        match self {
+            Self::LegacySnapshot(snapshot) => {
+                snapshot
+                    .matching_avs_with_async(component_id, attr_name)
+                    .await
+            }
+            Self::SplitSnapshot(_) => Ok(vec![]),
         }
     }
 

--- a/lib/frigg/BUCK
+++ b/lib/frigg/BUCK
@@ -12,6 +12,7 @@ rust_library(
         "//third-party/rust:bytes",
         "//third-party/rust:futures",
         "//third-party/rust:remain",
+        "//third-party/rust:serde",
         "//third-party/rust:serde_json",
         "//third-party/rust:strum",
         "//third-party/rust:thiserror",

--- a/lib/frigg/Cargo.toml
+++ b/lib/frigg/Cargo.toml
@@ -13,6 +13,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 nats-std = { path = "../../lib/nats-std" }
 remain = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 si-data-nats = { path = "../../lib/si-data-nats" }
 si-events = { path = "../../lib/si-events-rs" }

--- a/lib/frigg/src/workspace.rs
+++ b/lib/frigg/src/workspace.rs
@@ -2,6 +2,11 @@ use kv_history::{
     History,
     Keys,
 };
+use serde::{
+    Deserialize,
+    Serialize,
+    de::DeserializeOwned,
+};
 use si_data_nats::{
     Subject,
     async_nats::jetstream::{
@@ -99,6 +104,41 @@ impl FriggStore {
         {
             Some((bytes, _)) => Ok(Some(
                 serde_json::from_slice(bytes.as_ref()).map_err(Error::Deserialize)?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    #[instrument(
+        name = "frigg.get_workspace_object",
+        level = "debug",
+        skip_all,
+        fields(
+            si.workspace.id = %workspace_id,
+            si.frontend_object.id = %id,
+            si.frontend_object.kind = %kind,
+            si.frontend_object.checksum = %checksum,
+    ))]
+    pub async fn get_workspace_object_data<T: DeserializeOwned>(
+        &self,
+        workspace_id: WorkspacePk,
+        kind: &str,
+        id: &str,
+        checksum: &str,
+    ) -> Result<Option<T>> {
+        match self
+            .get_object_raw_bytes(&Self::workspace_object_key(
+                workspace_id,
+                kind,
+                id,
+                checksum,
+            ))
+            .await?
+        {
+            Some((bytes, _)) => Ok(Some(
+                serde_json::from_slice::<FrontendObjectData<T>>(bytes.as_ref())
+                    .map_err(Error::Deserialize)?
+                    .data,
             )),
             None => Ok(None),
         }
@@ -492,4 +532,11 @@ impl FriggStore {
             Scope::ChangeSet.as_ref()
         ))
     }
+}
+
+// Payload wrapper for sending data views to the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendObjectData<T> {
+    pub data: T,
 }

--- a/lib/luminork-server/src/service/v1/components/search_components_spike.rs
+++ b/lib/luminork-server/src/service/v1/components/search_components_spike.rs
@@ -1,0 +1,689 @@
+use std::{
+    collections::{
+        HashMap,
+        VecDeque,
+    },
+    sync::Arc,
+};
+
+use axum::response::Json;
+use dal::{
+    AttributeValue,
+    Component,
+    DalContext,
+};
+use futures::future::try_join_all;
+use itertools::Itertools as _;
+use sdf_extract::PosthogEventTracker;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use si_frontend_mv_types::{
+    index::change_set::ChangeSetMvIndexVersion,
+    object::FrontendObject,
+    reference::IndexReference,
+};
+use si_id::{
+    AttributeValueId,
+    ChangeSetId,
+    ComponentId,
+    WorkspacePk,
+};
+use telemetry::prelude::*;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use super::ComponentsResult;
+use crate::{
+    extract::{
+        FriggStore,
+        change_set::ChangeSetDalContext,
+    },
+    service::v1::ComponentsError,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/components/search",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+    ),
+    tag = "components",
+    request_body = SearchComponentsSpikeV1Request,
+    summary = "Complex search for components",
+    responses(
+        (status = 200, description = "Components retrieved successfully", body = SearchComponentsSpikeV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 404, description = "Component not found"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn search_components_spike(
+    ChangeSetDalContext(ref ctx): ChangeSetDalContext,
+    FriggStore(frigg): FriggStore,
+    tracker: PosthogEventTracker,
+    request: Json<SearchComponentsSpikeV1Request>,
+    // request: Result<Json<SearchComponentsSpikeV1Request>, axum::extract::rejection::JsonRejection>,
+) -> ComponentsResult<Json<SearchComponentsSpikeV1Response>> {
+    let Json(query) = request;
+    let query = Arc::new(query);
+    let workspace_pk = ctx.workspace_pk()?;
+    let change_set_id = ctx.change_set_id();
+
+    // Retrieve and search through AttributeTree MVs
+    let component_ids = match query.search_method {
+        Some(SearchMethod::Sync) => {
+            match_attribute_trees_sync(&frigg, workspace_pk, change_set_id, &query).await?
+        }
+        Some(SearchMethod::Async) => {
+            match_attribute_trees_async(&frigg, workspace_pk, change_set_id, &query).await?
+        }
+        Some(SearchMethod::TryJoinAll) => {
+            match_attribute_trees_try_join_all(&frigg, workspace_pk, change_set_id, &query).await?
+        }
+        Some(SearchMethod::TryJoinAllSpawn) => {
+            match_attribute_trees_try_join_all_spawn(&frigg, workspace_pk, change_set_id, &query)
+                .await?
+        }
+        Some(SearchMethod::LessDeserializing) => {
+            match_attribute_trees_less_deserializing(&frigg, workspace_pk, change_set_id, &query)
+                .await?
+        }
+        Some(SearchMethod::LessDeserializingSpawn) => {
+            match_attribute_trees_less_deserializing_spawn(
+                &frigg,
+                workspace_pk,
+                change_set_id,
+                &query,
+            )
+            .await?
+        }
+        Some(SearchMethod::Spawn) | None => {
+            match_attribute_trees_spawn(&frigg, workspace_pk, change_set_id, &query).await?
+        }
+        Some(SearchMethod::Graph) => match_components_graph(ctx, &query).await?,
+        Some(SearchMethod::GraphSpawn) => match_components_graph_spawn(ctx, &query).await?,
+        Some(SearchMethod::GraphSpawn2) => match_components_graph_spawn2(ctx, &query).await?,
+        Some(SearchMethod::Petgraph) => match_components_petgraph(ctx, &query).await?,
+        Some(SearchMethod::PetgraphSpawn) => match_components_petgraph_spawn(ctx, &query).await?,
+        Some(SearchMethod::PetgraphWithAsync) => {
+            match_components_petgraph_with_async(ctx, &query).await?
+        }
+    };
+
+    tracker.track(
+        ctx,
+        "api_search_components_spike",
+        json!({
+            "query": serde_json::to_value(query)?,
+            "result_count": component_ids.len(),
+        }),
+    );
+
+    Ok(Json(SearchComponentsSpikeV1Response { component_ids }))
+}
+
+async fn attribute_tree_mvs(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+) -> ComponentsResult<impl Iterator<Item = IndexReference>> {
+    // Grab the index
+    // TODO don't convert to JSON and immediately convert to struct--convert straight to struct
+    let Some((index, _)) = frigg
+        .get_change_set_index(workspace_pk, change_set_id)
+        .await?
+    else {
+        return Err(ComponentsError::ChangeSetIndexNotFound(
+            workspace_pk,
+            change_set_id,
+        ));
+    };
+    let all_mvs = match serde_json::from_value(index.data)? {
+        ChangeSetMvIndexVersion::V1(v1_index) => v1_index.mv_list,
+        ChangeSetMvIndexVersion::V2(v2_index) => v2_index.mv_list,
+    };
+    Ok(all_mvs.into_iter().filter(|mv| mv.kind == "AttributeTree"))
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_async(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Get all the MVs at once
+    let tasks = attribute_tree_mvs(frigg, workspace_pk, change_set_id)
+        .await?
+        .map(|mv| async move {
+            match_attribute_tree(frigg.clone(), workspace_pk, mv, query.clone()).await
+        })
+        .collect_vec();
+
+    // Collect the results
+    let mut results = vec![];
+    for task in tasks {
+        if let Some(component_id) = task.await? {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_spawn(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Get all the MVs at once
+    let tasks = attribute_tree_mvs(frigg, workspace_pk, change_set_id)
+        .await?
+        .map(|mv| {
+            tokio::spawn(match_attribute_tree(
+                frigg.clone(),
+                workspace_pk,
+                mv,
+                query.clone(),
+            ))
+        })
+        .collect_vec();
+
+    // Collect the results
+    let mut results = vec![];
+    for task in tasks {
+        if let Some(component_id) = task.await?? {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_try_join_all(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Get all the MVs at once
+    let results = try_join_all(
+        attribute_tree_mvs(frigg, workspace_pk, change_set_id)
+            .await?
+            .map(|mv| async move {
+                match_attribute_tree(frigg.clone(), workspace_pk, mv, query.clone()).await
+            }),
+    )
+    .await?;
+
+    // Collect the results
+    Ok(results.into_iter().flatten().collect())
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_try_join_all_spawn(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Get all the MVs at once
+    let results = try_join_all(
+        attribute_tree_mvs(frigg, workspace_pk, change_set_id)
+            .await?
+            .map(|mv| {
+                tokio::spawn(match_attribute_tree(
+                    frigg.clone(),
+                    workspace_pk,
+                    mv,
+                    query.clone(),
+                ))
+            }),
+    )
+    .await?;
+
+    // Collect the results
+    results.into_iter().flatten_ok().try_collect()
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_less_deserializing(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Collect the results
+    let mut results = vec![];
+    for mv in attribute_tree_mvs(frigg, workspace_pk, change_set_id).await? {
+        if let Some(component_id) =
+            match_attribute_tree_less_deserializing(frigg.clone(), workspace_pk, mv, query.clone())
+                .await?
+        {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_less_deserializing_spawn(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Get all the MVs at once
+    let results = try_join_all(
+        attribute_tree_mvs(frigg, workspace_pk, change_set_id)
+            .await?
+            .map(|mv| {
+                tokio::spawn(match_attribute_tree_less_deserializing(
+                    frigg.clone(),
+                    workspace_pk,
+                    mv,
+                    query.clone(),
+                ))
+            }),
+    )
+    .await?;
+
+    // Collect the results
+    results.into_iter().flatten_ok().try_collect()
+}
+
+#[instrument(level = "info", skip_all)]
+async fn match_attribute_trees_sync(
+    frigg: &frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    change_set_id: ChangeSetId,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    // Collect the results
+    let mut results = vec![];
+    for mv in attribute_tree_mvs(frigg, workspace_pk, change_set_id).await? {
+        if let Some(component_id) =
+            match_attribute_tree(frigg.clone(), workspace_pk, mv, query.clone()).await?
+        {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+#[instrument(level = "debug", skip_all, fields(id))]
+async fn match_attribute_tree(
+    frigg: frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    IndexReference { kind, id, checksum }: IndexReference,
+    query: Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Option<ComponentId>> {
+    // TODO don't convert to JSON and immediately convert to struct--convert straight to struct
+    let Some(FrontendObject { data, .. }) = frigg
+        .get_workspace_object(workspace_pk, &kind, &id, &checksum)
+        .await?
+    else {
+        return Err(ComponentsError::MvNotFound(kind, id, checksum));
+    };
+    let attribute_tree: AttributeTreeForSearch = serde_json::from_value(data)?;
+    for av in attribute_tree.attribute_values.values() {
+        if av.path.ends_with(&query.attr_name) {
+            if av.value == query.attr_value {
+                return Ok(Some(attribute_tree.id));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+#[instrument(level = "debug", skip_all, fields(id))]
+async fn match_attribute_tree_less_deserializing(
+    frigg: frigg::FriggStore,
+    workspace_pk: WorkspacePk,
+    IndexReference { kind, id, checksum }: IndexReference,
+    query: Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Option<ComponentId>> {
+    // TODO don't convert to JSON and immediately convert to struct--convert straight to struct
+    let Some(attribute_tree) = frigg
+        .get_workspace_object_data::<AttributeTreeForSearch>(workspace_pk, &kind, &id, &checksum)
+        .await?
+    else {
+        return Err(ComponentsError::MvNotFound(kind, id, checksum));
+    };
+    for av in attribute_tree.attribute_values.values() {
+        if av.path.ends_with(&query.attr_name) {
+            if av.value == query.attr_value {
+                return Ok(Some(attribute_tree.id));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+async fn match_components_graph(
+    ctx: &DalContext,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    let ctx = Arc::new(ctx.clone());
+    let mut results = vec![];
+    for component_id in Component::list_ids(&ctx).await? {
+        if let Some(component_id) =
+            match_component_graph(ctx.clone(), component_id, query.clone()).await?
+        {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+async fn match_components_graph_spawn(
+    ctx: &DalContext,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    info!("match_components_graph_spawn start");
+    let ctx = Arc::new(ctx.clone());
+    let tasks = Component::list_ids(&ctx)
+        .await?
+        .into_iter()
+        .map(|component_id| {
+            tokio::spawn(match_component_graph(
+                ctx.clone(),
+                component_id,
+                query.clone(),
+            ))
+        })
+        .collect_vec();
+    info!("match_components_graph_spawn spawned: {}", tasks.len());
+
+    // Collect the results
+    let mut results = vec![];
+    for task in tasks {
+        if let Some(component_id) = task.await?? {
+            results.push(component_id);
+        }
+    }
+    info!("match_components_graph_spawn finished");
+    Ok(results)
+}
+
+async fn match_components_graph_spawn2(
+    ctx: &DalContext,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    info!("match_components_graph_spawn2 start");
+    let ctx = Arc::new(ctx.clone());
+    let tasks = Component::list_ids(&ctx)
+        .await?
+        .into_iter()
+        .map(|component_id| {
+            info!("spawning for component_id: {}", component_id);
+            let ctx = ctx.clone();
+            let query = query.clone();
+            tokio::spawn(async move { match_component_graph_spawn(ctx, component_id, query).await })
+        });
+    info!("match_components_graph_spawn2 spawned: {}", tasks.len());
+
+    // Collect the results
+    let mut results = vec![];
+    for task in tasks {
+        if let Some(component_id) = task.await?? {
+            results.push(component_id);
+        }
+    }
+    info!("match_components_graph_spawn2 finished");
+    Ok(results)
+}
+
+async fn match_components_petgraph(
+    ctx: &DalContext,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    let ctx = Arc::new(ctx.clone());
+    let mut results = vec![];
+    for component_id in Component::list_ids(&ctx).await? {
+        if let Some(component_id) =
+            match_component_petgraph(ctx.clone(), component_id, query.clone()).await?
+        {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+async fn match_components_petgraph_spawn(
+    ctx: &DalContext,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    info!("match_components_petgraph_spawn start");
+    let ctx = Arc::new(ctx.clone());
+    let tasks = Component::list_ids(&ctx)
+        .await?
+        .into_iter()
+        .map(|component_id| {
+            tokio::spawn(match_component_petgraph(
+                ctx.clone(),
+                component_id,
+                query.clone(),
+            ))
+        })
+        .collect_vec();
+    info!("match_components_petgraph_spawn spawned: {}", tasks.len());
+
+    // Collect the results
+    let mut results = vec![];
+    for task in tasks {
+        if let Some(component_id) = task.await?? {
+            results.push(component_id);
+        }
+    }
+    info!("match_components_petgraph_spawn finished");
+    Ok(results)
+}
+
+async fn match_components_petgraph_with_async(
+    ctx: &DalContext,
+    query: &Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Vec<ComponentId>> {
+    let ctx = Arc::new(ctx.clone());
+    let mut results = vec![];
+    for component_id in Component::list_ids(&ctx).await? {
+        if let Some(component_id) =
+            match_component_petgraph_with_async(ctx.clone(), component_id, query.clone()).await?
+        {
+            results.push(component_id);
+        }
+    }
+    Ok(results)
+}
+
+// 1. Try petgraph dfs
+// 2. Try going through props first
+async fn match_component_graph(
+    ctx: Arc<DalContext>,
+    component_id: ComponentId,
+    query: Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Option<ComponentId>> {
+    info!("single match start {}", component_id);
+    let root_attribute_value_id = Component::root_attribute_value_id(&ctx, component_id).await?;
+    let mut work_queue = VecDeque::from([root_attribute_value_id]);
+    while let Some(av_id) = work_queue.pop_front() {
+        let key = AttributeValue::prop_name(&ctx, av_id).await?;
+        // let key = match AttributeValue::get_key_or_index_of_child_entry(&ctx, av_id).await? {
+        //     None => AttributeValue::prop_name(&ctx, av_id).await?,
+        //     Some(KeyOrIndex::Index(index)) => index.to_string(),
+        //     Some(KeyOrIndex::Key(key)) => key,
+        // };
+        if key == query.attr_name {
+            // We found one! Now check the value
+            let av = AttributeValue::get_by_id(&ctx, av_id).await?;
+            if let Some(serde_json::Value::String(value)) = av.value(&ctx).await? {
+                if value == query.attr_value {
+                    return Ok(Some(component_id));
+                }
+            }
+        }
+        work_queue.extend(AttributeValue::child_av_ids(&ctx, av_id).await?);
+    }
+    info!("single match complete {}", component_id);
+    Ok(None)
+}
+
+async fn match_component_graph_spawn(
+    ctx: Arc<DalContext>,
+    component_id: ComponentId,
+    query: Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Option<ComponentId>> {
+    info!("single start {}", component_id);
+    let root_attribute_value_id = Component::root_attribute_value_id(&ctx, component_id).await?;
+    let mut attr_values = vec![];
+    let mut work_queue = VecDeque::from([root_attribute_value_id]);
+    while let Some(av_id) = work_queue.pop_front() {
+        let key = AttributeValue::prop_name(&ctx, av_id).await?;
+        // let key = match AttributeValue::get_key_or_index_of_child_entry(&ctx, av_id).await? {
+        //     None => AttributeValue::prop_name(&ctx, av_id).await?,
+        //     Some(KeyOrIndex::Index(index)) => index.to_string(),
+        //     Some(KeyOrIndex::Key(key)) => key,
+        // };
+        if key == query.attr_name {
+            // We found one! Now check the value
+            let av = AttributeValue::get_by_id(&ctx, av_id).await?;
+            let ctx = ctx.clone();
+            attr_values.push(tokio::spawn(async move { av.value(&ctx).await }));
+        }
+        work_queue.extend(AttributeValue::child_av_ids(&ctx, av_id).await?);
+    }
+
+    for attr_value in attr_values {
+        if let Some(serde_json::Value::String(value)) = attr_value.await?? {
+            if value == query.attr_value {
+                info!("single complete");
+                return Ok(Some(component_id));
+            }
+        }
+    }
+    info!("single complete {}", component_id);
+    Ok(None)
+}
+
+// 1. Try petgraph dfs
+// 2. Try going through props first
+async fn match_component_petgraph(
+    ctx: Arc<DalContext>,
+    component_id: ComponentId,
+    query: Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Option<ComponentId>> {
+    for av in ctx
+        .workspace_snapshot()?
+        .matching_avs(component_id, &query.attr_name)
+        .await?
+    {
+        info!("Matching AV in {}", component_id);
+        let value = AttributeValue::fetch_value_from_store(&ctx, av.value).await?;
+        info!("Got content {}", component_id);
+        if let Some(serde_json::Value::String(value)) = value {
+            if value == query.attr_value {
+                return Ok(Some(component_id));
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn match_component_petgraph_with_async(
+    ctx: Arc<DalContext>,
+    component_id: ComponentId,
+    query: Arc<SearchComponentsSpikeV1Request>,
+) -> ComponentsResult<Option<ComponentId>> {
+    for av in ctx
+        .workspace_snapshot()?
+        .matching_avs_with_async(component_id, &query.attr_name)
+        .await?
+    {
+        info!("Matching AV in {}", component_id);
+        let value = AttributeValue::fetch_value_from_store(&ctx, av.value).await?;
+        info!("Got content {}", component_id);
+        if let Some(serde_json::Value::String(value)) = value {
+            if value == query.attr_value {
+                return Ok(Some(component_id));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// A pared-down version of the AttributeTree MV, containing only the fields we need for searching.
+/// That way we don't pay the cost of deserializing everything else.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeTreeForSearch {
+    pub id: ComponentId,
+    pub attribute_values: HashMap<AttributeValueId, AttributeValueForSearch>,
+    pub component_name: String,
+    pub schema_name: String,
+}
+
+/// A pared-down version of the AttributeTree MV, containing only the fields we need for searching.
+/// That way we don't pay the cost of deserializing everything else.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributeValueForSearch {
+    // pub id: AttributeValueId,
+    // pub key: Option<String>,
+    pub path: String,
+    // pub prop_id: Option<PropId>,
+    pub value: serde_json::Value,
+    // pub external_sources: Option<Vec<ExternalSource>>, // this is the detail of where the subscriptions are from
+    // pub is_controlled_by_ancestor: bool, // if ancestor of prop is set by dynamic func, ID of ancestor that sets it
+    // pub is_controlled_by_dynamic_func: bool, // props driven by non-dynamic funcs have a statically set value
+    // pub overridden: bool, // true if this prop has a different controlling func id than the default for this asset
+    // pub validation: Option<ValidationOutput>,
+    // pub secret: Option<Secret>,
+    // TODO remove from here and frontend. Always false right now.
+    // pub has_socket_connection: bool,
+    // pub is_default_source: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum SearchMethod {
+    Sync,
+    Async,
+    Spawn,
+    TryJoinAllSpawn,
+    TryJoinAll,
+    LessDeserializing,
+    LessDeserializingSpawn,
+    Petgraph,
+    PetgraphSpawn,
+    PetgraphWithAsync,
+    Graph,
+    GraphSpawn,
+    GraphSpawn2,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SearchComponentsSpikeV1Request {
+    #[schema(example = "Region")]
+    attr_name: String,
+    #[schema(example = "us-east-1")]
+    attr_value: String,
+    #[schema(example = "spawn")]
+    search_method: Option<SearchMethod>,
+}
+
+#[derive(Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchComponentsSpikeV1Response {
+    #[schema(value_type = Vec<String>, example = json!(["01H9ZQD35JPMBGHH69BT0Q79AA", "01H9ZQD35JPMBGHH69BT0Q79BB", "01H9ZQD35JPMBGHH69BT0Q79CC"]))]
+    component_ids: Vec<ComponentId>,
+}


### PR DESCRIPTION
I implemented component search (full attribute search) in 3 different ways, with a bunch of variations, to try to suss out some lingering questions about our performance.

These are the results of searching 1,000 components for `region:us-east-1`, on a localdev threadripper instance:

<img width="1979" height="1180" alt="image" src="https://github.com/user-attachments/assets/8746fc3e-27f7-49be-847e-f9d7e4e059e1" />

## Takeaways

* **90% Extractor overhead**

  We spend 90% of our time (350-400ms) in extractors before the endpoint even runs. There is likely low-hanging fruit here that will benefit **all** of our endpoints in Luminork and SDF.
* **100x DAL overhead**

  Our top-level DAL objects take 100x longer than petgraph to do the same job (after overhead). We use the same algorithm in both places (i.e. a VecDeque to walk the tree, and minimal CAS access).
  
  There is significant speedup to be had in many endpoints here. This needs more investigation to find the source, and decide on a remedy. Some of this is definitely due to the cost of `await` boundaries (between the reactor, the hit to inlining, and the need for `Arc`/`Vec`/`String`s instead of iterators and references. But that doesn't account for nearly the whole difference. I do *not* believe this is CAS, either: I tried to keep CAS accesses the same across the Petgraph and DAL experiments.
* **3-4x deserialization overhead**

  Selectively deserializing what we wanted from the AttributeTree MV led to a 3-4x speedup in the MV experiment. By not deserializing to serde_json::Value and not deserializing everything, we avoid a *ton* the HashMap, Vec and String allocation in deserialization. We are using this in the final search API.

  This is mainly something to keep in mind as we make other Rust endpoints that deserialize MVs, but there *may* be significant edda improvements in some places by just not deserializing the JSON when it needs to be passed through (and maybe even a streaming diff algorithm that avoids allocation).

## Algorithm

The searches go through all components, searching the whole attribute tree for "region=us-east-1". I did each experiment in a synchronous version, which does everything serially, as well as an async version (which spawns a tokio::task for each component and runs them in parallel). The synchronous version can help us see differences in how much actual work we're doing, while the asynchronous version helps us see how much of that work is "waiting for results."

* **Petgraph** loads the snapshot, pulls workspace_snapshot(), uses petgraph Contains/Prop edges to find "region" attributes in a VecDeque depth-first-search, and then loads the values from CAS to check "us-east-1". 
  - **Petgraph--** is the same, with artificial tokio::spawn(async) boundaries to check how much that's costing us.
* **DAL Snapshot** loads the snapshot, uses AttributeValue::child_av_ids/prop_name to find "region" attributes in a VecDeque depth-first-search., and then loads the values from CAS to check "us-east-1".
* ** MVs** loads the MV index, then loads AttributeTree MVs and scan them for region=us-east-1.
  - **MV--** is the same, but loads the MVs using frigg.get_frontend_object(), which deserializes the whole MV to serde_json::Value

# Results

The primary experiment results:

| Experiment | Sync (ms) | Async (ms) | Description |
|---|---|---|---|
| Petgraph | 425 | 407 | Snapshot using Petgraph primitives, avoiding `await`, mutexes |
| MVs | 635 | 448 | Load AttributeTree MVs from frigg |
| DAL Snapshot | 5434 | 2527 | Snapshot using dal::Component/etc. top-level objects, many awaits and calls to workspace_snapshot() with its mutex |
| MV-- | 1118 | 478 | MVs, but deserializing everything to serde_json::Value |
| Petgraph-- | 1399 | | Petgraph, but with artificial `await`s / `tokio::spawn` inserted to check its overhead |