### PR TITLE
Add process runtime metrics collection and Grafana dashboards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4192,7 +4192,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5602,6 +5602,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6657,26 +6676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -8413,6 +8412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "si-otel-metrics"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry",
+ "parking_lot",
+ "sysinfo",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "si-pkg"
 version = "0.1.0"
 dependencies = [
@@ -9088,15 +9098,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "windows",
 ]
 
@@ -9148,6 +9158,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "remain",
+ "si-otel-metrics",
  "telemetry",
  "thiserror 2.0.12",
  "tokio",
@@ -10466,24 +10477,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.57.0"
+name = "windows-collections"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -10492,22 +10503,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.3.4",
+ "windows-result",
  "windows-strings",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -10515,17 +10526,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10550,12 +10550,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -10657,6 +10658,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
   "lib/si-id",
   "lib/si-jwt-public-key",
   "lib/si-layer-cache",
+  "lib/si-otel-metrics",
   "lib/si-pkg",
   "lib/si-pool-noodle",
   "lib/si-posthog-rs",
@@ -212,6 +213,7 @@ once_cell = "1.20.2"
 opentelemetry = { version = "0.26.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.26.0", features = ["metrics", "trace"] }
 opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry-system-metrics = "0.4.2"
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
 ordered-float = { version = "4.5.0", features = ["serde"] }
 ouroboros = "0.18.4"
@@ -251,7 +253,7 @@ spicedb-client = { version = "0.1.1", features = ["tls"] }
 spicedb-grpc = "0.1.1"
 strum = { version = "0.26.3", features = ["derive"] }
 syn = { version = "2.0.90", features = ["extra-traits", "full"] }
-sysinfo = "0.33.0"
+sysinfo = "0.37.2"
 tar = "0.4.43"
 tempfile = "3.14.0"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }

