### PR TITLE
fix(si-mcp-server): Capture when trying to update a read-only prop

### DIFF
--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -12,7 +12,7 @@
     "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
     "@std/assert": "jsr:@std/assert@1",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.1.8",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.3.0",
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",

--- a/bin/si-mcp-server/deno.lock
+++ b/bin/si-mcp-server/deno.lock
@@ -5,7 +5,6 @@
     "jsr:@std/assert@*": "1.0.14",
     "jsr:@std/fmt@^1.0.2": "1.0.8",
     "jsr:@std/internal@^1.0.10": "1.0.10",
-    "jsr:@systeminit/api-client@^1.1.8": "1.2.0",
     "npm:@modelcontextprotocol/sdk@^1.16.0": "1.18.1_express@5.1.0_zod@3.25.76",
     "npm:axios@^1.12.0": "1.12.2",
     "npm:axios@^1.6.1": "1.12.2",
@@ -36,12 +35,6 @@
     },
     "@std/internal@1.0.10": {
       "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
-    },
-    "@systeminit/api-client@1.2.0": {
-      "integrity": "c2e622d73ef8c8df57d21480f57718f0d21bb29db7f49e4e0c4e9b446ecbcc68",
-      "dependencies": [
-        "npm:axios@^1.6.1"
-      ]
     }
   },
   "npm": {
@@ -634,7 +627,7 @@
       "jsr:@onjara/optic@^2.0.3",
       "jsr:@std/assert@1",
       "jsr:@std/encoding@^1.0.10",
-      "jsr:@systeminit/api-client@^1.1.8",
+      "jsr:@systeminit/api-client@^1.3.0",
       "npm:@modelcontextprotocol/sdk@^1.16.0",
       "npm:axios@^1.6.1",
       "npm:jwt-decode@4",


### PR DESCRIPTION
Depends-on #7438

When a user tries to update a READ-ONLY prop, we need to capture the error and hint the user:

```
can you update the KeyPair component and set the KeyName to be "updated-name"

⏺ I'll update the KeyPair component's KeyName to "updated-name". Let me first find the KeyPair component and then update it.
  ⎿  <response>{"status":"success","data":[{"id":"01K6DS9XXCXW5EDW22920QRAQE","name":"HEAD","status":"Open","isHead":true}]}</response>
     <hints>Apply, Force-Apply, and Abandon change sets using their 'id' and the change-set-status-update tool.</hints>

⏺ si-mcp-server - component-list (MCP)(changeSetId: "01K6DS9XXCXW5EDW22920QRAQE", filters: {"filterGroups":[{"responseField":"schemaName","regularExpressions":["KeyPair"]}]})
  ⎿  <response>{"status":"success","data":[{"componentId":"01K6WPWQX5VCJ2NETCDQ433VEP","componentName":"si-2225","schemaName":"AWS::EC2::KeyPair"}]}</response>

⏺ I found a KeyPair component but I can't update it in HEAD. Let me create a change set for you first.

⏺ si-mcp-server - change-set-create (MCP)(changeSetName: "Update KeyPair name")
  ⎿  <response>{"status":"success","data":{"id":"01K6WSGTRGM7P5FP6FA5R60R03","name":"Update KeyPair name","status":"Open","isHead":false}}</response>

⏺ si-mcp-server - component-update (MCP)(changeSetId: "01K6WSGTRGM7P5FP6FA5R60R03", componentId: "01K6WPWQX5VCJ2NETCDQ433VEP", attributes: {"/domain/KeyName":"updated-name"})
  ⎿  Error: <response>{"status":"failure","errorMessage":"Error Status: 412\nError Data: {\"message\":\"attribute error: cannot update create-only property at path '/domain/KeyName' when component has
      a resource attached\",\"statusCode\":412,\"code\":null}\nMessage:Request failed with status code 412"}</response>
     <hints>The property '/domain/KeyName' is read-only and cannot be updated once a resource is attached. Consider duplicating this component with the new value instead.</hints>

⏺ The KeyName property is read-only once the KeyPair resource exists. You can't update it. You would need to create a new KeyPair component with the desired name instead.
```