### PR TITLE
feat: Luminork top-level search endpoint

### DIFF
--- a/lib/luminork-server/src/service/v1.rs
+++ b/lib/luminork-server/src/service/v1.rs
@@ -10,6 +10,7 @@ mod components;
 mod funcs;
 mod management_funcs;
 mod schemas;
+mod search;
 mod secrets;
 mod user;
 mod workspaces;
@@ -159,6 +160,10 @@ pub use schemas::{
     unlock_schema::UnlockedSchemaV1Response,
     update_schema_variant::UpdateSchemaVariantV1Request,
 };
+pub use search::{
+    SearchV1Request,
+    SearchV1Response,
+};
 pub use workspaces::WorkspaceError;
 
 pub use crate::api_types::func_run::v1::{
@@ -228,6 +233,7 @@ pub use crate::api_types::func_run::v1::{
         secrets::delete_secret::delete_secret,
         secrets::update_secret::update_secret,
         secrets::get_secrets::get_secrets,
+        search::search,
     ),
     components(
         schemas(
@@ -314,6 +320,8 @@ pub use crate::api_types::func_run::v1::{
             CreateVariantManagementFuncV1Request,
             CreateVariantManagementFuncV1Response,
             UpdateSchemaVariantV1Request,
+            SearchV1Request,
+            SearchV1Response,
         )
     ),
     tags(

--- a/lib/luminork-server/src/service/v1/components/search_components.rs
+++ b/lib/luminork-server/src/service/v1/components/search_components.rs
@@ -70,8 +70,11 @@ pub async fn search_components(
 
     let query: SearchQuery = payload.query_string.as_deref().unwrap_or("").parse()?;
     let query = Arc::new(query);
-    let mut component_ids =
-        search::component::search(frigg, workspace_id, change_set_id, &query).await?;
+    let mut component_ids = search::component::search(frigg, workspace_id, change_set_id, &query)
+        .await?
+        .into_iter()
+        .map(|component| component.id)
+        .collect();
 
     if let Some(schema_name) = payload.schema_name.clone() {
         component_ids = apply_schema_filter(ctx, component_ids, schema_name).await?;

--- a/lib/luminork-server/src/service/v1/search.rs
+++ b/lib/luminork-server/src/service/v1/search.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    extract::Query,
+    response::Json,
+    routing::get,
+};
+use sdf_core::app_state::AppState;
+use sdf_extract::{
+    FriggStore,
+    change_set::ChangeSetAuthorization,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use serde_json::json;
+use utoipa::{
+    self,
+    ToSchema,
+};
+
+use crate::{
+    extract::PosthogEventTracker,
+    search::{
+        self,
+        component::ComponentSearchResult,
+    },
+    service::v1::ComponentsError,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/", get(search))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/w/{workspace_id}/change-sets/{change_set_id}/search",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace identifier"),
+        ("change_set_id" = String, Path, description = "Change Set identifier"),
+        ("q" = String, Query, description = "Query string. See https://docs.systeminit.com/explanation/search-syntax for details.", example = "AWS::EC2::Instance region:us-east-1")
+    ),
+    summary = "Complex search for components",
+    responses(
+        (status = 200, description = "Components retrieved successfully", body = SearchV1Response),
+        (status = 401, description = "Unauthorized - Invalid or missing token"),
+        (status = 500, description = "Internal server error", body = crate::service::v1::common::ApiError)
+    )
+)]
+pub async fn search(
+    FriggStore(ref frigg): FriggStore,
+    ChangeSetAuthorization {
+        workspace_id,
+        change_set_id,
+        ..
+    }: ChangeSetAuthorization,
+    tracker: PosthogEventTracker,
+    Query(SearchV1Request { q }): Query<SearchV1Request>,
+) -> Result<Json<SearchV1Response>, ComponentsError> {
+    let query = Arc::new(q.parse()?);
+    let components = search::component::search(frigg, workspace_id, change_set_id, &query).await?;
+
+    tracker.track_no_ctx(
+        workspace_id,
+        change_set_id,
+        "api_search",
+        json!({
+            "q": q,
+            "components": components.len(),
+        }),
+    );
+
+    Ok(Json(SearchV1Response { components }))
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchV1Request {
+    #[schema(example = "AWS::EC2::Instance region:us-east-1")]
+    pub q: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchV1Response {
+    #[schema(example = json!(["01H9ZQD35JPMBGHH69BT0Q79AA", "01H9ZQD35JPMBGHH69BT0Q79BB", "01H9ZQD35JPMBGHH69BT0Q79CC"]))]
+    pub components: Vec<ComponentSearchResult>,
+}

--- a/lib/luminork-server/src/service/v1/workspaces.rs
+++ b/lib/luminork-server/src/service/v1/workspaces.rs
@@ -67,6 +67,7 @@ pub fn routes(state: AppState) -> Router<AppState> {
                         Router::new()
                             .route("/", get(super::change_sets::get::get_change_set))
                             .route("/", delete(super::change_sets::delete::abandon_change_set))
+                            .nest("/search", super::search::routes())
                             .nest("/components", super::components::routes())
                             .nest("/schemas", super::schemas::routes())
                             .nest("/funcs", super::funcs::routes())

--- a/lib/sdf-core/src/tracking.rs
+++ b/lib/sdf-core/src/tracking.rs
@@ -1,5 +1,9 @@
 use dal::DalContext;
 use hyper::Uri;
+use si_id::{
+    ChangeSetId,
+    WorkspacePk,
+};
 use telemetry::prelude::*;
 
 use crate::app_state::PosthogClient;
@@ -20,7 +24,7 @@ pub fn track(
         .map(|workspace_pk| workspace_pk.to_string())
         .unwrap_or_else(|| "unknown".to_string());
     let changeset_id = ctx.change_set_id().to_string();
-    track_no_ctx(
+    _track(
         posthog_client,
         original_uri,
         host_name,
@@ -37,6 +41,57 @@ pub fn track(
 /// (e.g., for admin routes that operate across workspaces)
 #[allow(clippy::too_many_arguments)]
 pub fn track_no_ctx(
+    posthog_client: &PosthogClient,
+    original_uri: &Uri,
+    host_name: &String,
+    distinct_id: String,
+    workspace_id: WorkspacePk,
+    changeset_id: ChangeSetId,
+    event_name: impl AsRef<str>,
+    properties: serde_json::Value,
+) {
+    _track(
+        posthog_client,
+        original_uri,
+        host_name,
+        distinct_id,
+        Some(workspace_id.to_string()),
+        Some(changeset_id.to_string()),
+        event_name,
+        properties,
+    )
+}
+
+/// Send tracking events to PostHog when you either don't have a DalContext
+/// or when the DalContext does not have the correct workspace and change_set id
+/// (e.g., for admin routes that operate across workspaces)
+#[allow(clippy::too_many_arguments)]
+pub fn track_no_ctx_workspace(
+    posthog_client: &PosthogClient,
+    original_uri: &Uri,
+    host_name: &String,
+    distinct_id: String,
+    workspace_id: WorkspacePk,
+    event_name: impl AsRef<str>,
+    properties: serde_json::Value,
+) {
+    _track(
+        posthog_client,
+        original_uri,
+        host_name,
+        distinct_id,
+        Some(workspace_id.to_string()),
+        None,
+        event_name,
+        properties,
+    )
+}
+
+/// Send tracking events to PostHog when you either don't have a DalContext
+/// or when the DalContext does not have the correct workspace and change_set id
+/// (e.g., for admin routes that operate across workspaces)
+#[allow(clippy::too_many_arguments)]
+pub fn _track(
     posthog_client: &PosthogClient,
     original_uri: &Uri,
     host_name: &String,

--- a/lib/sdf-extract/src/services.rs
+++ b/lib/sdf-extract/src/services.rs
@@ -11,7 +11,11 @@ use axum::{
         request::Parts,
     },
 };
-use dal::DalContext;
+use dal::{
+    ChangeSetId,
+    DalContext,
+    WorkspacePk,
+};
 use derive_more::{
     Deref,
     Into,
@@ -100,6 +104,25 @@ impl PosthogEventTracker {
             ctx,
             &self.original_uri,
             &self.host,
+            event_name,
+            properties,
+        )
+    }
+
+    pub fn track_no_ctx(
+        &self,
+        workspace_id: WorkspacePk,
+        change_set_id: ChangeSetId,
+        event_name: impl AsRef<str>,
+        properties: serde_json::Value,
+    ) {
+        sdf_core::tracking::track_no_ctx(
+            &self.posthog_client,
+            &self.original_uri,
+            &self.host,
+            "anonymous".to_string(),
+            workspace_id,
+            change_set_id,
             event_name,
             properties,
         )

--- a/lib/sdf-server/src/lib.rs
+++ b/lib/sdf-server/src/lib.rs
@@ -79,6 +79,7 @@ pub(crate) use self::{
     tracking::{
         track,
         track_no_ctx,
+        track_no_ctx_workspace,
     },
 };
 

--- a/lib/sdf-server/src/service/v2/admin/get_cas_data.rs
+++ b/lib/sdf-server/src/service/v2/admin/get_cas_data.rs
@@ -83,8 +83,8 @@ pub async fn get_cas_data(
         &original_uri,
         &host_name,
         ctx.history_actor().distinct_id(),
-        Some(workspace_id.to_string()),
-        Some(change_set_id.to_string()),
+        workspace_id,
+        change_set_id,
         "admin.get_cas_data",
         serde_json::json!({}),
     );

--- a/lib/sdf-server/src/service/v2/admin/get_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/admin/get_snapshot.rs
@@ -64,8 +64,8 @@ pub async fn get_snapshot(
         &original_uri,
         &host_name,
         ctx.history_actor().distinct_id(),
-        Some(workspace_id.to_string()),
-        Some(change_set_id.to_string()),
+        workspace_id,
+        change_set_id,
         "admin.get_snapshot",
         serde_json::json!({
             "workspace_snapshot_address": snap_addr.to_string(),

--- a/lib/sdf-server/src/service/v2/admin/set_concurrency_limit.rs
+++ b/lib/sdf-server/src/service/v2/admin/set_concurrency_limit.rs
@@ -23,7 +23,7 @@ use crate::{
         AdminAPIResult,
         AdminUserContext,
     },
-    track_no_ctx,
+    track_no_ctx_workspace,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -75,13 +75,12 @@ pub async fn set_concurrency_limit(
 
     ctx.commit_no_rebase().await?;
 
-    track_no_ctx(
+    track_no_ctx_workspace(
         &posthog_client,
         &original_uri,
         &host_name,
         ctx.history_actor().distinct_id(),
-        Some(workspace_id.to_string()),
-        None,
+        workspace_id,
         "admin.set_concurrency_limit",
         serde_json::json!({
             "concurrency_limit": workspace.raw_component_concurrency_limit(),

--- a/lib/sdf-server/src/service/v2/admin/set_snapshot.rs
+++ b/lib/sdf-server/src/service/v2/admin/set_snapshot.rs
@@ -110,8 +110,8 @@ pub async fn set_snapshot(
         &original_uri,
         &host_name,
         ctx.history_actor().distinct_id(),
-        Some(workspace_id.to_string()),
-        Some(change_set_id.to_string()),
+        workspace_id,
+        change_set_id,
         "admin.set_snapshot",
         serde_json::json!({
             "workspace_snapshot_address": workspace_snapshot_address.to_string(),

--- a/lib/sdf-server/src/service/v2/admin/upload_cas_data.rs
+++ b/lib/sdf-server/src/service/v2/admin/upload_cas_data.rs
@@ -89,8 +89,8 @@ pub async fn upload_cas_data(
         &original_uri,
         &host_name,
         ctx.history_actor().distinct_id(),
-        Some(workspace_id.to_string()),
-        Some(change_set_id.to_string()),
+        workspace_id,
+        change_set_id,
         "admin.upload_cas_data",
         serde_json::json!({}),
     );


### PR DESCRIPTION
This attaches search to a top-level search endpoint, which currently only returns components but which may return other things like schemas and functions in the future.

```
GET /v1/w/:workspaceId/change-sets/:changeSetId/search?q=region:us-east-1
{ "components": [
  {'id': '01K4T90DDMQC17HG3JQ72KJKYB', 'name': 'us-east-1', 'schema': {'name': 'Region'}},
  {'id': '01K6BV9HMB56T33N2Z0QZP8SV2', 'name': 'test-component-994', 'schema': {'name': 'AWS::EC2::Instance'}},
  {'id': '01K6BWP9X9B1Q0HSZAYVMYF3C1', 'name': 'another us-east-1', 'schema': {'name': 'Region'}}
] }
```
**Factor Budget:** because this endpoint uses the Posthog track_no_ctx, this lightly factors the method so callers pass `workspace_id` instead of all of them doing `Some(workspace_id.to_string())`. There are only a few callers of this method.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: new API endpoint works

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZjdueDNpb3E5dXljNW92am1jMzA2ano1Ymxya3FwamF5aG10OWpxNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/N63fPtiPhkBdS/giphy.gif"/>