--- a/dev/METRICS.md
+++ b/dev/METRICS.md
@@ -1,0 +1,154 @@
+# Service Metrics Monitoring
+
+This document describes how to monitor memory, CPU, and other system metrics for SI services during development and load testing.
+
+## Overview
+
+SI services (sdf, rebaser, pinga, veritech, cyclone) export process-level metrics via OpenTelemetry. The metrics flow through the following pipeline:
+
+```text
+Services → OpenTelemetry (OTLP) → otelcol → Prometheus → Grafana
+```
+
+## Quick Start
+
+1. **Start the dev stack:**
+
+   ```bash
+   buck2 run dev:up
+   ```
+
+2. **Access Grafana:**
+   - URL: <http://localhost:3000>
+   - No authentication required (anonymous admin access enabled)
+
+3. **View the dashboard:**
+   - Navigate to "SI Service Metrics" dashboard
+   - Dashboard automatically refreshes every 5 seconds
+
+## Available Metrics
+
+The following process-level metrics are collected for each service:
+
+### Memory Metrics
+
+- `process_runtime_memory_rss_bytes` - Resident Set Size (physical memory in bytes)
+- `process_runtime_memory_virtual_bytes` - Virtual memory size (in bytes)
+
+### CPU Metrics
+
+- `process_runtime_cpu_usage_percent` - CPU usage percentage (can exceed 100% on multi-core machines)
+- `process_runtime_cpu_time_milliseconds` - Accumulated CPU time in milliseconds (cumulative across all cores)
+
+## Monitored Services
+
+The dashboard tracks metrics for the following services:
+
+- **sdf** - Main API server
+- **rebaser** - Change set rebasing service
+- **pinga** - Action execution service
+- **veritech** - Function execution engine
+- **cyclone** - Isolated workload runner
+
+## Direct Access to Monitoring Tools
+
+### Prometheus
+
+- URL: <http://localhost:9090>
+- Query metrics directly using PromQL
+- Example query: `process_runtime_memory_rss_bytes{exported_job="sdf"}`
+
+### OpenTelemetry Collector
+
+- Metrics endpoint: <http://localhost:9090/metrics> (exported by otelcol)
+- OTLP receiver (gRPC): localhost:4317
+- OTLP receiver (HTTP): localhost:4318
+
+### Jaeger (Distributed Tracing)
+
+- URL: <http://localhost:16686>
+- View distributed traces and request flows
+
+### Loki (Logs)
+
+- Query logs through Grafana's Loki datasource
+- Logs are also available in `../log/` directory
+
+## Creating Custom Dashboards
+
+You can create custom Grafana dashboards by:
+
+1. Navigate to Grafana (<http://localhost:3000>)
+2. Click "+" → "Dashboard" → "Add visualization"
+3. Select "Prometheus" as the datasource
+4. Use PromQL to query metrics
+5. Save the dashboard
+
+Example queries:
+
+```promql
+# Memory usage for sdf service
+process_runtime_memory_rss_bytes{exported_job="sdf"}
+
+# Total memory across all services
+sum(process_runtime_memory_rss_bytes)
+
+# Virtual memory for all services
+process_runtime_memory_virtual_bytes{exported_job=~"sdf|rebaser|pinga|veritech|cyclone"}
+```
+
+## Troubleshooting
+
+### No metrics appearing in Grafana
+
+1. **Check Prometheus is scraping otelcol:**
+   - Visit <http://localhost:9090/targets>
+   - Verify "otelcol-metrics" target is "UP"
+
+2. **Verify services are exporting metrics:**
+   - Visit <http://localhost:9090/metrics> (otelcol endpoint)
+   - Search for `process_runtime_memory` metrics
+   - You should see metrics with `exported_job` labels
+
+3. **Check service logs:**
+
+   ```bash
+   # Check if process metrics were initialized
+   docker logs dev-otelcol-1
+   ```
+
+### Dashboard shows "No data"
+
+- Wait 10-15 seconds after starting services for first scrape
+- Default scrape interval is 100ms (very fast)
+- Check Prometheus datasource is configured correctly in Grafana
+
+## Implementation Details
+
+### Metrics Collection
+
+Process metrics are collected using the `si-otel-metrics` crate, which is automatically initialized by the `telemetry-application` crate when services start. No manual initialization is required in service code.
+
+### Export Configuration
+
+Services export metrics via OTLP (OpenTelemetry Protocol):
+
+- Endpoint: `otelcol:4317` (gRPC) or `otelcol:4318` (HTTP)
+- Export interval: 1 second
+- Batch size: Configured in telemetry-application-rs
+
+### Prometheus Scrape Configuration
+
+Prometheus scrapes metrics from otelcol's Prometheus exporter:
+
+- Target: `otelcol:9090`
+- Scrape interval: 100ms
+- Scrape timeout: 90ms
+
+Configuration: [dev/config/prometheus/config.yml](config/prometheus/config.yml)
+
+## Additional Resources
+
+- [OpenTelemetry Rust Documentation](https://opentelemetry.io/docs/languages/rust/)
+- [Prometheus Query Documentation](https://prometheus.io/docs/prometheus/latest/querying/basics/)
+- [Grafana Dashboard Documentation](https://grafana.com/docs/grafana/latest/dashboards/)

--- a/dev/config/grafana/provisioning/dashboards/foyer-cache-metrics.json
+++ b/dev/config/grafana/provisioning/dashboards/foyer-cache-metrics.json
@@ -1,0 +1,1048 @@
+{
+  "id": null,
+  "uid": "foyer-cache-metrics",
+  "title": "Foyer Cache Metrics",
+  "tags": ["foyer", "cache", "memory", "disk", "performance"],
+  "timezone": "browser",
+  "schemaVersion": 16,
+  "version": 0,
+  "refresh": "5s",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "light-green",
+        "name": "Load test start",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "queryType": "annotations",
+          "tags": ["load-test", "start"],
+          "type": "tags"
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "semi-dark-green",
+        "name": "Load test end",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": ["load-test", "end"],
+          "type": "tags"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Hybrid Cache Operations Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(foyer_hybrid_op_total[1m])",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 2,
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Hybrid Cache Operation Duration (p99)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, rate(foyer_hybrid_op_duration_bucket[1m]))",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max"]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Memory Cache Operations Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(foyer_memory_op_total[1m])",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Memory Cache Usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "foyer_memory_usage",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 5,
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Disk Cache Operations Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(foyer_storage_op_total[1m])",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Disk Cache Operation Duration (Percentiles)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.50, rate(foyer_storage_op_duration_bucket[1m]))",
+          "legendFormat": "p50 - {{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.95, rate(foyer_storage_op_duration_bucket[1m]))",
+          "legendFormat": "p95 - {{exported_job}}/{{name}} - {{op}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, rate(foyer_storage_op_duration_bucket[1m]))",
+          "legendFormat": "p99 - {{exported_job}}/{{name}} - {{op}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max"]
+        }
+      }
+    },
+    {
+      "id": 7,
+      "gridPos": { "x": 0, "y": 24, "w": 8, "h": 8 },
+      "type": "timeseries",
+      "title": "Disk I/O Operations Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(foyer_storage_disk_io_total[1m])",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 8,
+      "gridPos": { "x": 8, "y": 24, "w": 8, "h": 8 },
+      "type": "timeseries",
+      "title": "Disk I/O Bytes Transferred",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(foyer_storage_disk_io_bytes_total[1m])",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "gridPos": { "x": 16, "y": 24, "w": 8, "h": 8 },
+      "type": "timeseries",
+      "title": "Disk I/O Duration (p99)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, rate(foyer_storage_disk_io_duration_bucket[1m]))",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max"]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Storage Inner Operations Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(foyer_storage_inner_op_total[1m])",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 11,
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Storage Inner Operation Duration (p99)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, rate(foyer_storage_inner_op_duration_bucket[1m]))",
+          "legendFormat": "{{exported_job}}/{{name}} - {{op}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max"]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "gridPos": { "x": 0, "y": 40, "w": 8, "h": 8 },
+      "type": "timeseries",
+      "title": "Block Engine Blocks",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "foyer_storage_block_engine_block",
+          "legendFormat": "{{exported_job}}/{{name}} - {{type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "gridPos": { "x": 8, "y": 40, "w": 8, "h": 8 },
+      "type": "timeseries",
+      "title": "Block Engine Block Sizes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "foyer_storage_block_engine_block_size_bytes",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "gridPos": { "x": 16, "y": 40, "w": 8, "h": 8 },
+      "type": "timeseries",
+      "title": "Disk Cache Regions In Use",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "foyer_storage_region{type=\"total\"} - ignoring(type) foyer_storage_region{type=\"clean\"}",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "gridPos": { "x": 0, "y": 48, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Recovery Duration (p99)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, rate(foyer_storage_block_engine_recover_duration_bucket[1m]))",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max"]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "gridPos": { "x": 12, "y": 48, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Storage Region Sizes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "foyer_storage_region_size_bytes",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 17,
+      "gridPos": { "x": 0, "y": 56, "w": 24, "h": 8 },
+      "type": "timeseries",
+      "title": "Operations by Cache Instance (Stacked)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (exported_job, name) (rate(foyer_hybrid_op_total[1m]))",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 50,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 18,
+      "gridPos": { "x": 0, "y": 64, "w": 24, "h": 8 },
+      "type": "timeseries",
+      "title": "Latency Comparison - p99 Across All Cache Instances",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, sum by (exported_job, name, le) (rate(foyer_hybrid_op_duration_bucket[1m])))",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 19,
+      "gridPos": { "x": 0, "y": 72, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Memory Usage by Service",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (exported_job) (foyer_memory_usage)",
+          "legendFormat": "{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 20,
+      "gridPos": { "x": 12, "y": 72, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Operations Rate by Service",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (exported_job) (rate(foyer_hybrid_op_total[1m]))",
+          "legendFormat": "{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "gridPos": { "x": 0, "y": 80, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Cache Hit vs Miss Ratio by Service",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (exported_job) (rate(foyer_hybrid_op_total{op=\"hit\"}[1m])) / (sum by (exported_job) (rate(foyer_hybrid_op_total{op=\"hit\"}[1m])) + sum by (exported_job) (rate(foyer_hybrid_op_total{op=\"miss\"}[1m])))",
+          "legendFormat": "{{exported_job}} hit ratio",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "mean"]
+        }
+      }
+    },
+    {
+      "id": 22,
+      "gridPos": { "x": 12, "y": 80, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "Top 10 Busiest Caches (All Services)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "topk(10, sum by (exported_job, name) (rate(foyer_hybrid_op_total[1m])))",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 23,
+      "gridPos": { "x": 0, "y": 88, "w": 24, "h": 8 },
+      "type": "timeseries",
+      "title": "Service Memory Usage Breakdown (Stacked by Cache)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "foyer_memory_usage",
+          "legendFormat": "{{exported_job}}/{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 50,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max"]
+        }
+      }
+    },
+    {
+      "id": 24,
+      "gridPos": { "x": 0, "y": 96, "w": 24, "h": 6 },
+      "type": "bargauge",
+      "title": "Current Operations Rate by Service",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (exported_job) (rate(foyer_hybrid_op_total[1m]))",
+          "legendFormat": "{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 100, "color": "yellow" },
+              { "value": 500, "color": "red" }
+            ]
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      }
+    }
+  ]
+}

