### PR TITLE
feat: iterate on management funcs via mcp

### DIFF
--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -12,7 +12,7 @@
     "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
     "@std/assert": "jsr:@std/assert@1",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.3.1",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.3.2",
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",

--- a/bin/si-mcp-server/deno.lock
+++ b/bin/si-mcp-server/deno.lock
@@ -12,7 +12,7 @@
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/text@~1.0.7": "1.0.16",
-    "jsr:@systeminit/api-client@^1.3.1": "1.3.1",
+    "jsr:@systeminit/api-client@^1.3.2": "1.3.2",
     "npm:@modelcontextprotocol/sdk@^1.16.0": "1.18.1_express@5.1.0_zod@3.25.76",
     "npm:axios@*": "1.12.2",
     "npm:axios@^1.12.0": "1.12.2",
@@ -76,8 +76,8 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
-    "@systeminit/api-client@1.3.1": {
-      "integrity": "e9356dfadfeae52917008432c58d0d0ff72322d9ccb90fce817a61f2db112bd6",
+    "@systeminit/api-client@1.3.2": {
+      "integrity": "cdbf93c8b3176ad82dc1ad6703cccf7a65cadea7e333848391995e6b01d0e8a5",
       "dependencies": [
         "npm:axios@^1.6.1"
       ]
@@ -673,7 +673,7 @@
       "jsr:@onjara/optic@^2.0.3",
       "jsr:@std/assert@1",
       "jsr:@std/encoding@^1.0.10",
-      "jsr:@systeminit/api-client@^1.3.1",
+      "jsr:@systeminit/api-client@^1.3.2",
       "npm:@modelcontextprotocol/sdk@^1.16.0",
       "npm:axios@^1.6.1",
       "npm:jwt-decode@4",


### PR DESCRIPTION
## How does this PR change the system?

This PR adds outputting the list of functions to the schemaCreateEditGet tool. That allows an MCP user to iterate on an existing or newly created  Run Template management function on a Template Schema.

This PR also fixes the funcCreateEditGet tool so that it can handle locked functions properly, automatically ensuring that the function and its schema are unlocked.

This work completes [ENG-3252](https://linear.app/system-initiative/issue/ENG-3252/ability-to-iterate-on-run-template-management-functions)!

## Screenshot

<img width="469" height="273" alt="Screenshot 2025-10-09 at 6 57 40 PM" src="https://github.com/user-attachments/assets/1d54f169-6533-47b8-8676-728f5506b46a" />


## How was it tested?

- [X] Integration tests pass
- [X] Manual tests: all the demos [in the Linear](https://linear.app/system-initiative/issue/ENG-3252/ability-to-iterate-on-run-template-management-functions) work!

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExM21rYXZuZTFsaDQ3b3d1NGRpNXdvZm51Y2szczJ0aXBsc3Vja3N5eCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/102TqFEr2QOfvi/giphy.gif)
