### PR TITLE
feat(web): Add the ability to multiselect a range of GridTiles

### DIFF
--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -1,9 +1,5 @@
 <template>
-  <AttributePanelBulk
-    v-if="bulkEditing"
-    @close="() => $emit('bulkDone')"
-    @deselect="(idx) => $emit('childDeselect', idx)"
-  />
+  <AttributePanelBulk v-if="bulkEditing" @close="() => $emit('bulkDone')" />
   <div
     v-else
     data-testid="explore-grid"
@@ -25,8 +21,8 @@
       }"
       :row="gridRows[row.index]!"
       @childClicked="(e, c, idx) => $emit('childClicked', e, c, idx)"
-      @childSelect="(idx) => $emit('childSelect', idx)"
-      @childDeselect="(idx) => $emit('childDeselect', idx)"
+      @childSelect="(idx, event) => $emit('childSelect', idx, event)"
+      @childDeselect="(idx, event) => $emit('childDeselect', idx, event)"
       @childHover="(componentId) => $emit('childHover', componentId)"
       @childUnhover="(componentId) => $emit('childUnhover', componentId)"
       @clickCollapse="clickCollapse"
@@ -205,8 +201,8 @@ watch([exploreContext.focusedComponentIdx], scrollCurrentTileIntoView);
 const emit = defineEmits<{
   (e: "bulkDone"): void;
   (e: "unpin", componentId: ComponentId): void;
-  (e: "childSelect", componentIdx: number): void;
-  (e: "childDeselect", componentIdx: number): void;
+  (e: "childSelect", componentIdx: number, event?: MouseEvent): void;
+  (e: "childDeselect", componentIdx: number, event?: MouseEvent): void;
   (e: "childHover", componentId: ComponentId): void;
   (e: "childUnhover", componentId: ComponentId): void;
   (e: "collapse", title: string, collapsed: boolean): void;

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -214,8 +214,8 @@
       :pendingActionCounts="
         exploreContext.componentsPendingActionNames.value.get(component.id)
       "
-      @select="emit('childSelect', dataIndexForTileInRow(row, columnIndex))"
-      @deselect="emit('childDeselect', dataIndexForTileInRow(row, columnIndex))"
+      @select="(e: MouseEvent) => emit('childSelect', dataIndexForTileInRow(row, columnIndex), e)"
+      @deselect="(e: MouseEvent) => emit('childDeselect', dataIndexForTileInRow(row, columnIndex), e)"
       @mouseenter="hover(component.id, true)"
       @mouseleave="hover(component.id, false)"
       @click.stop.left="
@@ -557,8 +557,8 @@ const emit = defineEmits<{
     componentIdx: number,
   ): void;
   (e: "clickCollapse", title: string, collapsed: boolean): void;
-  (e: "childSelect", componentIdx: number): void;
-  (e: "childDeselect", componentIdx: number): void;
+  (e: "childSelect", componentIdx: number, event?: MouseEvent): void;
+  (e: "childDeselect", componentIdx: number, event?: MouseEvent): void;
   (e: "componentNavigate", componentId: ComponentId): void;
   (e: "resetFilter"): void;
   (e: "selectAllInSection", sectionKey: string): void;

--- a/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridTile.vue
@@ -171,8 +171,8 @@
               ),
         )
       "
-      @click.stop.prevent.left="toggleSelection"
-      @click.stop.prevent.right="toggleSelection"
+      @click.stop.prevent.left="toggleSelection($event)"
+      @click.stop.prevent.right="toggleSelection($event)"
     >
       <Icon
         v-if="selected"
@@ -267,11 +267,11 @@ const dynamicRows = computed(() => {
 
   return rows;
 });
-const toggleSelection = () => {
+const toggleSelection = (event: MouseEvent) => {
   if (props.selected) {
-    emit("deselect");
+    emit("deselect", event);
   } else {
-    emit("select");
+    emit("select", event);
   }
 };
 
@@ -290,8 +290,8 @@ watch(
 );
 
 const emit = defineEmits<{
-  (e: "select"): void;
-  (e: "deselect"): void;
+  (e: "select", event: MouseEvent): void;
+  (e: "deselect", event: MouseEvent): void;
 }>();
 </script>
 


### PR DESCRIPTION
When I have a component selected and hold shift then click another component, all of the components inbetween will be put under selection

https://jam.dev/c/01162fc4-dcb0-4cb8-894a-aaa5e82317cd