### PR TITLE
Fix: URL path is incorrect, turn the tanstack call off once its successful (or tanstack puts you back into lobby on tab re-focus)

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -489,9 +489,11 @@ const checkOnboardingCompleteData = async () => {
   onboardingCompleted.value = !data.firstTimeModal;
 };
 
+const cohEnabled = ref(true);
 const componentsOnHeadApi = useApi(ctx.value);
 const componentsOnHeadQuery = useQuery<boolean | undefined>({
   queryKey: ["componentsOnHead", workspacePk.value],
+  enabled: cohEnabled,
   queryFn: async () => {
     const call = componentsOnHeadApi.endpoint<{ componentsOnHead: boolean }>(
       routes.ComponentsOnHead,
@@ -500,6 +502,7 @@ const componentsOnHeadQuery = useQuery<boolean | undefined>({
 
     // Check if the request was successful (200/201)
     if (componentsOnHeadApi.ok(response)) {
+      cohEnabled.value = false;
       return response.data.componentsOnHead;
     }
 

--- a/app/web/src/newhotness/api_composables/index.ts
+++ b/app/web/src/newhotness/api_composables/index.ts
@@ -274,6 +274,7 @@ export class APICall<Response, Args> {
         _routes.CreateChangeSet,
         _routes.ChangeSetInitializeAndApply,
         _routes.WorkspaceListUsers,
+        _routes.ComponentsOnHead,
       ].includes(this.path)
     ) {
       return `v2/workspaces/${this.workspaceId}${this.pathWithArgs()}`;


### PR DESCRIPTION
## How does this PR change the system?

1. tan stack re-fires the API call after `staleTime` if you leave the tab and come back
2. this brings you back into the lobby momentarily, which looks like an empty screen
3. this happened on _every_ page in the app
4. also, the API path was wrong and it was 404ing

Disable the tan stack call after it succeeds.

## How was it tested?

1. load SI
2. see `components_on_head` go 200
3. count to 5
4. change tabs
5. go back to SI
6. don't see lobby / "empty" page for a second.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlc2YyYnF3bnd0emVlOHZmb25yYnVqc25oNjcxbTUxa2ttY3pqbGNzdyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/hIzxE7RCcPNtOvI6RY/giphy.gif"/>