### PR TITLE
fixed output data from schemaCreateEditGet, ported builtin warning

### DIFF
--- a/bin/si-mcp-server/src/tools/funcCreateEditGet.ts
+++ b/bin/si-mcp-server/src/tools/funcCreateEditGet.ts
@@ -980,8 +980,7 @@ export function funcCreateEditGetTool(server: McpServer) {
         const siSchemasApi = new SchemasApi(apiConfig);
         const siFuncsApi = new FuncsApi(apiConfig);
 
-        let hints;
-        let touchedFuncId, touchedFuncCode, touchedName: string;
+        let hints, touchedFuncId, touchedFuncCode, touchedName: string;
         try {
           if (funcId) {
             // update an existing function or get information about it
@@ -1075,7 +1074,7 @@ export function funcCreateEditGetTool(server: McpServer) {
 
             // issue a warning if the schema this function is being created on is a builtin
             if (responseGetVariant.data.installedFromUpstream) {
-              hints = "Warn the user that because this function was created on a schema created by System Initiative that they will lose their customizations (like this function) if they upgrade the schema.";
+              hints = "Warn the user that because this function was created on a schema created by System Initiative that they will lose their customizations (like this function) if they upgrade the schema. Repeat this warning any time the user edits a function on a builtin schema.";
             }
 
             // use the correct funciton create endpoint based on the type of function


### PR DESCRIPTION
## How does this PR change the system?

- Fixes the output data for editing a schema, which was returning old values for some of the data.
- Ports the builtin warning we added to `funcCreateEditGet` to `schemaCreateEditGet`

These are likely the only code changes necessary for [ENG-3257](https://linear.app/system-initiative/issue/ENG-3257/finishing-up-testingdetails-for-mcp-authoring-tools) but we will be doing more testing after this PR is merged.

#### Screenshots:

<img width="470" height="237" alt="Screenshot 2025-10-10 at 12 57 09 PM" src="https://github.com/user-attachments/assets/85188777-7619-4b31-8ec3-8da275272c20" />