### PR TITLE
feat(RBE): only enable if SI_RBE_TOKEN is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ __pycache__
 
 # Buck
 /buck-out/
+/.buckconfig.d/
 
 # Nix builds
 /result

--- a/bin/edda/Dockerfile
+++ b/bin/edda/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/forklift/Dockerfile
+++ b/bin/forklift/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/innit/Dockerfile
+++ b/bin/innit/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/innitctl/Dockerfile
+++ b/bin/innitctl/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/luminork/Dockerfile
+++ b/bin/luminork/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/module-index/Dockerfile
+++ b/bin/module-index/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/pinga/Dockerfile
+++ b/bin/pinga/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/rebaser/Dockerfile
+++ b/bin/rebaser/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/sdf/Dockerfile
+++ b/bin/sdf/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/bin/veritech/Dockerfile
+++ b/bin/veritech/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /workdir
 COPY --from=buck2 /bin/buck2 /usr/local/bin/buck2
 
 RUN buck2 build bin/$BIN:$BIN \
+    --config rbe.enabled=true \
     --out /tmp/local-bin/$BIN
 
 FROM debian:${BASE_VERSION} AS final

--- a/flake.nix
+++ b/flake.nix
@@ -390,7 +390,20 @@
         };
 
         devShells.default = mkShell {
-          shellHook = with pkgs; if pkgs.stdenv.isLinux then ''
+          shellHook = with pkgs; ''
+            mkdir -p .buckconfig.d
+            if [ -n "$SI_RBE_TOKEN" ]; then
+              cat > .buckconfig.d/10-nix.buckconfig <<EOF
+[rbe]
+enabled = true
+EOF
+            else
+              cat > .buckconfig.d/10-nix.buckconfig <<EOF
+[rbe]
+enabled = false
+EOF
+            fi
+          '' + (if pkgs.stdenv.isLinux then ''
             export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
             export BINDGEN_EXTRA_CLANG_ARGS="\
               $(< ${pkgs.stdenv.cc}/nix-support/libc-crt1-cflags) \
@@ -400,7 +413,7 @@
               $NIX_CFLAGS_COMPILE"
             export OUT=${placeholder "out"}
             echo $OUT
-          '' else "";
+          '' else "");
           packages =
             [
               alejandra

--- a/prelude-si/platforms/defs.bzl
+++ b/prelude-si/platforms/defs.bzl
@@ -34,7 +34,9 @@ def _execution_platform_impl(ctx: AnalysisContext) -> list[Provider]:
 
     name = ctx.label.raw_target()
 
-    remote_enabled = False if (is_macos) else True
+    # Check if RBE is enabled via buckconfig (set by Nix flake based on SI_RBE_TOKEN)
+    rbe_enabled = read_root_config("rbe", "enabled", "false") == "true"
+    remote_enabled = False if (is_macos) else rbe_enabled
 
     platform = ExecutionPlatformInfo(
         label = name,


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Disable RBE by default. Enable it if the `SI_RBE_TOKEN` env var is set. 

This is done by using the nix flake to write a secondary buckconfig file that sets a value we check when setting up RBE.


## How was it tested?

Locally. This will rebuild the world, so if all of those tests pass this should be okay.

- [X] Integration tests pass
- [X] Manual test: new functionality works locally

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZW9wOHc3Z2Z0czhkbDgxMHg5YThiYWFtajdtdjU0dHptOWtmNGc1eCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEdv3yyWiMAtYlopq/giphy.gif"/>