### PR TITLE
feat: wildcard support in search API

### DIFF
--- a/lib/luminork-server/src/search/query.rs
+++ b/lib/luminork-server/src/search/query.rs
@@ -68,34 +68,18 @@ impl SearchTerm {
         // TODO handle international case comparison as well. Library? icu? case_sensitive_string?
         match self {
             SearchTerm::Match(term) => {
-                // Rust doesn't have a `contains_ignore_ascii_case()` function, so we do it
-                // ourselves by checking if the any subset of bytes in the value *equal* the
-                // query string (ignoring case).
-                let term = term.as_bytes();
-                let value = value.as_bytes();
-                value
-                    .windows(term.len())
-                    .any(|window| window.eq_ignore_ascii_case(term))
-            }
-            SearchTerm::Exact(term) => term.eq_ignore_ascii_case(value),
-            SearchTerm::StartsWith(term) => {
-                // Rust doesn't have a `starts_with_ignore_ascii_case()` function, so we do it
-                // ourselves by checking if the first N bytes of the value *equal* the query string
-                // (ignoring case).
-                //
-                // We use as_bytes() here because s could potentially have multi-byte UTF-8
-                // characters. If you ask whether term="€" (3 bytes) starts with value="a" (1 byte),
-                // term[..value.len()] would panic because it would try to slice in the middle of
-                // the multi-byte character. Using as_bytes() avoids that, but still correctly
-                // checks equality, because it's a byte-by-byte comparison.
-                let term = term.as_bytes();
-                let value = value.as_bytes();
-                if value.len() >= term.len() {
-                    term.eq_ignore_ascii_case(&value[..term.len()])
-                } else {
-                    false
+                // If we have a*b*c, find a, then b, then c ...
+                let mut value = value;
+                for part in term.split('*') {
+                    let Some((_, remaining)) = value.split_once_ignore_ascii_case(part) else {
+                        return false;
+                    };
+                    value = remaining;
                 }
+                true
             }
+            SearchTerm::Exact(term) => value.eq_ignore_ascii_case(term),
+            SearchTerm::StartsWith(term) => value.starts_with_ignore_ascii_case(term),
         }
     }
 
@@ -146,6 +130,41 @@ impl SearchTerm {
     }
 }
 
