### PR TITLE
feat(dal): management prototype overlays

### DIFF
--- a/lib/dal-materialized-views/src/luminork/schema/variant.rs
+++ b/lib/dal-materialized-views/src/luminork/schema/variant.rs
@@ -84,7 +84,7 @@ pub async fn build_func_details(
 ) -> crate::Result<Vec<LuminorkSchemaVariantFunc>> {
     let action_prototypes = ActionPrototype::for_variant(ctx, schema_variant_id).await?;
     let management_prototypes =
-        ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await?;
+        ManagementPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?;
 
     let mut index: HashMap<FuncId, FuncKindVariant> = HashMap::new();
 

--- a/lib/dal-materialized-views/src/mgmt_prototype_view_list.rs
+++ b/lib/dal-materialized-views/src/mgmt_prototype_view_list.rs
@@ -25,7 +25,7 @@ pub async fn assemble(
     let ctx = &ctx;
 
     let management_prototypes_for_variant =
-        ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await?;
+        ManagementPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?;
     let mut views = Vec::with_capacity(management_prototypes_for_variant.len());
 
     for p in management_prototypes_for_variant {

--- a/lib/dal-test/src/helpers/component.rs
+++ b/lib/dal-test/src/helpers/component.rs
@@ -88,11 +88,12 @@ pub async fn find_management_prototype(
 ) -> Result<ManagementPrototype> {
     let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
 
-    let management_prototype = ManagementPrototype::list_for_variant_id(ctx, schema_variant_id)
-        .await?
-        .into_iter()
-        .find(|proto| proto.name() == prototype_name)
-        .expect("could not find prototype");
+    let management_prototype =
+        ManagementPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id)
+            .await?
+            .into_iter()
+            .find(|proto| proto.name() == prototype_name)
+            .expect("could not find prototype");
 
     Ok(management_prototype)
 }

--- a/lib/dal-test/src/helpers/schema.rs
+++ b/lib/dal-test/src/helpers/schema.rs
@@ -1,7 +1,9 @@
 use dal::{
     DalContext,
+    FuncId,
     Schema,
     SchemaId,
+    func::authoring::FuncAuthoringClient,
 };
 
 use crate::{
@@ -46,4 +48,18 @@ impl SchemaKey for &str {
     async fn id(ctx: &DalContext, key: Self) -> Result<SchemaId> {
         Ok(Schema::get_by_name(ctx, key).await?.id())
     }
+}
+
+/// Create a management func overaly for the given schema
+pub async fn create_overlay_management_func(
+    ctx: &DalContext,
+    schema: impl SchemaKey,
+    name: impl Into<String>,
+    code: impl Into<String>,
+) -> Result<FuncId> {
+    let schema_id = SchemaKey::id(ctx, schema).await?;
+    let func =
+        FuncAuthoringClient::create_new_management_func(ctx, Some(name.into()), schema_id).await?;
+    FuncAuthoringClient::save_code(ctx, func.id, code.into()).await?;
+    Ok(func.id)
 }

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -95,6 +95,7 @@ use crate::{
             FuncArgumentKind,
         },
     },
+    management::prototype::ManagementPrototypeParent,
     prop::PropError,
     schema::variant::{
         authoring::{
@@ -361,15 +362,19 @@ impl FuncAuthoringClient {
     #[instrument(
         name = "func.authoring.create_new_management_func",
         level = "info",
-        skip(ctx)
+        skip(ctx, parent)
     )]
     pub async fn create_new_management_func(
         ctx: &DalContext,
         name: Option<String>,
-        schema_variant_id: SchemaVariantId,
+        parent: impl Into<ManagementPrototypeParent>,
     ) -> FuncAuthoringResult<Func> {
-        SchemaVariant::error_if_locked(ctx, schema_variant_id).await?;
-        let func = create::create_management_func(ctx, name, schema_variant_id).await?;
+        let parent = parent.into();
+        if let ManagementPrototypeParent::SchemaVariant(schema_variant_id) = parent {
+            SchemaVariant::error_if_locked(ctx, schema_variant_id).await?;
+        }
+
+        let func = create::create_management_func(ctx, name, parent).await?;
         Ok(func)
     }
 

--- a/lib/dal/src/func/authoring/create.rs
+++ b/lib/dal/src/func/authoring/create.rs
@@ -29,6 +29,7 @@ use crate::{
         management::ManagementBinding,
     },
     generate_name,
+    management::prototype::ManagementPrototypeParent,
     schema::variant::leaves::{
         LeafInputLocation,
         LeafKind,
@@ -54,7 +55,7 @@ static DEFAULT_VALIDATION_CODE: &str = include_str!("data/defaults/validation.ts
 pub(crate) async fn create_management_func(
     ctx: &DalContext,
     name: Option<String>,
-    schema_variant_id: SchemaVariantId,
+    parent: ManagementPrototypeParent,
 ) -> FuncAuthoringResult<Func> {
     let func = create_func_stub(
         ctx,
@@ -67,7 +68,21 @@ pub(crate) async fn create_management_func(
     )
     .await?;
 
-    ManagementBinding::create_management_binding(ctx, func.id, schema_variant_id).await?;
+    match parent {
+        ManagementPrototypeParent::Schemas(schema_ids) => {
+            ManagementBinding::create_management_binding(ctx, func.id, Some(schema_ids), None)
+                .await?;
+        }
+        ManagementPrototypeParent::SchemaVariant(schema_variant_id) => {
+            ManagementBinding::create_management_binding(
+                ctx,
+                func.id,
+                None,
+                Some(schema_variant_id),
+            )
+            .await?;
+        }
+    }
 
     Ok(func)
 }

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -14,6 +14,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use si_id::ManagementPrototypeId;
 use si_split_graph::SplitGraphError;
 use strum::{
     Display,
@@ -133,6 +134,8 @@ pub enum FuncBindingError {
     MalformedInput(AttributeBindingMalformedInput),
     #[error("management prototype error: {0}")]
     ManagementPrototype(#[from] Box<ManagementPrototypeError>),
+    #[error("management prototype has no parent: {0}")]
+    ManagementPrototypeNoParent(ManagementPrototypeId),
     #[error("no input location given for attribute prototype id ({0}) and func argument id ({1})")]
     NoInputLocationGiven(AttributePrototypeId, FuncArgumentId),
     #[error("no output location given for func: {0}")]
@@ -339,7 +342,8 @@ impl From<FuncBinding> for si_frontend_types::FuncBinding {
                 func_id: Some(auth.func_id),
             },
             FuncBinding::Management(mgmt) => si_frontend_types::FuncBinding::Management {
-                schema_variant_id: Some(mgmt.schema_variant_id),
+                schema_ids: mgmt.schema_ids,
+                schema_variant_id: mgmt.schema_variant_id,
                 management_prototype_id: Some(mgmt.management_prototype_id),
                 func_id: Some(mgmt.func_id),
             },
@@ -479,7 +483,7 @@ impl FuncBinding {
                     None
                 }
             }
-            FuncBinding::Management(mgmt) => Some(mgmt.schema_variant_id),
+            FuncBinding::Management(mgmt) => mgmt.schema_variant_id,
         }
     }
 

--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -225,19 +225,6 @@ impl ManagementFuncJob {
         ctx: &DalContext,
         execution_state_id: ManagementFuncJobStateId,
     ) -> ManagementFuncJobResult<JobCompletionState> {
-        if !ManagementPrototype::is_valid_prototype_for_component(
-            ctx,
-            self.prototype_id,
-            self.component_id,
-        )
-        .await?
-        {
-            return Err(ManagementFuncJobError::InvalidPrototypeForComponent(
-                self.prototype_id,
-                self.component_id,
-            ));
-        }
-
         let mut ctx_clone = ctx.clone();
         // Loop for 5_000 * 50 ms (= 250 seconds max) and then mark job as failed if not ready
         self.spin_until_ready(&mut ctx_clone, MAX_WAITS).await?;

--- a/lib/dal/src/pkg/export.rs
+++ b/lib/dal/src/pkg/export.rs
@@ -576,6 +576,7 @@ impl PkgExporter {
         schema_variant_id: SchemaVariantId,
     ) -> PkgResult<Vec<ManagementFuncSpec>> {
         let mut specs = vec![];
+        // Only export variant level mgmt protos. No overlays
         let management_prototypes =
             ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await?;
 

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -16,7 +16,10 @@ use si_events::{
     ContentHash,
     Timestamp,
 };
-use si_id::ActionPrototypeId;
+use si_id::{
+    ActionPrototypeId,
+    ManagementPrototypeId,
+};
 use si_layer_cache::LayerDbError;
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -187,6 +190,14 @@ impl Schema {
         destination_id: ActionPrototypeId,
         add_fn: add_edge_to_action_prototype,
         discriminant: EdgeWeightKindDiscriminants::ActionPrototype,
+        result: SchemaResult,
+    );
+
+    implement_add_edge_to!(
+        source_id: SchemaId,
+        destination_id: ManagementPrototypeId,
+        add_fn: add_edge_to_management_prototype,
+        discriminant: EdgeWeightKindDiscriminants::ManagementPrototype,
         result: SchemaResult,
     );
 

--- a/lib/dal/src/workspace_snapshot/edge_weight.rs
+++ b/lib/dal/src/workspace_snapshot/edge_weight.rs
@@ -67,7 +67,7 @@ pub enum EdgeWeightKind {
     },
     /// Edge from attribute value to validation result node
     ValidationOutput,
-    /// Edge from [`SchemaVariant`](crate::SchemaVariant) to [`ManagementPrototype`](crate::ManagementPrototype).
+    /// Edge from [`Schema`](crate::Schema) or a [`SchemaVariant`](crate::SchemaVariant) to [`ManagementPrototype`](crate::ManagementPrototype).
     ManagementPrototype,
     /// From a Geometry node to the node it represents on a view.
     Represents,

--- a/lib/luminork-server/src/service/v1/components/execute_management_function.rs
+++ b/lib/luminork-server/src/service/v1/components/execute_management_function.rs
@@ -213,7 +213,7 @@ async fn resolve_management_function_reference(
         ManagementFunctionReference::ByName { function } => {
             let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
             let prototypes =
-                ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await?;
+                ManagementPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?;
 
             let mut matching_prototypes: Vec<_> = vec![];
             for prototype in prototypes {

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -286,7 +286,9 @@ pub async fn get_component_functions(
     }
 
     let mut management_functions = Vec::new();
-    for prototype in ManagementPrototype::list_for_variant_id(ctx, schema_variant_id).await? {
+    for prototype in
+        ManagementPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?
+    {
         let func_id = ManagementPrototype::func_id(ctx, prototype.id).await?;
         let func = Func::get_by_id(ctx, func_id).await?;
 

--- a/lib/sdf-server/src/service/v2/fs/bindings.rs
+++ b/lib/sdf-server/src/service/v2/fs/bindings.rs
@@ -592,6 +592,7 @@ async fn parse_binding_for_create(
             inputs,
         },
         Binding::Management => FuncBinding::Management {
+            schema_ids: None,
             schema_variant_id: Some(schema_variant_id),
             management_prototype_id: None,
             func_id: Some(func_id),
@@ -726,7 +727,8 @@ async fn create_management_binding(
     func_id: FuncId,
     schema_variant_id: SchemaVariantId,
 ) -> FsResult<()> {
-    ManagementBinding::create_management_binding(ctx, func_id, schema_variant_id).await?;
+    ManagementBinding::create_management_binding(ctx, func_id, None, Some(schema_variant_id))
+        .await?;
 
     let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
     let func = Func::get_by_id(ctx, func_id).await?;

--- a/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
@@ -388,7 +388,8 @@ pub async fn create_binding(
                             ManagementBinding::create_management_binding(
                                 &ctx,
                                 func_id,
-                                schema_variant_id,
+                                None,
+                                Some(schema_variant_id),
                             )
                             .await?;
                             let schema = SchemaVariant::schema_id(&ctx, schema_variant_id).await?;

--- a/lib/sdf-server/src/service/v2/management/latest.rs
+++ b/lib/sdf-server/src/service/v2/management/latest.rs
@@ -57,11 +57,13 @@ pub async fn all_latest_for_component(
         ComponentId,
     )>,
 ) -> ManagementApiResult<Json<Vec<FuncRunView>>> {
-    let sv_id = Component::schema_variant_id(ctx, component_id).await?;
+    let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
 
     let mut runs = vec![];
 
-    for mgmt_prototype in ManagementPrototype::list_for_variant_id(ctx, sv_id).await? {
+    for mgmt_prototype in
+        ManagementPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?
+    {
         let func_id = ManagementPrototype::func_id(ctx, mgmt_prototype.id).await?;
 
         let Some(run) = ctx

--- a/lib/si-frontend-types-rs/src/func.rs
+++ b/lib/si-frontend-types-rs/src/func.rs
@@ -19,6 +19,7 @@ use si_events::{
     SchemaVariantId,
     Timestamp,
 };
+use si_id::SchemaId;
 use strum::{
     AsRefStr,
     Display,
@@ -140,7 +141,7 @@ pub enum FuncBinding {
     },
     #[serde(rename_all = "camelCase")]
     Management {
-        // unique ids
+        schema_ids: Option<Vec<SchemaId>>,
         schema_variant_id: Option<SchemaVariantId>,
         management_prototype_id: Option<ManagementPrototypeId>,
         func_id: Option<FuncId>,


### PR DESCRIPTION
Adds the ability to create a mangement prototype that is parented by a schema instead of a schema variant. These will be listed in addition to schema variant level management prototypes when prototypes are listed for a component.