### PR TITLE
fix: Don't load workspace snapshot unnecessarily

### DIFF
--- a/lib/luminork-server/src/service/v1/change_sets/request_approval.rs
+++ b/lib/luminork-server/src/service/v1/change_sets/request_approval.rs
@@ -45,12 +45,7 @@ use crate::extract::{
 )]
 pub async fn request_approval(
     ChangeSetDalContext(ref mut ctx): ChangeSetDalContext,
-    WorkspaceAuthorization {
-        workspace_id,
-        ctx: _,
-        user: _,
-        authorized_role: _,
-    }: WorkspaceAuthorization,
+    WorkspaceAuthorization { workspace_id, .. }: WorkspaceAuthorization,
     tracker: PosthogEventTracker,
     Host(_host_name): Host,
 ) -> ChangeSetResult<Json<RequestApprovalChangeSetV1Response>> {

--- a/lib/luminork-server/src/service/whoami.rs
+++ b/lib/luminork-server/src/service/whoami.rs
@@ -65,14 +65,11 @@ pub async fn whoami(
     ValidatedToken(token): ValidatedToken,
     tracker: PosthogEventTracker,
     WorkspaceAuthorization {
-        ctx,
-        workspace_id,
-        user,
-        ..
+        workspace_id, user, ..
     }: WorkspaceAuthorization,
 ) -> impl IntoResponse {
-    tracker.track(
-        &ctx,
+    tracker.track_no_ctx_workspace(
+        workspace_id,
         "api_whoami",
         json!({
             "user_id": user.pk(),

--- a/lib/sdf-extract/src/services.rs
+++ b/lib/sdf-extract/src/services.rs
@@ -127,6 +127,23 @@ impl PosthogEventTracker {
             properties,
         )
     }
+
+    pub fn track_no_ctx_workspace(
+        &self,
+        workspace_id: WorkspacePk,
+        event_name: impl AsRef<str>,
+        properties: serde_json::Value,
+    ) {
+        sdf_core::tracking::track_no_ctx_workspace(
+            &self.posthog_client,
+            &self.original_uri,
+            &self.host,
+            "anonymous".to_string(),
+            workspace_id,
+            event_name,
+            properties,
+        )
+    }
 }
 
 #[async_trait]

--- a/lib/sdf-extract/src/v1.rs
+++ b/lib/sdf-extract/src/v1.rs
@@ -31,7 +31,10 @@ impl FromRequestParts<AppState> for AccessBuilder {
     ) -> Result<Self, Self::Rejection> {
         // Ensure we get the workspace ID from the token
         let _: TargetWorkspaceIdFromToken = parts.extract_with_state(state).await?;
-        let WorkspaceAuthorization { ctx, .. } = parts.extract_with_state(state).await?;
-        Ok(Self(ctx.access_builder()))
+        let WorkspaceAuthorization {
+            ctx_without_snapshot,
+            ..
+        } = parts.extract_with_state(state).await?;
+        Ok(Self(ctx_without_snapshot.access_builder()))
     }
 }

--- a/lib/sdf-server/src/service/v2.rs
+++ b/lib/sdf-server/src/service/v2.rs
@@ -80,7 +80,10 @@ impl FromRequestParts<AppState> for AccessBuilder {
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
         // Ensure the endpoint is authorized
-        let WorkspaceAuthorization { ctx, .. } = parts.extract_with_state(state).await?;
-        Ok(Self(ctx.access_builder()))
+        let WorkspaceAuthorization {
+            ctx_without_snapshot,
+            ..
+        } = parts.extract_with_state(state).await?;
+        Ok(Self(ctx_without_snapshot.access_builder()))
     }
 }


### PR DESCRIPTION
This fixes a couple of performance problems caused by loading snapshots we don't use in SDF and Luminork API endpoints:
1. *All* Luminork and SDF API endpoints load the HEAD snapshot, even when they only need the changeset snapshot.
2. Some Luminork and SDF API endpoints do not need snapshots at all, and load both HEAD and changeset snapshots.

This primarily affects endpoint speed during times of heavy load / DVU when the workspace is *changing*; repeated reloads of the same snapshot in the same SDF are cached and do not affect performance.

## This PR

To fix this, we:
* Remove snapshot loading from `WorkspaceAuthorization` and `ChangeSetAuthorization` (which are used on all endpoints)
* Rename the ctx exposed by those extractors to `ctx_without_snapshot` to make it clear to the caller what's happening.
* Review the very few callers that use that ctx, and make sure they don't need the snapshot (they don't).
* Load the snapshot in the `WorkspaceDalContext` and `ChangeSetDalContext` extractors, restoring parity so that all existing endpoints still have a snapshot.

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: search endpoint has much less overhead
- [X] Manual test: luminork API endpoints authorize
- [X] Manual test: can load a changeset, create component, watch WsEvents fly by, apply changeset
- [X] Manual test: login, logout, reload

## In short: [:link:](https://giphy.com/)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdleTVsd2t4Mjd4amF4MmhtMnJ0eDY1aWtmZTFrZzZibThreWc3ZGVvdSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/pX3q0vHXKjwOY/giphy.gif"/>
