### PR TITLE
feat(web): Add ability to select all components in row header

### DIFF
--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -35,6 +35,12 @@
       "
       @unpin="(componentId) => $emit('unpin', componentId)"
       @resetFilter="$emit('resetFilter')"
+      @selectAllInSection="
+        (sectionKey) => $emit('selectAllInSection', sectionKey)
+      "
+      @deselectAllInSection="
+        (sectionKey) => $emit('deselectAllInSection', sectionKey)
+      "
     />
   </div>
 </template>
@@ -206,6 +212,8 @@ const emit = defineEmits<{
   (e: "collapse", title: string, collapsed: boolean): void;
   (e: "componentNavigate", componentId: ComponentId): void;
   (e: "resetFilter"): void;
+  (e: "selectAllInSection", sectionKey: string): void;
+  (e: "deselectAllInSection", sectionKey: string): void;
   (
     e: "childClicked",
     event: MouseEvent,

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -7,18 +7,35 @@
         themeClasses('bg-neutral-200', 'bg-neutral-800'),
       )
     "
-    @click="emit('clickCollapse', row.title, !row.collapsed)"
   >
-    <Icon :name="row.collapsed ? 'chevron--right' : 'chevron--down'" />
+    <Icon
+      :name="row.collapsed ? 'chevron--right' : 'chevron--down'"
+      @click="emit('clickCollapse', row.title, !row.collapsed)"
+    />
     <Icon
       v-if="titleIcon"
       :name="titleIcon.iconName"
       :tone="titleIcon.iconTone"
     />
-    <span class="select-none">
+    <span
+      class="select-none"
+      @click="emit('clickCollapse', row.title, !row.collapsed)"
+    >
       {{ row.title }}
     </span>
     <PillCounter :count="row.count" class="text-xs" />
+    <NewButton
+      v-if="!row.collapsed"
+      class="ml-auto"
+      size="xs"
+      :label="row.allSelected ? 'Deselect All' : 'Select All'"
+      :disabled="row.count === 0"
+      @click.stop.prevent="
+        row.allSelected
+          ? emit('deselectAllInSection', row.title)
+          : emit('selectAllInSection', row.title)
+      "
+    />
   </div>
   <div
     v-else-if="row.type === 'defaultSubHeader'"
@@ -28,9 +45,11 @@
         themeClasses('bg-neutral-200', 'bg-neutral-800'),
       )
     "
-    @click="emit('clickCollapse', row.subKey, !row.collapsed)"
   >
-    <Icon :name="row.collapsed ? 'chevron--right' : 'chevron--down'" />
+    <Icon
+      :name="row.collapsed ? 'chevron--right' : 'chevron--down'"
+      @click="emit('clickCollapse', row.subKey, !row.collapsed)"
+    />
     <Icon :name="getAssetIcon(row.schemaCategory)" size="md" />
     <div
       class="cursor-pointer select-none flex flex-row items-center gap-xs"
@@ -78,6 +97,18 @@
       </span>
     </div>
     <PillCounter :count="row.count" class="text-xs" />
+    <NewButton
+      v-if="!row.collapsed"
+      class="ml-auto"
+      size="xs"
+      :label="row.allSelected ? 'Deselect All' : 'Select All'"
+      :disabled="row.count === 0"
+      @click.stop.prevent="
+        row.allSelected
+          ? emit('deselectAllInSection', row.subKey)
+          : emit('selectAllInSection', row.subKey)
+      "
+    />
   </div>
   <div
     v-else-if="row.type === 'contentHeader'"
@@ -216,7 +247,13 @@
   </div>
   <div
     v-else-if="row.type === 'emptyRow'"
-    class="flex items-center justify-center pb-xs px-xs"
+    :class="
+      clsx(
+        'flex items-center justify-center pb-xs',
+        row.insideSection && 'px-xs',
+        row.insideSection && themeClasses('bg-neutral-200', 'bg-neutral-800'),
+      )
+    "
   >
     <div
       :class="
@@ -294,6 +331,7 @@ import {
   IconNames,
   Tones,
   TruncateWithTooltip,
+  NewButton,
 } from "@si/vue-lib/design-system";
 import { tw } from "@si/vue-lib";
 import { useQuery } from "@tanstack/vue-query";
@@ -523,6 +561,8 @@ const emit = defineEmits<{
   (e: "childDeselect", componentIdx: number): void;
   (e: "componentNavigate", componentId: ComponentId): void;
   (e: "resetFilter"): void;
+  (e: "selectAllInSection", sectionKey: string): void;
+  (e: "deselectAllInSection", sectionKey: string): void;
 }>();
 </script>
 
@@ -544,6 +584,7 @@ export type ExploreGridRowData =
       title: string;
       count: number;
       collapsed: boolean;
+      allSelected: boolean;
     }
   | {
       type: "footer";
@@ -551,6 +592,7 @@ export type ExploreGridRowData =
   | {
       type: "emptyRow";
       groupName: string;
+      insideSection: boolean;
     }
   | {
       type: "filteredCounterRow";
@@ -571,6 +613,7 @@ export type ExploreGridRowData =
       collapsed: boolean;
       count: number;
       subKey: string; // Needed for collapse handling
+      allSelected: boolean;
     };
 </script>
 


### PR DESCRIPTION
When you make a groupBy, this adds the ability to select all or deselect all

https://jam.dev/c/85ba93db-3d22-4046-a748-8b5dbe57f892

This also introduces a fix where the empty state for a groupBy row didn't quite fit the row header and had gaps

<img width="1442" height="381" alt="Screenshot 2025-10-08 at 19 28 36" src="https://github.com/user-attachments/assets/3edfa5c2-fbb1-412f-92bb-51798afce25a" />
