### PR TITLE
fix(dal): Prevent Autosubscribe from creating subscriptions that would cause a graph cycle

### DIFF
--- a/lib/dal-test/src/expected.rs
+++ b/lib/dal-test/src/expected.rs
@@ -510,7 +510,7 @@ impl ExpectComponent {
         ExpectComponentOutputSocket(self.0, output_socket_id)
     }
 
-    pub async fn execute_management_func(self, ctx: &DalContext, func: ExpectFunc) {
+    pub async fn execute_management_func(self, ctx: &mut DalContext, func: ExpectFunc) {
         component::execute_management_func(ctx, self.0, func.id())
             .await
             .expect("execute management func")

--- a/lib/dal-test/src/helpers/attribute/value.rs
+++ b/lib/dal-test/src/helpers/attribute/value.rs
@@ -100,6 +100,20 @@ pub async fn is_set(ctx: &DalContext, av: impl AttributeValueKey) -> Result<bool
     }
 }
 
+/// Check whether the value has any subscriptions
+pub async fn has_subscription(ctx: &DalContext, av: impl AttributeValueKey) -> Result<bool> {
+    match AttributeValueKey::resolve(ctx, av).await? {
+        Some(av_id) => {
+            let subscriptions = AttributeValue::subscriptions(ctx, av_id).await?;
+            match subscriptions {
+                Some(subs) => Ok(!subs.is_empty()),
+                None => Ok(false),
+            }
+        }
+        None => Ok(false),
+    }
+}
+
 /// Unset a value (creates it if it doesn't exist)
 pub async fn unset(ctx: &DalContext, av: impl AttributeValueKey) -> Result<()> {
     let av_id = vivify(ctx, av).await?;

--- a/lib/dal-test/src/helpers/component.rs
+++ b/lib/dal-test/src/helpers/component.rs
@@ -10,14 +10,9 @@ use dal::{
         geometry::Geometry,
         view::View,
     },
-    management::{
-        ManagementFuncReturn,
-        ManagementOperator,
-        prototype::ManagementPrototype,
-    },
+    management::prototype::ManagementPrototype,
 };
 use si_id::ViewId;