+/// String methods that ignore ascii case (like eq_ignore_ascii_case for other pattern matches)
+trait StrIgnoreAsciiCaseHelpers {
+    /// Like find(), but ignores ascii case
+    fn find_ignore_ascii_case(&self, pattern: &str) -> Option<usize>;
+
+    /// Like split_once(), but ignores ascii case
+    fn split_once_ignore_ascii_case<'a>(&'a self, pattern: &str) -> Option<(&'a str, &'a str)>;
+
+    /// Like starts_with(), but ignores ascii case
+    fn starts_with_ignore_ascii_case(&self, prefix: &str) -> bool;
+}
+
+impl StrIgnoreAsciiCaseHelpers for str {
+    fn find_ignore_ascii_case(&self, pattern: &str) -> Option<usize> {
+        let pattern = pattern.as_bytes();
+        let bytes = self.as_bytes();
+        if pattern.len() > self.len() {
+            return None;
+        }
+
+        (0..=(bytes.len() - pattern.len()))
+            .find(|&i| bytes[i..i + pattern.len()].eq_ignore_ascii_case(pattern))
+    }
+
+    fn split_once_ignore_ascii_case<'a>(&'a self, pattern: &str) -> Option<(&'a str, &'a str)> {
+        self.find_ignore_ascii_case(pattern)
+            .map(|i| (&self[..i], &self[i + pattern.len()..]))
+    }
+
+    fn starts_with_ignore_ascii_case(&self, prefix: &str) -> bool {
+        self.get(..prefix.len())
+            .is_some_and(|slice| slice.eq_ignore_ascii_case(prefix))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -168,6 +187,19 @@ mod tests {
         assert!(!term.match_str("")); // empty
         assert!(!term.match_str("foo")); // something else entirely
         assert!(!term.match_str("foobario")); // something else entirely of the same length
+
+        let value = "Instance";
+        assert!(SearchTerm::Match("*Stan*".to_string()).match_str(value));
+        assert!(SearchTerm::Match("*St*an*".to_string()).match_str(value));
+        assert!(SearchTerm::Match("*S*n*".to_string()).match_str(value));
+        assert!(SearchTerm::Match("n*t*n*e".to_string()).match_str(value));
+        assert!(SearchTerm::Match("**".to_string()).match_str(value));
+        assert!(SearchTerm::Match("n*".to_string()).match_str(value));
+        assert!(SearchTerm::Match("**ta**c**e**".to_string()).match_str(value));
+        assert!(!SearchTerm::Match("n*t*x".to_string()).match_str(value));
+        assert!(!SearchTerm::Match("*an*St*".to_string()).match_str(value));
+        assert!(!SearchTerm::Match("*an*St*".to_string()).match_str(value));
+        assert!(!SearchTerm::Match("*a*cee*".to_string()).match_str(value));
     }
 
     #[test]
@@ -311,5 +343,63 @@ mod tests {
             !SearchTerm::Match("1.2".to_string()).match_number(&Number::from_f64(1.2001).unwrap())
         );
         assert!(!SearchTerm::Match("1.2".to_string()).match_number(&1.into()));
+    }
+
+    #[test]
+    fn find_ignore_ascii_case() {
+        assert_eq!("Hello, world".find_ignore_ascii_case("hello"), Some(0));
+        assert_eq!("Hello, world".find_ignore_ascii_case("WORLD"), Some(7));
+        assert_eq!("Hello, world".find_ignore_ascii_case("o, W"), Some(4));
+        assert_eq!("Hello, world".find_ignore_ascii_case("foo"), None);
+        assert_eq!("Hello, world".find_ignore_ascii_case(""), Some(0));
+        assert_eq!(
+            "Hello, world".find_ignore_ascii_case("Hello, world"),
+            Some(0)
+        );
+        assert_eq!("Hello, world".find_ignore_ascii_case("Hello, worldd"), None);
+        assert_eq!("".find_ignore_ascii_case("foo"), None);
+        assert_eq!("".find_ignore_ascii_case(""), Some(0));
+    }
+
+    #[test]
+    fn split_once_ignore_ascii_case() {
+        assert_eq!(
+            "abc DEF def".split_once_ignore_ascii_case("def"),
+            Some(("abc ", " def"))
+        );
+        assert_eq!(
+            "abc DEF def".split_once_ignore_ascii_case("def"),
+            Some(("abc ", " def"))
+        );
+        assert_eq!(
+            "abc DEF def".split_once_ignore_ascii_case("abc DEF def"),
+            Some(("", ""))
+        );
+        assert_eq!(
+            "abc DEF def".split_once_ignore_ascii_case("abc DEF deff"),
+            None
+        );
+        assert_eq!("abc DEF def".split_once_ignore_ascii_case("ghi"), None);
+        assert_eq!(
+            "abc DEF def".split_once_ignore_ascii_case(""),
+            Some(("", "abc DEF def"))
+        );
+        assert_eq!(
+            "abc DEF def".split_once_ignore_ascii_case("c d"),
+            Some(("ab", "EF def"))
+        );
+        assert_eq!("".split_once_ignore_ascii_case("foo"), None);
+        assert_eq!("".split_once_ignore_ascii_case(""), Some(("", "")));
+    }
+
+    #[test]
+    fn starts_with_ignore_ascii_case() {
+        assert!("Hello, world".starts_with_ignore_ascii_case("hello"));
+        assert!("Hello, world".starts_with_ignore_ascii_case("HELLO"));
+        assert!(!"Hello, world".starts_with_ignore_ascii_case("world"));
+        assert!(!"Hello, world".starts_with_ignore_ascii_case("foo"));
+        assert!("Hello, world".starts_with_ignore_ascii_case(""));
+        assert!(!"".starts_with_ignore_ascii_case("foo"));
+        assert!("".starts_with_ignore_ascii_case(""));
     }
 }


### PR DESCRIPTION
When you search for `AWS::EC2::*`, it should get you all EC2 components. When you search for region:us-*-1, it should give you us-east-1 and us-west-1.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: searched for AWS::EC2::* and region:us-*-1

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdldjZzMmVic3NnY2tmeWN5bG4yaTAxazQ1dmxndnA3YmFzNWhvNjk2OSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/opDRL3H2A9iLNuvbOv/giphy.gif"/>