### PR TITLE
feat(web): Skip onboarding flow for invited users

### DIFF
--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -38,6 +38,7 @@ export enum routes {
   ChangeSetReopen = "ChangeSetReopen",
   ChangeSetRequestApproval = "ChangeSetRequestApproval",
   ComponentDebug = "ComponentDebug",
+  ComponentsOnHead = "ComponentsOnHead",
   CreateComponent = "CreateComponent",
   CreateSecret = "CreateSecret",
   CreateTemplate = "CreateTemplate",
@@ -149,6 +150,7 @@ const _routes: Record<routes, string> = {
   ChangeSets: "/change-sets",
   CreateChangeSet: "/change-sets/create_change_set",
   ChangeSetInitializeAndApply: "/change-sets/create_initialize_apply",
+  ComponentsOnHead: "/change-sets/components_on_head",
   WorkspaceListUsers: "/users",
   // Auth Api Endpoints
   Workspaces: "/workspaces",

--- a/lib/sdf-server/src/service/v2/change_set.rs
+++ b/lib/sdf-server/src/service/v2/change_set.rs
@@ -46,6 +46,7 @@ mod apply;
 mod approval_status;
 mod approve;
 mod cancel_approval_request;
+mod components_on_head;
 mod create;
 mod create_initialize_apply;
 mod force_apply;
@@ -222,6 +223,10 @@ pub async fn post_to_webhook(
 pub fn change_sets_routes() -> Router<AppState> {
     Router::new()
         .route("/", get(list::list_actionable))
+        .route(
+            "/components_on_head",
+            get(components_on_head::components_on_head),
+        )
         .route("/create_change_set", post(create::create_change_set))
         .route(
             "/create_initialize_apply",

--- a/lib/sdf-server/src/service/v2/change_set/components_on_head.rs
+++ b/lib/sdf-server/src/service/v2/change_set/components_on_head.rs
@@ -1,0 +1,25 @@
+use axum::Json;
+use dal::Component;
+use sdf_extract::workspace::WorkspaceDalContext;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::Result;
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentsOnHeadResponse {
+    components_found: bool,
+}
+
+pub async fn components_on_head(
+    WorkspaceDalContext(ref mut ctx): WorkspaceDalContext,
+) -> Result<Json<ComponentsOnHeadResponse>> {
+    let components_on_head = Component::list_ids(ctx).await?;
+
+    Ok(Json(ComponentsOnHeadResponse {
+        components_found: !components_on_head.is_empty(),
+    }))
+}


### PR DESCRIPTION
If a user has onboard to a workspace and then invites another user and that user is new to SI, we should skip the onboarding flow for that invited user.

The way we determine if the workspace has been onboarded is that there are components on HEAD. These components would be the credential and the region as part of the onboarding

If a user deletes them, then it’s fine for an invited user to go through onboarding as the aim of the game is to make that workspace ready for action!