--- a/dev/config/grafana/provisioning/dashboards/si-service-metrics.json
+++ b/dev/config/grafana/provisioning/dashboards/si-service-metrics.json
@@ -1,0 +1,221 @@
+{
+  "id": null,
+  "uid": "si-service-metrics",
+  "title": "SI Service Metrics",
+  "tags": ["si", "services", "memory", "cpu"],
+  "timezone": "browser",
+  "schemaVersion": 16,
+  "version": 0,
+  "refresh": "5s",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "light-green",
+        "name": "Load test start",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "queryType": "annotations",
+          "tags": ["load-test", "start"],
+          "type": "tags"
+        }
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "semi-dark-green",
+        "name": "Load test end",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": ["load-test", "end"],
+          "type": "tags"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "type": "timeseries",
+      "title": "Process Memory Usage (RSS)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "process_runtime_memory_rss_bytes{exported_job=~\"sdf|rebaser|pinga|veritech|cyclone\"}",
+          "legendFormat": "{{exported_job}} - RSS",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 2,
+      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 },
+      "type": "timeseries",
+      "title": "Process Virtual Memory",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "process_runtime_memory_virtual_bytes{exported_job=~\"sdf|rebaser|pinga|veritech|cyclone\"}",
+          "legendFormat": "{{exported_job}} - Virtual",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "CPU Usage Percentage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "process_runtime_cpu_usage_percent{exported_job=~\"sdf|rebaser|pinga|veritech|cyclone\"}",
+          "legendFormat": "{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max", "mean"]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "type": "timeseries",
+      "title": "CPU Time Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "rate(process_runtime_cpu_time_milliseconds{exported_job=~\"sdf|rebaser|pinga|veritech|cyclone\"}[1m])",
+          "legendFormat": "{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms/s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull"]
+        }
+      }
+    }
+  ]
+}

--- a/lib/si-otel-metrics/BUCK
+++ b/lib/si-otel-metrics/BUCK
@@ -1,0 +1,16 @@
+load("@prelude-si//:macros.bzl", "rust_library")
+
+rust_library(
+    name = "si-otel-metrics",
+    deps = [
+        "//third-party/rust:opentelemetry",
+        "//third-party/rust:parking_lot",
+        "//third-party/rust:sysinfo",
+        "//third-party/rust:thiserror",
+    ],
+    env = {
+        "CARGO_PKG_NAME": "si-otel-metrics",
+        "CARGO_PKG_VERSION": "0.1.0",
+    },
+    srcs = glob(["src/**/*.rs"]),
+)

