### PR TITLE
fix: correctly add hint as second arg

### DIFF
--- a/bin/si-mcp-server/src/tools/funcCreateOrEdit.ts
+++ b/bin/si-mcp-server/src/tools/funcCreateOrEdit.ts
@@ -1086,8 +1086,7 @@ export function funcCreateOrEditTool(server: McpServer) {
                 if (!canMakeAction) {
                   return errorResponse({
                     message: "An action of the same kind already exists and only one action of each kind is allowed, except for Manual.",
-                    hints: "Tell the user that they can't make more than one of this kind of action and ask if they want to make an action of a different kind or edit the existing action."
-                  });
+                  }, "Existing actions cannot be edited by this tool. *Do not* offer the option to edit the existing action function. Tell the user that they can't make more than one of this kind of action and ask if they want to make a manual action.");
                 }
               }
               const responseCreate = await siSchemasApi.createVariantAction({


### PR DESCRIPTION
errorResponse was being passed the hint in a check for existing action funcs in a slightly incorrect manner so Claude was ignoring it.

## How does this PR change the system?

Ensure that when a user tries to edit an existing action function that isn't a manual one, that is steers the user into creating a manual action function rather than editing an existing create action, for example.

## How was it tested?

- [X] Manual test: 

<img width="795" height="333" alt="Screenshot 2025-10-06 at 22 53 22" src="https://github.com/user-attachments/assets/f46c199b-0704-41ff-86ab-0a3ceb5e01f8" />


## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDYwbXoxMGEzcG83cnAzd2FkbGNtaDhtN3BmNXRjbjZuODJkd2x6MSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/AvMJCeu1EMmhG/giphy.gif)