-use veritech_client::ManagementFuncStatus;
 
 use super::schema::variant::SchemaVariantKey;
 use crate::{
@@ -104,61 +99,43 @@ pub async fn find_management_prototype(
 
 /// Execute a the management function and apply the result to the component
 pub async fn execute_management_func(
-    ctx: &DalContext,
+    ctx: &mut DalContext,
     component: impl ComponentKey,
     func: impl FuncKey,
 ) -> Result<()> {
+    use crate::helpers::ChangeSetTestHelpers;
+
     let func_id = func::id(ctx, func).await?;
     let component_id = id(ctx, component).await?;
-    let mut prototype_ids = ManagementPrototype::list_ids_for_func_id(ctx, func_id)
-        .await?
-        .into_iter();
-    let prototype_id = prototype_ids
-        .next()
-        .ok_or(eyre!("no prototypes for func"))?;
-    if prototype_ids.next().is_some() {
-        return Err(eyre!("multiple prototypes for func"));
-    }
 
-    let (geometries, placeholders, run_channel, _) = ManagementPrototype::start_execution(
+    // Get the function name to find the management prototype
+    let func = dal::Func::get_by_id(ctx, func_id).await?;
+
+    // Find the management prototype by name
+    let management_prototype = find_management_prototype(ctx, component_id, &func.name).await?;
+
+    // Enqueue the management function job
+    ChangeSetTestHelpers::enqueue_management_func_job(
         ctx,
-        prototype_id,
+        management_prototype.id(),
         component_id,
-        Some(view_id(ctx, component_id).await?),
-    )
-    .await?;
-
-    let mut execution_result = ManagementPrototype::finalize_execution(
-        ctx,
-        component_id,
-        prototype_id,
-        geometries,
-        placeholders,
-        run_channel,
-    )
-    .await?;
-
-    let result: ManagementFuncReturn = execution_result
-        .result
-        .take()
-        .ok_or(eyre!("no result for func"))?
-        .try_into()?;
-
-    assert_eq!(ManagementFuncStatus::Ok, result.status);
-
-    let operations = result.operations.expect("should have operations");
-
-    ManagementOperator::new(
-        ctx,
-        component_id,
-        operations,
-        execution_result,
         None,
-        ulid::Ulid::new(),
     )
-    .await?
-    .operate()
     .await?;
+
+    // Commit changes
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Wait for the management job to complete
+    ChangeSetTestHelpers::wait_for_mgmt_job_to_run(ctx, management_prototype.id(), component_id)
+        .await?;
+
+    // Wait for dependent value update (DVU)
+    dal::ChangeSet::wait_for_dvu(ctx, false).await?;
+
+    // Update to visibility
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
     Ok(())
 }
 

--- a/lib/dal/tests/integration_test/management.rs
+++ b/lib/dal/tests/integration_test/management.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use dal::{
     AttributeValue,
-    ChangeSet,
     Component,
     ComponentId,
     DalContext,
@@ -156,27 +155,9 @@ async fn set_resource(ctx: &mut DalContext) -> Result<()> {
 
     // Create a component for the new schema variant
     let test_component = component::create(ctx, "test::resource", "test-component").await?;
-
     ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
 
-    // Find and enqueue the management job
-    let management_prototype =
-        find_management_prototype(ctx, test_component, "Set Resource").await?;
-
-    ChangeSetTestHelpers::enqueue_management_func_job(
-        ctx,
-        management_prototype.id(),
-        test_component,
-        None,
-    )
-    .await?;
-
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
-
-    ChangeSetTestHelpers::wait_for_mgmt_job_to_run(ctx, management_prototype.id(), test_component)
-        .await?;
-    ChangeSet::wait_for_dvu(ctx, false).await?;
-    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    component::execute_management_func(ctx, test_component, "Set Resource").await?;
 
     // Ensure that resource_value gets propagated
     // Check domain values were set


### PR DESCRIPTION
## How does this PR change the system?
This change does two things: 
1. Enable cycle detection when autosubscribing, to ensure autosubscribe doesn’t create subscriptions that result in graph cycles
2. If any errors occur when attempting to create the subscription, ensure the value remains manually set to the same value

Without number one, management functions that Discover or Import could accidentally create a graph cycle, that then impacts future management functions as we also check for cycles when creating management edges. 

Without number two, given the number of places where an error can occur when creating a new subscription (including if there’s a Cycle), there’s a risk we’ll end up with a partially created subscription (for example, a new Attribute Prototype Argument, with no Value Source if we failed between creating the new argument and setting it’s value source), which renders the Component effectively broken as the Attribute Tree MV can’t build. 

This is aggressively defensive, and I added error tracing so we can narrow down why this happens, but I suspect this partially explains some cases where we see failing AttributeTree MV builds in prod.
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:
Further changes to prevent cycles, for example removing the cycle check for management functions, or adding one when any subscription is created. As autosubscribe runs in the Management Func job, and there's a chance you can't even manually remove the subscription due to create_only props, this situation is far less recoverable than if a cycle exists when creating a new subscription manually.

<!-- Anything this PR explicitly leaves out? -->

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] New Integration test that covers off on both manually running autosubscribe (which we haven't exposed to users) and when autosubscribe runs in the management func job

## In short: [:link:](https://giphy.com/)

<div><img src="https://media2.giphy.com/media/ypDcHZ9RyjsYxyxbaV/200.gif?cid=5a38a5a22n6zk7v6m0c3awslnlm8pp9igguntkce3q0k4fvl&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:170px;width:300px"/><br/>via <a href="https://giphy.com/iontelevision/">ION</a> on <a href="https://giphy.com/gifs/iontelevision-hawaii-hawaiifive0-hf0-ypDcHZ9RyjsYxyxbaV">GIPHY</a></div>