--- a/lib/si-otel-metrics/Cargo.toml
+++ b/lib/si-otel-metrics/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "si-otel-metrics"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+opentelemetry = { workspace = true }
+parking_lot = { workspace = true }
+sysinfo = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/lib/si-otel-metrics/src/lib.rs
+++ b/lib/si-otel-metrics/src/lib.rs
@@ -1,0 +1,211 @@
+//! Process metrics collection for System Initiative services using OpenTelemetry.
+//!
+//! This crate provides a simple API for instrumenting Rust services with process-level
+//! metrics (memory, CPU) that are exported via OpenTelemetry.
+
+#![warn(
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::missing_panics_doc,
+    clippy::panic_in_result_fn,
+    missing_docs
+)]
+#![allow(clippy::missing_errors_doc)]
+
+use std::sync::Arc;
+
+use opentelemetry::metrics::{
+    Meter,
+    ObservableGauge,
+};
+use sysinfo::{
+    Pid,
+    ProcessRefreshKind,
+    ProcessesToUpdate,
+    System,
+};
+use thiserror::Error;
+
+/// Errors that can occur during metrics initialization or collection.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Failed to get current process information
+    #[error("failed to get current process information")]
+    ProcessInfoUnavailable,
+}
+
+/// Result type for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Process metrics observer that registers observable gauges for memory and CPU metrics.
+///
+/// This struct maintains a reference to the system information and registers callbacks
+/// with OpenTelemetry to report process metrics.
+pub struct ProcessMetricsObserver {
+    _memory_rss_gauge: ObservableGauge<u64>,
+    _memory_virtual_gauge: ObservableGauge<u64>,
+    _cpu_usage_gauge: ObservableGauge<f64>,
+    _cpu_time_gauge: ObservableGauge<u64>,
+}
+
+impl ProcessMetricsObserver {
+    /// Initialize process metrics collection for the current process.
+    ///
+    /// This function registers observable gauges that will automatically report
+    /// process memory and CPU metrics to OpenTelemetry on each collection interval.
+    ///
+    /// # Arguments
+    ///
+    /// * `meter` - The OpenTelemetry meter to use for creating metric instruments
+    ///
+    /// # Returns
+    ///
+    /// Returns a `ProcessMetricsObserver` that must be kept alive for the duration
+    /// of the metrics collection. Dropping this struct will stop metrics collection.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use opentelemetry::global;
+    /// use si_otel_metrics::ProcessMetricsObserver;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let meter = global::meter("my-service");
+    ///     let _observer = ProcessMetricsObserver::init(meter).unwrap();
+    ///
+    ///     // Metrics will be collected automatically
+    ///     // Keep _observer alive for the duration of the program
+    /// }
+    /// ```
+    pub fn init(meter: Meter) -> Result<Self> {
+        let pid = sysinfo::get_current_pid().map_err(|_| Error::ProcessInfoUnavailable)?;
+
+        // Create a shared System instance wrapped in Arc for thread-safe access
+        let system = Arc::new(parking_lot::Mutex::new(System::new_all()));
+
+        // Perform initial CPU refresh to establish baseline for accurate cpu_usage() readings
+        // Per sysinfo docs: "To start to have accurate CPU usage, a process needs to be refreshed twice"
+        {
+            let mut sys = system.lock();
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                false,
+                ProcessRefreshKind::default().with_cpu().with_memory(),
+            );
+        }
+
+        // Register memory RSS (Resident Set Size) gauge
+        let memory_rss_gauge = {
+            let system = Arc::clone(&system);
+            meter
+                .u64_observable_gauge("process.runtime.memory.rss")
+                .with_description("Process resident set size (physical memory)")
+                .with_unit("bytes")
+                .with_callback(move |observer| {
+                    if let Some(memory_bytes) = get_process_memory_rss(&system, pid) {
+                        observer.observe(memory_bytes, &[]);
+                    }
+                })
+                .init()
+        };
+
+        // Register memory virtual size gauge
+        let memory_virtual_gauge = {
+            let system = Arc::clone(&system);
+            meter
+                .u64_observable_gauge("process.runtime.memory.virtual")
+                .with_description("Process virtual memory size")
+                .with_unit("bytes")
+                .with_callback(move |observer| {
+                    if let Some(memory_bytes) = get_process_memory_virtual(&system, pid) {
+                        observer.observe(memory_bytes, &[]);
+                    }
+                })
+                .init()
+        };
+
+        // Register CPU usage gauge (percentage)
+        let cpu_usage_gauge = {
+            let system = Arc::clone(&system);
+            meter
+                .f64_observable_gauge("process.runtime.cpu.usage")
+                .with_description("Process CPU usage percentage")
+                .with_unit("percent")
+                .with_callback(move |observer| {
+                    if let Some(cpu_usage) = get_process_cpu_usage(&system, pid) {
+                        observer.observe(cpu_usage, &[]);
+                    }
+                })
+                .init()
+        };
+
+        // Register accumulated CPU time gauge (milliseconds)
+        let cpu_time_gauge = {
+            let system = Arc::clone(&system);
+            meter
+                .u64_observable_gauge("process.runtime.cpu.time")
+                .with_description("Accumulated CPU time in milliseconds")
+                .with_unit("ms")
+                .with_callback(move |observer| {
+                    if let Some(cpu_time) = get_process_cpu_time(&system, pid) {
+                        observer.observe(cpu_time, &[]);
+                    }
+                })
+                .init()
+        };
+
+        Ok(Self {
+            _memory_rss_gauge: memory_rss_gauge,
+            _memory_virtual_gauge: memory_virtual_gauge,
+            _cpu_usage_gauge: cpu_usage_gauge,
+            _cpu_time_gauge: cpu_time_gauge,
+        })
+    }
+}
+
+/// Get the RSS (physical memory) usage of a process.
+fn get_process_memory_rss(system: &Arc<parking_lot::Mutex<System>>, pid: Pid) -> Option<u64> {
+    let mut sys = system.lock();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::default().with_cpu().with_memory(),
+    );
+    sys.process(pid).map(|process| process.memory())
+}
+
+/// Get the virtual memory usage of a process.
+fn get_process_memory_virtual(system: &Arc<parking_lot::Mutex<System>>, pid: Pid) -> Option<u64> {
+    let mut sys = system.lock();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::default().with_cpu().with_memory(),
+    );
+    sys.process(pid).map(|process| process.virtual_memory())
+}
+
+/// Get the CPU usage percentage of a process.
+fn get_process_cpu_usage(system: &Arc<parking_lot::Mutex<System>>, pid: Pid) -> Option<f64> {
+    let mut sys = system.lock();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::default().with_cpu().with_memory(),
+    );
+    sys.process(pid).map(|process| process.cpu_usage() as f64)
+}
+
+/// Get the accumulated CPU time of a process in milliseconds.
+fn get_process_cpu_time(system: &Arc<parking_lot::Mutex<System>>, pid: Pid) -> Option<u64> {
+    let mut sys = system.lock();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::default().with_cpu().with_memory(),
+    );
+    sys.process(pid)
+        .map(|process| process.accumulated_cpu_time())
+}

