### PR TITLE
debug panel now shows both schema id and schema variant id

### DIFF
--- a/app/web/src/newhotness/ComponentDebugPanel.vue
+++ b/app/web/src/newhotness/ComponentDebugPanel.vue
@@ -37,21 +37,29 @@
           <h3 class="text-base font-semibold mb-xs" :class="headerClass">
             Component Details
           </h3>
-          <div class="space-y-2xs text-xs">
+          <div
+            :class="
+              clsx(
+                'space-y-2xs text-xs',
+                '[&_div]:flex [&_div]:flex-row [&_div]:gap-xs [&_div]:flex-wrap [&_h3]:font-semibold [&_p]:font-mono [&_p]:text-2xs [&_p]:break-all',
+              )
+            "
+          >
             <div>
-              <span class="font-semibold">Name:</span> {{ componentData.name }}
+              <h3>Name:</h3>
+              <p>{{ componentData.name }}</p>
             </div>
             <div>
-              <span class="font-semibold">Schema ID:</span>
-              <span class="font-mono text-2xs break-all">{{
-                componentData.schemaVariantId
-              }}</span>
+              <h3>Schema ID:</h3>
+              <p>{{ componentData.schemaId }}</p>
+            </div>
+            <div>
+              <h3>Schema Variant ID:</h3>
+              <p>{{ componentData.schemaVariantId }}</p>
             </div>
             <div v-if="componentData.parentId">
-              <span class="font-semibold">Parent ID:</span>
-              <span class="font-mono text-2xs break-all">{{
-                componentData.parentId
-              }}</span>
+              <h3>Parent ID:</h3>
+              <p>{{ componentData.parentId }}</p>
             </div>
           </div>
         </div>
@@ -414,12 +422,14 @@ import { computed, ref } from "vue";
 import { useQuery } from "@tanstack/vue-query";
 import { SiSearch, themeClasses } from "@si/vue-lib/design-system";
 import { tw } from "@si/vue-lib";
+import clsx from "clsx";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { routes, useApi } from "./api_composables";
 import EmptyState from "./EmptyState.vue";
 
 interface ComponentDebugView {
   name: string;
+  schemaId: string;
   schemaVariantId: string;
   attributes: AttributeDebugView[];
   inputSockets: SocketDebugView[];

--- a/lib/dal/src/component/debug.rs
+++ b/lib/dal/src/component/debug.rs
@@ -4,6 +4,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use si_id::SchemaId;
 use telemetry::prelude::*;
 use thiserror::Error;
 
@@ -65,6 +66,7 @@ type ComponentDebugViewResult<T> = Result<T, ComponentDebugViewError>;
 #[serde(rename_all = "camelCase")]
 pub struct ComponentDebugView {
     pub name: String,
+    pub schema_id: SchemaId,
     pub schema_variant_id: SchemaVariantId,
     pub attributes: Vec<AttributeDebugView>,
     pub input_sockets: Vec<SocketDebugView>,
@@ -78,6 +80,7 @@ pub struct ComponentDebugView {
 #[serde(rename_all = "camelCase")]
 pub struct ComponentDebugData {
     pub name: String,
+    pub schema_id: SchemaId,
     pub schema_variant_id: SchemaVariantId,
     pub attribute_tree: HashMap<AttributeValueId, Vec<AttributeValueId>>,
     pub input_sockets: Vec<ComponentInputSocket>,
@@ -188,6 +191,7 @@ impl ComponentDebugView {
 
         let debug_view = ComponentDebugView {
             name: component_debug_data.name,
+            schema_id: component_debug_data.schema_id,
             schema_variant_id: component_debug_data.schema_variant_id,
             attributes,
             input_sockets,
@@ -203,6 +207,7 @@ impl ComponentDebugData {
     #[instrument(level = "trace", skip_all)]
     pub async fn new(ctx: &DalContext, component: &Component) -> ComponentDebugViewResult<Self> {
         let schema_variant_id = Component::schema_variant_id(ctx, component.id()).await?;
+        let schema_id = Component::schema_id_for_component_id(ctx, component.id()).await?;
         let attribute_tree =
             Self::get_attribute_value_tree_for_component(ctx, component.id()).await?;
         let input_sockets =
@@ -216,6 +221,7 @@ impl ComponentDebugData {
 
         let debug_view = ComponentDebugData {
             name,
+            schema_id,
             schema_variant_id,
             attribute_tree,
             input_sockets,


### PR DESCRIPTION
## How does this PR change the system?

Previously the `ComponentDebugPanel` was displaying only the schema variant id of the component, incorrectly labeled as "schema ID"

This changes it to show both the correct schema id and schema variant id for the component.

#### Screenshots:

<img width="328" height="119" alt="Screenshot 2025-10-06 at 6 09 37 PM" src="https://github.com/user-attachments/assets/b1ab7568-0724-4256-90e9-9ffdd3274737" />