### PR TITLE
collapsing panels in FuncRunDetails right column

### DIFF
--- a/app/web/src/components/CodeViewer.vue
+++ b/app/web/src/components/CodeViewer.vue
@@ -44,10 +44,10 @@
       @click="copyCodeToClipboard"
     />
     <div
-      v-if="numberOfLinesInCode > 1"
+      v-if="numberOfLinesInCode > 1 || forceLineNumbers"
       :class="
         clsx(
-          'w-full h-full overflow-auto',
+          'w-full h-full overflow-auto scrollable',
           border && 'border',
           themeClasses('border-neutral-300', 'border-neutral-600'),
         )
@@ -55,7 +55,7 @@
     >
       <div
         ref="editorMountRef"
-        class="w-full h-full overflow-auto"
+        class="w-full h-full overflow-auto scrollable"
         @keyup.stop
         @keydown.stop
       ></div>
@@ -74,7 +74,7 @@
         )
       "
     >
-      <div class="overflow-auto">{{ code }}</div>
+      <div class="overflow-auto scrollable">{{ code }}</div>
     </div>
   </div>
 </template>
@@ -133,6 +133,7 @@ const props = defineProps({
   border: { type: Boolean, default: false },
   disableScroll: { type: Boolean },
   copyTooltip: { type: String, default: "Copy code to clipboard" },
+  forceLineNumbers: { type: Boolean }, // forces line numbers even for a one line string
 });
 
 const numberOfLinesInCode = computed(() => {
@@ -203,7 +204,10 @@ const editorExtensionList = computed<Extension[]>(() => {
 function initCodeMirrorEditor() {
   editorView = new EditorView({
     state: EditorState.create({
-      doc: props.code,
+      doc:
+        numberOfLinesInCode.value === 1 && props.forceLineNumbers
+          ? `${props.code}\n`
+          : props.code,
       extensions: editorExtensionList.value,
     }),
     parent: editorMountRef.value,

--- a/app/web/src/newhotness/FuncRunDetails.vue
+++ b/app/web/src/newhotness/FuncRunDetails.vue
@@ -14,6 +14,7 @@
     "
     :errorMessageRaw="managementFuncJobState?.message"
     :isLive="isLive"
+    :collapsingStyles="collapsingStyles"
   >
     <template #headerList>
       <template v-if="funcRun.functionKind">
@@ -61,36 +62,39 @@
       />
     </template>
     <template #grid>
-      <GridItemWithLiveHeader title="Code" :live="false">
+      <GridItemWithLiveHeader ref="codeRef" title="Code" :live="false">
         <CodeViewer
           v-if="functionCode"
           :code="functionCode"
           language="javascript"
           allowCopy
+          forceLineNumbers
         />
         <div v-else class="text-neutral-400 italic text-xs p-xs">
           No code available
         </div>
       </GridItemWithLiveHeader>
 
-      <GridItemWithLiveHeader title="Arguments" :live="false">
+      <GridItemWithLiveHeader ref="argsRef" title="Arguments" :live="false">
         <CodeViewer
           v-if="argsJson"
           :code="argsJson"
           language="json"
           allowCopy
+          forceLineNumbers
         />
         <div v-else class="text-neutral-400 italic text-xs p-xs">
           No arguments available
         </div>
       </GridItemWithLiveHeader>
 
-      <GridItemWithLiveHeader title="Result" :live="false">
+      <GridItemWithLiveHeader ref="resultRef" title="Result" :live="false">
         <CodeViewer
           v-if="resultJson"
           :code="resultJson"
           language="json"
           allowCopy
+          forceLineNumbers
         />
         <div v-else class="text-neutral-400 italic text-xs p-xs">
           No result available
@@ -370,5 +374,15 @@ onMounted(() => {
 // Ensure cleanup on component unmount
 onBeforeUnmount(() => {
   keyEmitter.off("Escape");
+});
+
+const codeRef = ref<InstanceType<typeof GridItemWithLiveHeader>>();
+const argsRef = ref<InstanceType<typeof GridItemWithLiveHeader>>();
+const resultRef = ref<InstanceType<typeof GridItemWithLiveHeader>>();
+
+// Calculate collapsing styles
+const collapsingStyles = computed(() => {
+  if (!codeRef.value || !argsRef.value || !resultRef.value) return undefined;
+  return `grid-template-rows: ${codeRef.value.collapseStyle} ${argsRef.value.collapseStyle} ${resultRef.value.collapseStyle};`;
 });
 </script>

--- a/app/web/src/newhotness/LatestFuncRunDetails.vue
+++ b/app/web/src/newhotness/LatestFuncRunDetails.vue
@@ -29,12 +29,18 @@
     </template>
 
     <template #grid>
-      <GridItemWithLiveHeader class="row-span-3" title="Code" :live="false">
+      <GridItemWithLiveHeader
+        class="row-span-3"
+        title="Code"
+        :live="false"
+        disableCollapse
+      >
         <CodeViewer
           v-if="functionCode"
           :code="functionCode"
           language="javascript"
           allowCopy
+          forceLineNumbers
         />
         <div v-else class="text-neutral-400 italic text-xs p-xs">
           No code available
@@ -45,12 +51,14 @@
         class="row-span-3"
         title="Arguments"
         :live="false"
+        disableCollapse
       >
         <CodeViewer
           v-if="argsJson"
           :code="argsJson"
           language="json"
           allowCopy
+          forceLineNumbers
         />
         <div v-else class="text-neutral-400 italic text-xs p-xs">
           No arguments available

--- a/app/web/src/newhotness/layout_components/CollapsingGridItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingGridItem.vue
@@ -4,16 +4,21 @@
       :class="
         clsx(
           'group/header flex flex-row items-center h-[40px]',
-          'cursor-pointer text-lg font-bold px-xs py-xs flex-none border',
+          'text-lg font-bold px-xs py-xs flex-none border',
           themeClasses(
-            'bg-neutral-300 hover:bg-neutral-400 border-neutral-400',
-            'bg-neutral-800 hover:bg-neutral-700 border-neutral-600',
+            'bg-neutral-300 border-neutral-400',
+            'bg-neutral-800 border-neutral-600',
           ),
+          !disableCollapse && [
+            'cursor-pointer',
+            themeClasses('hover:bg-neutral-400', 'hover:bg-neutral-700'),
+          ],
         )
       "
-      @click="openState.toggle"
+      @click="toggleOpen"
     >
       <Icon
+        v-if="!disableCollapse"
         class="group-hover/header:scale-125 mr-xs"
         :name="openState.open.value ? 'chevron-down' : 'chevron-right'"
         size="sm"
@@ -24,9 +29,18 @@
     </h3>
     <div
       :class="
-        disableScroll
-          ? 'overflow-hidden flex flex-col min-h-[calc(100%-40px)]'
-          : 'scrollable flex-1 min-h-0'
+        clsx(
+          disableScroll
+            ? 'overflow-hidden flex flex-col min-h-[calc(100%-40px)]'
+            : 'scrollable flex-1 min-h-0',
+          funcRunScreen && [
+            'border-x border-b',
+            themeClasses(
+              'bg-neutral-300 border-neutral-400',
+              'bg-neutral-800 border-neutral-600',
+            ),
+          ],
+        )
       "
     >
       <slot />
@@ -39,11 +53,17 @@ import { Icon, themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useToggle } from "../logic_composables/toggle_containers";
 
-defineProps({
+const props = defineProps({
   disableScroll: { type: Boolean },
+  disableCollapse: { type: Boolean },
+  funcRunScreen: { type: Boolean },
 });
 
 const openState = useToggle();
+const toggleOpen = () => {
+  if (props.disableCollapse) return;
+  openState.toggle();
+};
 
 defineExpose({
   openState,

--- a/app/web/src/newhotness/layout_components/GridItemWithLiveHeader.vue
+++ b/app/web/src/newhotness/layout_components/GridItemWithLiveHeader.vue
@@ -1,26 +1,23 @@
 <template>
-  <div
-    :class="
-      clsx(
-        'flex flex-col rounded overflow-hidden border',
-        themeClasses(
-          'bg-neutral-200 border-neutral-300',
-          'bg-neutral-800 border-neutral-600',
-        ),
-      )
-    "
+  <CollapsingGridItem
+    ref="collapseRef"
+    funcRunScreen
+    disableScroll
+    :disableCollapse="disableCollapse"
   >
-    <div class="flex flex-row items-center justify-between px-sm py-2xs">
-      <h2 class="text-sm font-medium pt-xs pb-xs">{{ title }}</h2>
-      <!-- Live updating indicator -->
-      <div
-        v-if="live"
-        class="grow flex flex-row items-center text-xs text-action-400 ml-2"
-      >
-        <Icon name="loader" size="xs" class="mr-2xs" />
-        Live
+    <template #header>
+      <div class="flex flex-row items-center justify-between px-sm py-2xs">
+        <h2 class="text-sm font-medium pt-xs pb-xs">{{ title }}</h2>
+        <!-- Live updating indicator -->
+        <div
+          v-if="live"
+          class="grow flex flex-row items-center text-xs text-action-400 ml-2"
+        >
+          <Icon name="loader" size="xs" class="mr-2xs" />
+          Live
+        </div>
       </div>
-    </div>
+    </template>
     <div
       :class="
         clsx(
@@ -29,17 +26,34 @@
         )
       "
     >
-      <slot></slot>
+      <slot />
     </div>
-  </div>
+  </CollapsingGridItem>
 </template>
 
 <script setup lang="ts">
 import { Icon, themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
+import { computed, ref } from "vue";
+import CollapsingGridItem from "./CollapsingGridItem.vue";
+import { gridCollapseStyle } from "../util";
 
 defineProps<{
   live: boolean;
   title: string;
+  disableCollapse?: boolean;
 }>();
+
+const collapseRef = ref<InstanceType<typeof CollapsingGridItem>>();
+
+const collapseStyle = computed(() => {
+  if (collapseRef.value) {
+    return gridCollapseStyle(collapseRef.value.openState.open);
+  }
+  return "1fr";
+});
+
+defineExpose({
+  collapseStyle,
+});
 </script>


### PR DESCRIPTION
## How does this PR change the system?

UI improvements to the `FuncRunDetails` page, primarily the ability to collapse/expand the three panels on the right side.

#### Screenshots:

<img width="1913" height="870" alt="Screenshot 2025-10-06 at 8 28 41 PM" src="https://github.com/user-attachments/assets/5d7a29c3-6c3c-4870-81d1-5f5a47675003" />

#### Out of Scope:

The left panel does not collapse, nor does either column in `LatestFuncRunDetails`