--- a/lib/telemetry-application-rs/BUCK
+++ b/lib/telemetry-application-rs/BUCK
@@ -3,6 +3,7 @@ load("@prelude-si//:macros.bzl", "rust_library")
 rust_library(
     name = "telemetry-application",
     deps = [
+        "//lib/si-otel-metrics:si-otel-metrics",
         "//lib/telemetry-rs:telemetry",
         "//third-party/rust:chrono",
         "//third-party/rust:console-subscriber",

--- a/lib/telemetry-application-rs/Cargo.toml
+++ b/lib/telemetry-application-rs/Cargo.toml
@@ -17,6 +17,7 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 remain = { workspace = true }
+si-otel-metrics = { path = "../../lib/si-otel-metrics" }
 telemetry = { path = "../../lib/telemetry-rs" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -11637,6 +11637,67 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "objc2-core-foundation-0.3.2.crate",
+    sha256 = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536",
+    strip_prefix = "objc2-core-foundation-0.3.2",
+    urls = ["https://static.crates.io/crates/objc2-core-foundation/0.3.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "objc2-core-foundation-0.3.2",
+    srcs = [":objc2-core-foundation-0.3.2.crate"],
+    crate = "objc2_core_foundation",
+    crate_root = "objc2-core-foundation-0.3.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "CFArray",
+        "CFBase",
+        "CFData",
+        "CFDictionary",
+        "CFError",
+        "CFNumber",
+        "CFPlugInCOM",
+        "CFRunLoop",
+        "CFString",
+        "CFURL",
+        "CFUUID",
+        "alloc",
+        "bitflags",
+        "std",
+    ],
+    visibility = [],
+    deps = [":bitflags-2.9.1"],
+)
+
+http_archive(
+    name = "objc2-io-kit-0.3.2.crate",
+    sha256 = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15",
+    strip_prefix = "objc2-io-kit-0.3.2",
+    urls = ["https://static.crates.io/crates/objc2-io-kit/0.3.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "objc2-io-kit-0.3.2",
+    srcs = [":objc2-io-kit-0.3.2.crate"],
+    crate = "objc2_io_kit",
+    crate_root = "objc2-io-kit-0.3.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "hidsystem",
+        "libc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":libc-0.2.174",
+        ":objc2-core-foundation-0.3.2",
+    ],
+)
+
+http_archive(
     name = "object-0.36.7.crate",
     sha256 = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87",
     strip_prefix = "object-0.36.7",
@@ -11889,6 +11950,56 @@ cargo.rust_library(
     ],
 )
 
+http_archive(
+    name = "opentelemetry-0.29.1.crate",
+    sha256 = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c",
+    strip_prefix = "opentelemetry-0.29.1",
+    urls = ["https://static.crates.io/crates/opentelemetry/0.29.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "opentelemetry-0.29.1",
+    srcs = [":opentelemetry-0.29.1.crate"],
+    crate = "opentelemetry",
+    crate_root = "opentelemetry-0.29.1.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "CARGO_CRATE_NAME": "opentelemetry",
+        "CARGO_MANIFEST_DIR": "opentelemetry-0.29.1.crate",
+        "CARGO_PKG_AUTHORS": "",
+        "CARGO_PKG_DESCRIPTION": "OpenTelemetry API for Rust",
+        "CARGO_PKG_NAME": "opentelemetry",
+        "CARGO_PKG_REPOSITORY": "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry",
+        "CARGO_PKG_VERSION": "0.29.1",
+        "CARGO_PKG_VERSION_MAJOR": "0",
+        "CARGO_PKG_VERSION_MINOR": "29",
+        "CARGO_PKG_VERSION_PATCH": "1",
+        "CARGO_PKG_VERSION_PRE": "",
+    },
+    features = [
+        "default",
+        "futures",
+        "futures-core",
+        "futures-sink",
+        "internal-logs",
+        "logs",
+        "metrics",
+        "pin-project-lite",
+        "thiserror",
+        "trace",
+        "tracing",
+    ],
+    visibility = [],
+    deps = [
+        ":futures-core-0.3.31",
+        ":futures-sink-0.3.31",
+        ":pin-project-lite-0.2.16",
+        ":thiserror-2.0.12",
+        ":tracing-0.1.41",
+    ],
+)
+
 alias(
     name = "opentelemetry-otlp",
     actual = ":opentelemetry-otlp-0.26.0",
@@ -12001,6 +12112,37 @@ cargo.rust_library(
     crate_root = "opentelemetry-semantic-conventions-0.14.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
+)
+
+alias(
+    name = "opentelemetry-system-metrics",
+    actual = ":opentelemetry-system-metrics-0.4.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "opentelemetry-system-metrics-0.4.2.crate",
+    sha256 = "3ff095ac36df870a11380877fb7e9b1e7529abfe994fd06a6d6d17ca1c77d30b",
+    strip_prefix = "opentelemetry-system-metrics-0.4.2",
+    urls = ["https://static.crates.io/crates/opentelemetry-system-metrics/0.4.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "opentelemetry-system-metrics-0.4.2",
+    srcs = [":opentelemetry-system-metrics-0.4.2.crate"],
+    crate = "opentelemetry_system_metrics",
+    crate_root = "opentelemetry-system-metrics-0.4.2.crate/src/lib.rs",
+    edition = "2021",
+    features = ["default"],
+    visibility = [],
+    deps = [
+        ":eyre-0.6.12",
+        ":opentelemetry-0.29.1",
+        ":sysinfo-0.34.2",
+        ":tokio-1.46.1",
+        ":tracing-0.1.41",
+    ],
 )
 
 alias(
@@ -13983,102 +14125,6 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":getrandom-0.3.3"],
-)
-
-http_archive(
-    name = "rayon-1.10.0.crate",
-    sha256 = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa",
-    strip_prefix = "rayon-1.10.0",
-    urls = ["https://static.crates.io/crates/rayon/1.10.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "rayon-1.10.0",
-    srcs = [":rayon-1.10.0.crate"],
-    crate = "rayon",
-    crate_root = "rayon-1.10.0.crate/src/lib.rs",
-    edition = "2021",
-    visibility = [],
-    deps = [
-        ":either-1.15.0",
-        ":rayon-core-1.12.1",
-    ],
-)
-
-http_archive(
-    name = "rayon-core-1.12.1.crate",
-    sha256 = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2",
-    strip_prefix = "rayon-core-1.12.1",
-    urls = ["https://static.crates.io/crates/rayon-core/1.12.1/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "rayon-core-1.12.1",
-    srcs = [":rayon-core-1.12.1.crate"],
-    crate = "rayon_core",
-    crate_root = "rayon-core-1.12.1.crate/src/lib.rs",
-    edition = "2021",
-    env = {
-        "CARGO_CRATE_NAME": "rayon_core",
-        "CARGO_MANIFEST_DIR": "rayon-core-1.12.1.crate",
-        "CARGO_PKG_AUTHORS": "Niko Matsakis <niko@alum.mit.edu>:Josh Stone <cuviper@gmail.com>",
-        "CARGO_PKG_DESCRIPTION": "Core APIs for Rayon",
-        "CARGO_PKG_NAME": "rayon-core",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rayon-rs/rayon",
-        "CARGO_PKG_VERSION": "1.12.1",
-        "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "12",
-        "CARGO_PKG_VERSION_PATCH": "1",
-        "CARGO_PKG_VERSION_PRE": "",
-        "OUT_DIR": "$(location :rayon-core-1.12.1-build-script-run[out_dir])",
-    },
-    rustc_flags = ["@$(location :rayon-core-1.12.1-build-script-run[rustc_flags])"],
-    visibility = [],
-    deps = [
-        ":crossbeam-deque-0.8.6",
-        ":crossbeam-utils-0.8.21",
-    ],
-)
-
-cargo.rust_binary(
-    name = "rayon-core-1.12.1-build-script-build",
-    srcs = [":rayon-core-1.12.1.crate"],
-    crate = "build_script_build",
-    crate_root = "rayon-core-1.12.1.crate/build.rs",
-    edition = "2021",
-    env = {
-        "CARGO_CRATE_NAME": "build_script_build",
-        "CARGO_MANIFEST_DIR": "rayon-core-1.12.1.crate",
-        "CARGO_PKG_AUTHORS": "Niko Matsakis <niko@alum.mit.edu>:Josh Stone <cuviper@gmail.com>",
-        "CARGO_PKG_DESCRIPTION": "Core APIs for Rayon",
-        "CARGO_PKG_NAME": "rayon-core",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rayon-rs/rayon",
-        "CARGO_PKG_VERSION": "1.12.1",
-        "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "12",
-        "CARGO_PKG_VERSION_PATCH": "1",
-        "CARGO_PKG_VERSION_PRE": "",
-    },
-    visibility = [],
-)
-
-buildscript_run(
-    name = "rayon-core-1.12.1-build-script-run",
-    package_name = "rayon-core",
-    buildscript_rule = ":rayon-core-1.12.1-build-script-build",
-    env = {
-        "CARGO_MANIFEST_LINKS": "rayon-core",
-        "CARGO_PKG_AUTHORS": "Niko Matsakis <niko@alum.mit.edu>:Josh Stone <cuviper@gmail.com>",
-        "CARGO_PKG_DESCRIPTION": "Core APIs for Rayon",
-        "CARGO_PKG_REPOSITORY": "https://github.com/rayon-rs/rayon",
-        "CARGO_PKG_VERSION_MAJOR": "1",
-        "CARGO_PKG_VERSION_MINOR": "12",
-        "CARGO_PKG_VERSION_PATCH": "1",
-        "CARGO_PKG_VERSION_PRE": "",
-    },
-    version = "1.12.1",
 )
 
 alias(
@@ -18140,41 +18186,36 @@ cargo.rust_library(
     ],
 )
 
-alias(
-    name = "sysinfo",
-    actual = ":sysinfo-0.33.1",
-    visibility = ["PUBLIC"],
-)
-
 http_archive(
-    name = "sysinfo-0.33.1.crate",
-    sha256 = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01",
-    strip_prefix = "sysinfo-0.33.1",
-    urls = ["https://static.crates.io/crates/sysinfo/0.33.1/download"],
+    name = "sysinfo-0.34.2.crate",
+    sha256 = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2",
+    strip_prefix = "sysinfo-0.34.2",
+    urls = ["https://static.crates.io/crates/sysinfo/0.34.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "sysinfo-0.33.1",
-    srcs = [":sysinfo-0.33.1.crate"],
+    name = "sysinfo-0.34.2",
+    srcs = [":sysinfo-0.34.2.crate"],
     crate = "sysinfo",
-    crate_root = "sysinfo-0.33.1.crate/src/lib.rs",
+    crate_root = "sysinfo-0.34.2.crate/src/lib.rs",
     edition = "2021",
     features = [
         "component",
         "default",
         "disk",
-        "multithread",
         "network",
         "system",
         "user",
     ],
     platform = {
         "macos-arm64": dict(
-            deps = [":core-foundation-sys-0.8.7"],
+            features = ["objc2-core-foundation"],
+            deps = [":objc2-core-foundation-0.3.2"],
         ),
         "macos-x86_64": dict(
-            deps = [":core-foundation-sys-0.8.7"],
+            features = ["objc2-core-foundation"],
+            deps = [":objc2-core-foundation-0.3.2"],
         ),
         "windows-gnu": dict(
             features = ["windows"],
@@ -18195,7 +18236,72 @@ cargo.rust_library(
     deps = [
         ":libc-0.2.174",
         ":memchr-2.7.5",
-        ":rayon-1.10.0",
+    ],
+)
+
+alias(
+    name = "sysinfo",
+    actual = ":sysinfo-0.37.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "sysinfo-0.37.2.crate",
+    sha256 = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f",
+    strip_prefix = "sysinfo-0.37.2",
+    urls = ["https://static.crates.io/crates/sysinfo/0.37.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sysinfo-0.37.2",
+    srcs = [":sysinfo-0.37.2.crate"],
+    crate = "sysinfo",
+    crate_root = "sysinfo-0.37.2.crate/src/lib.rs",
+    edition = "2024",
+    features = [
+        "component",
+        "default",
+        "disk",
+        "network",
+        "objc2-io-kit",
+        "system",
+        "user",
+    ],
+    platform = {
+        "macos-arm64": dict(
+            features = ["objc2-core-foundation"],
+            deps = [
+                ":objc2-core-foundation-0.3.2",
+                ":objc2-io-kit-0.3.2",
+            ],
+        ),
+        "macos-x86_64": dict(
+            features = ["objc2-core-foundation"],
+            deps = [
+                ":objc2-core-foundation-0.3.2",
+                ":objc2-io-kit-0.3.2",
+            ],
+        ),
+        "windows-gnu": dict(
+            features = ["windows"],
+            deps = [
+                ":ntapi-0.4.1",
+                ":windows-0.61.3",
+            ],
+        ),
+        "windows-msvc": dict(
+            features = ["windows"],
+            deps = [
+                ":ntapi-0.4.1",
+                ":windows-0.61.3",
+            ],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":libc-0.2.174",
+        ":memchr-2.7.5",
     ],
 )
 
@@ -21111,6 +21217,7 @@ cargo.rust_library(
         "Win32_System_Com",
         "Win32_System_Diagnostics",
         "Win32_System_Diagnostics_Debug",
+        "Win32_System_Diagnostics_ToolHelp",
         "Win32_System_IO",
         "Win32_System_Ioctl",
         "Win32_System_Kernel",
@@ -21137,6 +21244,95 @@ cargo.rust_library(
         ":windows-core-0.57.0",
         ":windows-targets-0.52.6",
     ],
+)
+
+http_archive(
+    name = "windows-0.61.3.crate",
+    sha256 = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893",
+    strip_prefix = "windows-0.61.3",
+    urls = ["https://static.crates.io/crates/windows/0.61.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-0.61.3",
+    srcs = [":windows-0.61.3.crate"],
+    crate = "windows",
+    crate_root = "windows-0.61.3.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "Wdk",
+        "Wdk_System",
+        "Wdk_System_SystemInformation",
+        "Wdk_System_SystemServices",
+        "Wdk_System_Threading",
+        "Win32",
+        "Win32_Foundation",
+        "Win32_NetworkManagement",
+        "Win32_NetworkManagement_IpHelper",
+        "Win32_NetworkManagement_Ndis",
+        "Win32_NetworkManagement_NetManagement",
+        "Win32_Networking",
+        "Win32_Networking_WinSock",
+        "Win32_Security",
+        "Win32_Security_Authentication",
+        "Win32_Security_Authentication_Identity",
+        "Win32_Security_Authorization",
+        "Win32_Storage",
+        "Win32_Storage_FileSystem",
+        "Win32_System",
+        "Win32_System_Com",
+        "Win32_System_Diagnostics",
+        "Win32_System_Diagnostics_Debug",
+        "Win32_System_Diagnostics_ToolHelp",
+        "Win32_System_IO",
+        "Win32_System_Ioctl",
+        "Win32_System_Kernel",
+        "Win32_System_Memory",
+        "Win32_System_Ole",
+        "Win32_System_Performance",
+        "Win32_System_Power",
+        "Win32_System_ProcessStatus",
+        "Win32_System_Registry",
+        "Win32_System_RemoteDesktop",
+        "Win32_System_Rpc",
+        "Win32_System_SystemInformation",
+        "Win32_System_SystemServices",
+        "Win32_System_Threading",
+        "Win32_System_Variant",
+        "Win32_System_WindowsProgramming",
+        "Win32_System_Wmi",
+        "Win32_UI",
+        "Win32_UI_Shell",
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":windows-collections-0.2.0",
+        ":windows-core-0.61.2",
+        ":windows-future-0.2.1",
+        ":windows-link-0.1.3",
+        ":windows-numerics-0.2.0",
+    ],
+)
+
+http_archive(
+    name = "windows-collections-0.2.0.crate",
+    sha256 = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8",
+    strip_prefix = "windows-collections-0.2.0",
+    urls = ["https://static.crates.io/crates/windows-collections/0.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-collections-0.2.0",
+    srcs = [":windows-collections-0.2.0.crate"],
+    crate = "windows_collections",
+    crate_root = "windows-collections-0.2.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":windows-core-0.61.2"],
 )
 
 http_archive(
@@ -21167,6 +21363,53 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "windows-core-0.61.2.crate",
+    sha256 = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3",
+    strip_prefix = "windows-core-0.61.2",
+    urls = ["https://static.crates.io/crates/windows-core/0.61.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-core-0.61.2",
+    srcs = [":windows-core-0.61.2.crate"],
+    crate = "windows_core",
+    crate_root = "windows-core-0.61.2.crate/src/lib.rs",
+    edition = "2021",
+    features = ["std"],
+    visibility = [],
+    deps = [
+        ":windows-implement-0.60.0",
+        ":windows-interface-0.59.1",
+        ":windows-link-0.1.3",
+        ":windows-result-0.3.4",
+        ":windows-strings-0.4.2",
+    ],
+)
+
+http_archive(
+    name = "windows-future-0.2.1.crate",
+    sha256 = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e",
+    strip_prefix = "windows-future-0.2.1",
+    urls = ["https://static.crates.io/crates/windows-future/0.2.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-future-0.2.1",
+    srcs = [":windows-future-0.2.1.crate"],
+    crate = "windows_future",
+    crate_root = "windows-future-0.2.1.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":windows-core-0.61.2",
+        ":windows-link-0.1.3",
+        ":windows-threading-0.1.0",
+    ],
+)
+
+http_archive(
     name = "windows-implement-0.57.0.crate",
     sha256 = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7",
     strip_prefix = "windows-implement-0.57.0",
@@ -21179,6 +21422,29 @@ cargo.rust_library(
     srcs = [":windows-implement-0.57.0.crate"],
     crate = "windows_implement",
     crate_root = "windows-implement-0.57.0.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.95",
+        ":quote-1.0.40",
+        ":syn-2.0.104",
+    ],
+)
+
+http_archive(
+    name = "windows-implement-0.60.0.crate",
+    sha256 = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836",
+    strip_prefix = "windows-implement-0.60.0",
+    urls = ["https://static.crates.io/crates/windows-implement/0.60.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-implement-0.60.0",
+    srcs = [":windows-implement-0.60.0.crate"],
+    crate = "windows_implement",
+    crate_root = "windows-implement-0.60.0.crate/src/lib.rs",
     edition = "2021",
     proc_macro = True,
     visibility = [],
@@ -21213,6 +21479,29 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "windows-interface-0.59.1.crate",
+    sha256 = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8",
+    strip_prefix = "windows-interface-0.59.1",
+    urls = ["https://static.crates.io/crates/windows-interface/0.59.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-interface-0.59.1",
+    srcs = [":windows-interface-0.59.1.crate"],
+    crate = "windows_interface",
+    crate_root = "windows-interface-0.59.1.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.95",
+        ":quote-1.0.40",
+        ":syn-2.0.104",
+    ],
+)
+
+http_archive(
     name = "windows-link-0.1.3.crate",
     sha256 = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a",
     strip_prefix = "windows-link-0.1.3",
@@ -21227,6 +21516,27 @@ cargo.rust_library(
     crate_root = "windows-link-0.1.3.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
+)
+
+http_archive(
+    name = "windows-numerics-0.2.0.crate",
+    sha256 = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1",
+    strip_prefix = "windows-numerics-0.2.0",
+    urls = ["https://static.crates.io/crates/windows-numerics/0.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-numerics-0.2.0",
+    srcs = [":windows-numerics-0.2.0.crate"],
+    crate = "windows_numerics",
+    crate_root = "windows-numerics-0.2.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":windows-core-0.61.2",
+        ":windows-link-0.1.3",
+    ],
 )
 
 http_archive(
@@ -21249,6 +21559,44 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":windows-targets-0.52.6"],
+)
+
+http_archive(
+    name = "windows-result-0.3.4.crate",
+    sha256 = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6",
+    strip_prefix = "windows-result-0.3.4",
+    urls = ["https://static.crates.io/crates/windows-result/0.3.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-result-0.3.4",
+    srcs = [":windows-result-0.3.4.crate"],
+    crate = "windows_result",
+    crate_root = "windows-result-0.3.4.crate/src/lib.rs",
+    edition = "2021",
+    features = ["std"],
+    visibility = [],
+    deps = [":windows-link-0.1.3"],
+)
+
+http_archive(
+    name = "windows-strings-0.4.2.crate",
+    sha256 = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57",
+    strip_prefix = "windows-strings-0.4.2",
+    urls = ["https://static.crates.io/crates/windows-strings/0.4.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-strings-0.4.2",
+    srcs = [":windows-strings-0.4.2.crate"],
+    crate = "windows_strings",
+    crate_root = "windows-strings-0.4.2.crate/src/lib.rs",
+    edition = "2021",
+    features = ["std"],
+    visibility = [],
+    deps = [":windows-link-0.1.3"],
 )
 
 http_archive(
@@ -21467,6 +21815,24 @@ cargo.rust_library(
         ),
     },
     visibility = [],
+)
+
+http_archive(
+    name = "windows-threading-0.1.0.crate",
+    sha256 = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6",
+    strip_prefix = "windows-threading-0.1.0",
+    urls = ["https://static.crates.io/crates/windows-threading/0.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-threading-0.1.0",
+    srcs = [":windows-threading-0.1.0.crate"],
+    crate = "windows_threading",
+    crate_root = "windows-threading-0.1.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":windows-link-0.1.3"],
 )
 
 http_archive(

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -4284,7 +4284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4d2b55cea00ffba84e3df1e875d9190331e2f3bba2ee3bdd3abcc739639a71"
 dependencies = [
  "itertools 0.14.0",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "parking_lot",
 ]
 
@@ -4522,6 +4522,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,6 +4591,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,7 +4613,7 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 1.3.1",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
@@ -4595,7 +4628,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -4606,6 +4639,19 @@ name = "opentelemetry-semantic-conventions"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry-system-metrics"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff095ac36df870a11380877fb7e9b1e7529abfe994fd06a6d6d17ca1c77d30b"
+dependencies = [
+ "eyre",
+ "opentelemetry 0.29.1",
+ "sysinfo 0.34.2",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -4619,7 +4665,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -5446,26 +5492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -6970,16 +6996,29 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
- "windows",
+ "objc2-core-foundation",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7140,9 +7179,10 @@ dependencies = [
  "nkeys",
  "num_cpus",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "opentelemetry-system-metrics",
  "opentelemetry_sdk",
  "ordered-float 4.6.0",
  "ouroboros",
@@ -7182,7 +7222,7 @@ dependencies = [
  "spicedb-grpc",
  "strum",
  "syn 2.0.104",
- "sysinfo",
+ "sysinfo 0.37.2",
  "tar",
  "tempfile",
  "test-log",
@@ -7825,7 +7865,7 @@ checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
@@ -8357,6 +8397,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8379,6 +8441,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.4",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8430,6 +8503,16 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -8539,6 +8622,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -110,6 +110,7 @@ once_cell = "1.20.2"
 opentelemetry = { version = "0.26.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.26.0", features = ["metrics", "trace"] }
 opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry-system-metrics = "0.4.2"
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
 ordered-float = { version = "4.5.0", features = ["serde"] }
 ouroboros = "0.18.4"
@@ -149,7 +150,7 @@ spicedb-client = { version = "0.1.1", features = ["tls"] }
 spicedb-grpc = "0.1.1"
 strum = { version = "0.26.3", features = ["derive"] }
 syn = { version = "2.0.90", features = ["extra-traits", "full"] }
-sysinfo = "0.33.0"
+sysinfo = "0.37.2"
 tar = "0.4.43"
 tempfile = "3.14.0"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }


### PR DESCRIPTION
This commit introduces comprehensive process-level and cache metrics
collection for System Initiative services to enable monitoring of memory,
CPU usage, and cache performance during load testing and production operations.

The implementation creates a reusable si-otel-metrics crate for process
metrics and adds a detailed Foyer cache metrics dashboard to complement
the existing process metrics dashboard.

Key changes:

**New si-otel-metrics crate:**
- Created lib/si-otel-metrics providing ProcessMetricsObserver
- Implements thread-safe process metrics collection using sysinfo
- Exports four metrics via OpenTelemetry:
  - process.runtime.memory.rss (bytes): Resident set size
  - process.runtime.memory.virtual (bytes): Virtual memory size
  - process.runtime.cpu.usage (percent): CPU usage percentage
  - process.runtime.cpu.time (ms): Accumulated CPU time
- Properly initializes CPU baseline per sysinfo documentation

**Telemetry integration:**
- Modified telemetry-application to automatically initialize process metrics
- Stores ProcessMetricsObserver in TelemetryShutdownGuard to maintain lifecycle
- Logs initialization status (debug on success, warn on failure)

**Prometheus configuration fix:**
- Increased otelcol scrape timeout from 10ms to 90ms
- Previous 10ms timeout caused "context deadline exceeded" errors
- 90ms provides adequate time for metric collection without blocking

**SI Service Metrics dashboard:**
- Created SI Service Metrics dashboard with four panels:
  - Process Memory Usage (RSS): Physical memory consumption over time
  - Process Virtual Memory: Virtual memory allocation over time
  - CPU Usage Percentage: Current CPU utilization
  - CPU Time Rate: Rate of CPU time consumption (ms/s over 1min window)
- Dashboard filters to key services: sdf, rebaser, pinga, veritech, cyclone
- Queries use exported_job label for service identification
- Configured with Prometheus datasource and 5s auto-refresh

**Foyer Cache Metrics dashboard (24 panels):**
- Comprehensive monitoring of Foyer hybrid cache across all SI services
- All metrics include service name (exported_job/cache_name) to distinguish
  between sdf/cas, rebaser/cas, etc.

Overview & Hybrid Cache (Panels 1-2):
- Operations rate and p99 latency for hybrid cache operations

Memory Cache (Panels 3-4):
- Operations rate by operation type (hit/miss/insert/remove)
- Current memory usage per cache instance

Disk Cache (Panels 5-9):
- Storage operations rate and duration percentiles (p50/p95/p99)
- Disk I/O operations, bytes transferred, and I/O latency
- Tracks read/write/delete operations at disk level

Storage Internals (Panels 10-14):
- Inner operation rates and latencies
- Block engine metrics (no data - services use region-based storage)
- Disk cache regions in use (total - clean regions)

Recovery & Advanced (Panels 15-16):
- Cache recovery duration on startup
- Storage region sizes

Comparative Views (Panels 17-18):
- Stacked operations by cache instance
- Latency comparison (p99) across all caches

Service-Level Aggregations (Panels 19-24):
- Memory usage by service
- Operations rate by service
- Cache hit vs miss ratio by service
- Top 10 busiest caches overall
- Service memory breakdown (stacked)
- Current operations bar gauge

Covers 10 cache types: cas, change_batches, encrypted_secrets, func_runs,
func_run_logs, rebase_batches, workspace_snapshots, split_snapshot_subgraphs,
split_snapshot_supergraphs, split_snapshot_rebase_batches

**Dependencies:**
- Updated sysinfo from 0.33.0 to 0.37.2 for latest process metrics APIs
- Added parking_lot for efficient cross-platform mutex implementation
- Added necessary Buck2 and Cargo configurations

**Documentation:**
- Created dev/METRICS.md with setup instructions and dashboard access
- Documented metric semantics and troubleshooting guidance

The monitoring pipeline flows: services → si-otel-metrics → otelcol →
Prometheus → Grafana, providing real-time visibility into service resource
consumption and cache performance patterns.

## Process metrics:

<img width="1682" height="1142" alt="image" src="https://github.com/user-attachments/assets/45246a49-476d-4571-b0aa-25efd186cee0" />

## Foyer metrics:

<img width="1687" height="2681" alt="image" src="https://github.com/user-attachments/assets/f8c50649-8f16-48fa-83a7-4271d1d47bb2" />
