### PR TITLE
[feat] Hetzner: qualification for location name

### DIFF
--- a/bin/clover/src/pipelines/generic/applyAssetOverrides.ts
+++ b/bin/clover/src/pipelines/generic/applyAssetOverrides.ts
@@ -20,12 +20,18 @@ export function applyAssetOverrides(
     const variant = spec.schemas[0].variants[0];
 
     // If there's a schema-level override for this spec, run it
-    const schemaOverrideFn = providerConfig.overrides.schemaOverrides.get(
+    const schemaOverrideFns = providerConfig.overrides.schemaOverrides.get(
       spec.name,
     );
-    if (schemaOverrideFn) {
+    if (schemaOverrideFns) {
       logger.debug(`Running schema override for ${spec.name}`);
-      schemaOverrideFn(spec);
+      if (Array.isArray(schemaOverrideFns)) {
+        for (const schemaOverrideFn of schemaOverrideFns) {
+          schemaOverrideFn(spec);
+        }
+      } else {
+        schemaOverrideFns(spec);
+      }
     }
 
     // If there are prop-level overrides for this schema+spec, run them

--- a/bin/clover/src/pipelines/generic/overrides.ts
+++ b/bin/clover/src/pipelines/generic/overrides.ts
@@ -286,6 +286,27 @@ export function widget(
   };
 }
 
+export function addQualificationFunction(
+  funcPath: string,
+  name: string,
+  uniqueId: string,
+): SchemaOverrideFn {
+  return (spec) => {
+    const variant = spec.schemas[0].variants[0];
+    if (!variant.domain.uniqueId) {
+      throw new Error("Expected domain.uniqueId");
+    }
+    const { func, leafFuncSpec } = attachQualificationFunction(
+      funcPath,
+      name,
+      uniqueId,
+      variant.domain.uniqueId,
+    );
+
+    spec.funcs.push(func);
+    variant.leafFunctions.push(leafFuncSpec);
+  };
+}
 export function addScalarProp(
   propPath: PropPath,
   kind: "string" | "number" | "boolean",

--- a/bin/clover/src/pipelines/hetzner/funcs/overrides/Hetzner::Cloud::Locations/qualifications/locationQualification.ts
+++ b/bin/clover/src/pipelines/hetzner/funcs/overrides/Hetzner::Cloud::Locations/qualifications/locationQualification.ts
@@ -1,0 +1,36 @@
+async function main({ domain: { name } }: Input): Promise<Output> {
+  const token = requestStorage.getEnv("HETZNER_API_TOKEN");
+  if (!token) {
+    return {
+      result: "failure",
+      message: "Credentials are empty",
+    };
+  }
+
+  const response = await fetch(
+    `https://api.hetzner.cloud/v1/locations?${new URLSearchParams({ name })}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    return {
+      result: "failure",
+      message: "Credentials are invalid!",
+    };
+  }
+  const result = await response.json();
+  if (result.locations.length !== 1) {
+    return {
+      result: "failure",
+      message: `Location "${name}" invalid (${result.locations.length} results)!`,
+    };
+  }
+
+  return {
+    result: "success",
+  };
+}

--- a/bin/clover/src/pipelines/hetzner/overrides.ts
+++ b/bin/clover/src/pipelines/hetzner/overrides.ts
@@ -1,4 +1,9 @@
-import { widget, suggest, addScalarProp } from "../generic/overrides.ts";
+import {
+  widget,
+  suggest,
+  addScalarProp,
+  addQualificationFunction,
+} from "../generic/overrides.ts";
 import { PropOverrideFn, SchemaOverrideFn } from "../types.ts";
 
 const HETZNER_LOCATIONS = ["fsn1", "nbg1", "hel1", "ash", "hil", "sin"];
@@ -23,10 +28,22 @@ export const HETZNER_PROP_OVERRIDES: Record<
   },
 };
 
-// Hetzner-specific schema overrides!!!
-export const HETZNER_SCHEMA_OVERRIDES = new Map<string, SchemaOverrideFn>([
-  //
-  // Add Hetzner::Cloud::Locations.name so it can be selected and filled in
-  //
-  ["Hetzner::Cloud::Locations", addScalarProp("/domain/name", "string", true)],
-]);
+// Hetzner-specific schema overrides
+export const HETZNER_SCHEMA_OVERRIDES = new Map<
+  string,
+  SchemaOverrideFn | SchemaOverrideFn[]
+>(
+  Object.entries({
+    //
+    // Add Hetzner::Cloud::Locations.name so it can be selected and filled in
+    //
+    "Hetzner::Cloud::Locations": [
+      addScalarProp("/domain/name", "string", true),
+      addQualificationFunction(
+        "./src/pipelines/hetzner/funcs/overrides/Hetzner::Cloud::Locations/qualifications/locationQualification.ts",
+        "Hetzner::Cloud::Locations Check Valid Location Name",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      ),
+    ],
+  }),
+);


### PR DESCRIPTION
Qualifies the location name in Hetzner::Locations.

Also adds some affordances for easily adding qualification function overrides.

<img width="679" height="123" alt="image" src="https://github.com/user-attachments/assets/871b99b8-c05c-4891-9f1a-7a0fbe141797" />

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: qualification function passes
- [x] Manual test: qualification function from uploaded asset passes

## In short: [:link:](https://giphy.com/)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaGMxNnJ6eTR4dDA2cXBpOXdieDExNWx4c2VoejhhcmVxanpkbGx1ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3ohze082krk0OLhHG0/giphy.gif"/>