### PR TITLE
feat(mcp-server): Add the ability to trigger the discovery of Hetzner assets in si-mcp-server

### DIFF
--- a/bin/si-mcp-server/deno.lock
+++ b/bin/si-mcp-server/deno.lock
@@ -1,11 +1,20 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/flags@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@onjara/optic@^2.0.3": "2.0.3",
     "jsr:@std/assert@*": "1.0.14",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fmt@^1.0.2": "1.0.8",
+    "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@systeminit/api-client@^1.3.0": "1.3.0",
     "npm:@modelcontextprotocol/sdk@^1.16.0": "1.18.1_express@5.1.0_zod@3.25.76",
+    "npm:axios@*": "1.12.2",
     "npm:axios@^1.12.0": "1.12.2",
     "npm:axios@^1.6.1": "1.12.2",
     "npm:dotenv@^16.3.1": "16.6.1",
@@ -18,10 +27,35 @@
     "npm:zod@^3.21.4": "3.25.76"
   },
   "jsr": {
+    "@cliffy/command@1.0.0-rc.8": {
+      "integrity": "758147790797c74a707e5294cc7285df665422a13d2a483437092ffce40b5557",
+      "dependencies": [
+        "jsr:@cliffy/flags",
+        "jsr:@cliffy/internal",
+        "jsr:@cliffy/table",
+        "jsr:@std/fmt@~1.0.2",
+        "jsr:@std/text"
+      ]
+    },
+    "@cliffy/flags@1.0.0-rc.8": {
+      "integrity": "0f1043ce6ef037ba1cb5fe6b1bcecb25dc2f29371a1c17f278ab0f45e4b6f46c",
+      "dependencies": [
+        "jsr:@std/text"
+      ]
+    },
+    "@cliffy/internal@1.0.0-rc.8": {
+      "integrity": "34cdf2fad9b084b5aed493b138d573f52d4e988767215f7460daf0b918ff43d8"
+    },
+    "@cliffy/table@1.0.0-rc.8": {
+      "integrity": "8bbcdc2ba5e0061b4b13810a24e6f5c6ab19c09f0cce9eb691ccd76c7c6c9db5",
+      "dependencies": [
+        "jsr:@std/fmt@~1.0.2"
+      ]
+    },
     "@onjara/optic@2.0.3": {
       "integrity": "b4bf8cae0820a3c3f362ba4d78939237fcfa23e3087bbd3f9fd3c883839820f1",
       "dependencies": [
-        "jsr:@std/fmt"
+        "jsr:@std/fmt@^1.0.2"
       ]
     },
     "@std/assert@1.0.14": {
@@ -30,11 +64,23 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
     "@std/internal@1.0.10": {
       "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    },
+    "@std/text@1.0.16": {
+      "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
+    },
+    "@systeminit/api-client@1.3.0": {
+      "integrity": "b2a1171055c389f00ae6dfbbc56817edc36a5ca5a4833895be8a39843dbdeae5",
+      "dependencies": [
+        "npm:axios@^1.6.1"
+      ]
     }
   },
   "npm": {

--- a/bin/si-mcp-server/src/data/schemaHints.ts
+++ b/bin/si-mcp-server/src/data/schemaHints.ts
@@ -1,0 +1,37 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { errorResponse } from "../tools/commonBehavior.ts";
+
+export function validateSchemaPrereqs(
+  schemaName: string,
+  attributes: Record<string, unknown>,
+): CallToolResult | null {
+  // quick lookups instead of looping
+  const has = (key: string) =>
+    Object.prototype.hasOwnProperty.call(attributes, key);
+
+  if (schemaName.startsWith("AWS")) {
+    const hasRegion = has("/domain/extra/Region");
+    const hasCredential = has("/secrets/AWS Credential");
+
+    if (!hasRegion || !hasCredential) {
+      return errorResponse({
+        response: { status: "bad prereq", data: {} },
+        message:
+          "This is an AWS resource, and to import it we must have /domain/extra/Region set to a valid value or subscription, and /secrets/AWS Credential set to a subscription.",
+      });
+    }
+  }
+
+  if (schemaName.startsWith("Hetzner")) {
+    const hasCredential = has("/secrets/Hetzner Api Token");
+    if (!hasCredential) {
+      return errorResponse({
+        response: { status: "bad prereq", data: {} },
+        message:
+          "This is a Hetzner resource, and to import it we must have /secrets/Hetzner API Token set to a subscription.",
+      });
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
```
⏺ Great! The discovery was actually successful - it found 1 server. The error message was misleading. Let me check the components in the change set to see the discovered server:

⏺ si-mcp-server - component-list (MCP)(changeSetId: "01K6XSA575QK3Y3MDG9DKDW58E", filters: {"filterGroups":[{"responseField":"schemaName","regularExpressions":["Hetzner::Cloud::Servers"]}]})
  ⎿ <response>{"status":"success","data":[{"componentId":"01K6XSW6TNFFQWD6E8BNCFPDCN","componentName":"Discover Hetzner::Cloud::Servers - Temporary","schemaName":"Hetzner::Cloud::Servers"}]}</re
    sponse>


⏺ I discovered 1 Hetzner Cloud server in your account:

  Server Details:
  - Name: ubuntu-2gb-nbg1-1
  - ID: 110313551
  - Status: running
  - Server Type: cpx11 (CPX 11 - 2 vCPU cores, 2GB RAM, 40GB disk)
  - Location: Nuremberg (nbg1-dc3)
  - Image: Ubuntu 24.04
  - Public IPv4: 116.203.245.234
  - Public IPv6: 2a01:4f8:1c1a:4aaf::/64
  - Created: 2025-10-06T21:54:44Z
  - Monthly Cost: €4.49 (net) / €4.49 (gross)

  The server has been discovered and is now available in the "Discover Hetzner Servers" change set. You can view it in the System Initiative web interface or manage it through further MCP
  commands.
```