### PR TITLE
fix(luminork): Ensure we don't try to get non default variant from deployment MV

### DIFF
--- a/lib/luminork-server/src/service/v1/schemas/get_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_variant.rs
@@ -152,6 +152,10 @@ pub async fn get_variant(
                 let display_name_for_log = cached_variant.display_name.clone();
                 let category_for_log = cached_variant.category.clone();
 
+                if cached_variant.variant_id != schema_variant_id {
+                    return Err(SchemaError::SchemaVariantNotFound(schema_variant_id));
+                }
+
                 let response = GetSchemaVariantV1Response {
                     variant_id: cached_variant.variant_id,
                     display_name: cached_variant.display_name,


### PR DESCRIPTION
In the get_variant MV, if we don’t find an installed variant we fallback to getting an unstalled variant. We only have MVs for default variants NOT any other version. If we ask for a variant_id that isn’t the default, then we error