### PR TITLE
feat(luminork): Error when a user tries to update a readonly property

### DIFF
--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -211,6 +211,9 @@ impl From<JsonRejection> for ComponentsError {
 impl crate::service::v1::common::ErrorIntoResponse for ComponentsError {
     fn status_and_message(&self) -> (StatusCode, String) {
         match self {
+            ComponentsError::Attribute(
+                dal::attribute::attributes::AttributesError::CannotUpdateCreateOnlyProperty(_),
+            ) => (StatusCode::PRECONDITION_FAILED, self.to_string()),
             ComponentsError::Component(dal::ComponentError::NotFound(_)) => {
                 (StatusCode::NOT_FOUND, self.to_string())
             }


### PR DESCRIPTION
FIXES: BUG-1080

When a user tries to update a read-only prop, we should throw a 412.

Trying to change the KeyName of an AWS::EC2::KeyPair as the following request:

```
curl -X 'PUT' \
  'http://localhost:5380/v1/w/01HPJ3K7RC486W9RPR3T0B6HS2/change-sets/01K6WQ2YG46GJYSXFA4S58F2EX/components/01K6WPWQX5VCJ2NETCDQ433VEP' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "attributes": {
    "/domain/KeyName": "updated-key-name
  }
}'
```
now throws an error so that the user knows what the issue is:

```
{
  "message": "attribute error: cannot update create-only property at path '/domain/KeyName' when component has a resource attached",
  "statusCode": 412,
  "code": null
}
```