### PR TITLE
[feat] Hetzner: add name to Locations component

### DIFF
--- a/bin/clover/README.md
+++ b/bin/clover/README.md
@@ -23,7 +23,7 @@ $ deno task run generate-specs [...SCHEMA]
 - `generate-specs` with no arguments to regenerate all specs
 - `generate-specs EC2 S3 SecurityGroup` to regenerate all EC2 and S3 schemas,
   plus the SecurityGroup schema
-- `SI_MODULE_INDEX_URL=https://module-index/systeminit.com` to point at
+- `SI_MODULE_INDEX_URL=https://module-index.systeminit.com` to point at
   production
 - `SI_MODULE_INDEX_URL=http://127.0.0.1:5157` to point at your local module
   index. (**If you do this, do NOT upload the resulting specs to

--- a/bin/clover/src/pipelines/generic/applyAssetOverrides.ts
+++ b/bin/clover/src/pipelines/generic/applyAssetOverrides.ts
@@ -1,6 +1,6 @@
 import _logger from "../../logger.ts";
 import { ExpandedPkgSpec } from "../../spec/pkgs.ts";
-import { bfsPropTree } from "../../spec/props.ts";
+import { bfsPropTree, propPathStr } from "../../spec/props.ts";
 import { ProviderConfig } from "../types.ts";
 
 const logger = _logger.ns("assetOverrides").seal();
@@ -20,7 +20,9 @@ export function applyAssetOverrides(
     const variant = spec.schemas[0].variants[0];
 
     // If there's a schema-level override for this spec, run it
-    const schemaOverrideFn = providerConfig.overrides.schemaOverrides.get(spec.name);
+    const schemaOverrideFn = providerConfig.overrides.schemaOverrides.get(
+      spec.name,
+    );
     if (schemaOverrideFn) {
       logger.debug(`Running schema override for ${spec.name}`);
       schemaOverrideFn(spec);
@@ -28,10 +30,12 @@ export function applyAssetOverrides(
 
     // If there are prop-level overrides for this schema+spec, run them
     bfsPropTree([variant.domain, variant.resourceValue], (prop) => {
-      const propPath = "/" + prop.metadata.propPath.slice(1).join("/");
+      const propPath = propPathStr(prop);
 
       // Check for overrides that match the schema
-      for (const [matchSchema, overrides] of Object.entries(providerConfig.overrides.propOverrides)) {
+      for (const [matchSchema, overrides] of Object.entries(
+        providerConfig.overrides.propOverrides,
+      )) {
         if (!spec.name.match(new RegExp(`^${matchSchema}$`))) continue;
 
         // Check for overrides that match the prop

--- a/bin/clover/src/pipelines/generic/createSuggestionsAcrossAssets.ts
+++ b/bin/clover/src/pipelines/generic/createSuggestionsAcrossAssets.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 
-import { bfsPropTree } from "../../spec/props.ts";
+import { bfsPropTree, propPathStr } from "../../spec/props.ts";
 import pluralize from "npm:pluralize@^8.0.0";
 import { ExpandedPkgSpec } from "../../spec/pkgs.ts";
 import { addPropSuggestSource } from "../../spec/props.ts";
@@ -19,7 +19,8 @@ export function createSuggestionsForPrimaryIdentifiers(
     const [schemaVariant] = schema.variants;
     const resource = schemaVariant.resourceValue;
     const specName = spec.name;
-    const categoryStr = typeof schema.data?.category === "string" ? schema.data.category : "";
+    const categoryStr =
+      typeof schema.data?.category === "string" ? schema.data.category : "";
     const category = categoryStr.split("::")[1];
     const variantName = specName.split("::")[2];
 
@@ -68,8 +69,7 @@ export function createSuggestionsForPrimaryIdentifiers(
           nameVariants.add(`${pluralSpaced}Item`);
         }
 
-        // stripping /root out
-        const propPath = "/" + prop.metadata.propPath.slice(1).join("/");
+        const propPath = propPathStr(prop);
         schemasToPrimaryIdents.set(specName, [propPath, nameVariants]);
       },
       { skipTypeProps: true },
@@ -85,12 +85,10 @@ export function createSuggestionsForPrimaryIdentifiers(
     bfsPropTree(
       domain,
       (prop) => {
-        for (
-          const [
-            specName,
-            [propName, possibleNames],
-          ] of schemasToPrimaryIdents.entries()
-        ) {
+        for (const [
+          specName,
+          [propName, possibleNames],
+        ] of schemasToPrimaryIdents.entries()) {
           if (spec.name != specName && possibleNames.has(prop.name)) {
             logger.debug(
               `suggest {schema:${specName}, prop:${propName}} for prop ${prop.name} on ${spec.name}`,

--- a/bin/clover/src/pipelines/hetzner/overrides.ts
+++ b/bin/clover/src/pipelines/hetzner/overrides.ts
@@ -1,20 +1,38 @@
+import { createScalarProp } from "../../spec/props.ts";
+import { widget, suggest } from "../generic/overrides.ts";
 import { PropOverrideFn, SchemaOverrideFn } from "../types.ts";
+
+const HETZNER_LOCATIONS = ["fsn1", "nbg1", "hel1", "ash", "hil", "sin"];
 
 // Hetzner-specific property overrides (empty for now)
 export const HETZNER_PROP_OVERRIDES: Record<
   string,
   Record<string, PropOverrideFn | PropOverrideFn[]>
 > = {
-  // Add Hetzner-specific property overrides here as needed
-  // Example:
-  // "Hetzner::Cloud::Server": {
-  //   LocationsProp: makeDropdownOverride,
-  // },
+  ".*": {
+    // Add location dropdown and suggestion to "location" prop on all resources
+    location: [
+      suggest("Hetzner::Cloud::Locations", "/domain/name"),
+      widget("ComboBox", HETZNER_LOCATIONS),
+    ],
+  },
+  "Hetzner::Cloud::Locations": {
+    name: widget("ComboBox", HETZNER_LOCATIONS),
+  },
 };
 
-// Hetzner-specific schema overrides (empty for now)
+// Hetzner-specific schema overrides
 export const HETZNER_SCHEMA_OVERRIDES = new Map<string, SchemaOverrideFn>([
-  // Add Hetzner-specific schema overrides here as needed
-  // Example:
-  // ["Hetzner::Cloud::Server", serverSchemaOverride],
+  //
+  // Add Hetzner::Cloud::Locations.name so it can be selected and filled in
+  //
+  [
+    "Hetzner::Cloud::Locations",
+    (spec) => {
+      const variant = spec.schemas[0].variants[0];
+      variant.domain.entries.unshift(
+        createScalarProp("name", "string", ["root", "domain"], true),
+      );
+    },
+  ],
 ]);

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -65,10 +65,14 @@ export interface PropSuggestion {
 
 // Type guard to check if a JsonValue is a PropSuggestion array
 function isPropSuggestionArray(value: unknown): value is PropSuggestion[] {
-  return Array.isArray(value) &&
+  return (
+    Array.isArray(value) &&
     (value.length === 0 ||
-      (typeof value[0] === "object" && value[0] !== null &&
-        "schema" in value[0] && "prop" in value[0]));
+      (typeof value[0] === "object" &&
+        value[0] !== null &&
+        "schema" in value[0] &&
+        "prop" in value[0]))
+  );
 }
 
 interface PropSpecOverrides {
@@ -91,9 +95,9 @@ interface PropSpecOverrides {
   joiValidation?: string;
   cfProp:
     | (CfProperty & {
-      // The name of the definition this property lives under
-      defName?: string;
-    })
+        // The name of the definition this property lives under
+        defName?: string;
+      })
     | undefined;
 }
 
@@ -230,9 +234,10 @@ export function createPropFromCf(
     widgetKind: null,
     widgetOptions: [],
     hidden: false,
-    docLink: parentProp?.kind === "object"
-      ? docFn(superSchema, cfProp.defName, name)
-      : null,
+    docLink:
+      parentProp?.kind === "object"
+        ? docFn(superSchema, cfProp.defName, name)
+        : null,
     documentation: cfProp.description ?? null,
     uiOptionals: null,
   };
@@ -385,11 +390,9 @@ export function createPropFromCf(
           break;
         // This is a special case (and seems likely wrong), but may as well support it
         case "(^arn:[a-z\\d-]+:rekognition:[a-z\\d-]+:\\d{12}:collection\\/([a-zA-Z0-9_.\\-]+){1,255})":
-          validation += `.pattern(new RegExp(${
-            JSON.stringify(
-              normalizedCfProp.format,
-            )
-          }))`;
+          validation += `.pattern(new RegExp(${JSON.stringify(
+            normalizedCfProp.format,
+          )}))`;
           break;
         case undefined:
           break;
@@ -405,11 +408,9 @@ export function createPropFromCf(
       if (normalizedCfProp.pattern !== undefined) {
         const toRegexp = cfPcreToRegexp(normalizedCfProp.pattern);
         if (toRegexp) {
-          validation += `.pattern(new RegExp(${
-            JSON.stringify(
-              toRegexp.pattern,
-            )
-          }${toRegexp.flags ? `, ${JSON.stringify(toRegexp.flags)}` : ""}))`;
+          validation += `.pattern(new RegExp(${JSON.stringify(
+            toRegexp.pattern,
+          )}${toRegexp.flags ? `, ${JSON.stringify(toRegexp.flags)}` : ""}))`;
         }
       }
       if (required) validation += ".required()";
@@ -495,11 +496,9 @@ export function createPropFromCf(
       prop.kind = "object";
       prop.data.widgetKind = "Header";
       prop.entries = [];
-      for (
-        const [name, childCfProp] of Object.entries(
-          normalizedCfProp.properties,
-        )
-      ) {
+      for (const [name, childCfProp] of Object.entries(
+        normalizedCfProp.properties,
+      )) {
         queue.push({
           cfProp: childCfProp,
           propPath: [...propPath, name],
@@ -790,4 +789,8 @@ export function propSuggestionFor(
     // stripping /root out
     prop: "/" + prop.metadata.propPath.slice(1).join("/"),
   };
+}
+
+export function propPathStr(prop: ExpandedPropSpec): string {
+  return "/" + prop.metadata.propPath.slice(1).join("/");
 }


### PR DESCRIPTION
Right now you can't actually specify the location in Hetzner::Location. This adds the ability to set it and a suggestion to subscribe to it.

* Adds /domain/name to Hetzner::Location
* Adds suggestions to all fields named "/domain/location" in other Hetzner objets
* Makes Locations.name and all location fields dropdowns with valid values including all Hetzner regions 

#### Screenshots:

<img width="475" height="607" alt="image" src="https://github.com/user-attachments/assets/38a28200-b0d1-4ddb-ae9f-fc1ce583bea3" />

#### Out of Scope:

* Qualifications validating that the location is valid for the account

## How was it tested?

- [X] Manual test: Suggestions and subscriptions work from Server.location -> Locations.name
- [ ] Manual test: Server is actually created when name is specified from dropdown

NOTE: no reason to think create action will fail (Locations domain and create action haven't changed) but I haven't got a credential set up yet to do so--will make sure in the morning.

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMTQ2d29zZXR4bWFlODAxN2kxbDZ5cW1pZG05dzBhMzR3ZmE4ZXR3MCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/yvqRaXlOsc068DDTzt/giphy.gif"/>
