### PR TITLE
Disable eviction grace period

### DIFF
--- a/lib/rebaser-server/src/config.rs
+++ b/lib/rebaser-server/src/config.rs
@@ -37,7 +37,7 @@ const DEFAULT_CONCURRENCY_LIMIT: Option<usize> = None;
 const DEFAULT_QUIESCENT_PERIOD_SECS: u64 = 60 * 5;
 const DEFAULT_QUIESCENT_PERIOD: Duration = Duration::from_secs(DEFAULT_QUIESCENT_PERIOD_SECS);
 
-const DEFAULT_SNAPSHOT_EVICTION_GRACE_PERIOD_SECS: u64 = 60; // 1 minute
+const DEFAULT_SNAPSHOT_EVICTION_GRACE_PERIOD_SECS: u64 = 0; // Disabled until eviction handles not to-rebase snapshots better.
 const DEFAULT_SNAPSHOT_EVICTION_GRACE_PERIOD: Duration =
     Duration::from_secs(DEFAULT_SNAPSHOT_EVICTION_GRACE_PERIOD_SECS);
 


### PR DESCRIPTION
The eviction code is only looking at the snapshot the change set pointer is moving _from_, and not considering previous snapshots, which means that we're never evicting snapshots that are older than the grace period if the last time they were used was while their creation was still within the grace period (which is very common in active change sets).