### PR TITLE
Persist Deployment MVs in WASM SQLite

### DIFF
--- a/app/web/cypress/e2e/webworker.cy.ts
+++ b/app/web/cypress/e2e/webworker.cy.ts
@@ -68301,6 +68301,9 @@ describe('webworkertest', () => {
     cy.intercept('POST', `http://localhost:8080/api/v2/workspaces/${workspaceId}/change-sets/${changeSetId}/index/multi_mjolnir`,
       {
         statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
         body: hammerBody,
       })
 
@@ -68314,6 +68317,56 @@ describe('webworkertest', () => {
       {
         statusCode: 500,  // this shouldn't actually get called!
         body: hammerBody,
+      })
+
+    const globalIndex = `
+{
+  "workspaceSnapshotAddress": "0001M9MKQK4DPQK3TQ5WP8CJ0Z",
+  "indexChecksum": "d556d181be774b20d83d5deb7eb61448",
+  "frontEndObject": {
+    "kind": "DeploymentMvIndex",
+    "id": "0001M9MKQK4DPQK3TQ5WP8CJ0Z",
+    "checksum": "d556d181be774b20d83d5deb7eb61448",
+    "data": {
+      "mvList": [
+        {
+          "kind": "CachedDefaultVariant",
+          "id": "01J1QXEJC12EEBZ00H4T15YHNQ",
+          "checksum": "5283e232a15993fdd4b03499a8b3058d"
+        }
+      ]
+    }
+  }
+}
+    `
+    cy.intercept('GET', `http://localhost:8080/api/v2/workspaces/${workspaceId}/deployment_index`,
+      {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: globalIndex,
+      })
+
+    const globalHammer = `
+{"successful":[{"kind":"CachedDefaultVariant","id":"01J1QXEJC12EEBZ00H4T15YHNQ","checksum":"5283e232a15993fdd4b03499a8b3058d","data":
+{"id":"01J1QXEJC12EEBZ00H4T15YHNQ","variantId":"01K3S6J6JQVFD2QKNVD91HCEBJ","displayName":"Docker Image","category":"Docker","color":"#4695E7","isLocked":true,
+"description":"","link":null,"assetFuncId":"01K3S6J5X6H4ZMF4V0633SBAHZ","variantFuncIds":
+["01K3S6J6K4KZ3ABK3E5RBA9X04","01K3S6J6K5KS5F7JNC4VN08YTN"],"domainProps":
+{"propId":"01K37FBCPP0004SAZTWFH7WRP0","name":"domain","propType":"object","description":null,"children":
+[{"propId":"01K37FBCPP000FCTNPBD8Q68FV","name":"image","propType":"string","description":null,"children":null,"validationFormat":null,"defaultValue":null,"hidden":false,
+"docLink":null},{"propId":"01K37FBCPP00052Z502FEXPEER","name":"ExposedPorts","propType":"array","description":null,"children":
+[{"propId":"01K37FBCPP000C3BQ7CZ25YSDH","name":"ExposedPort","propType":"string","description":null,"children":null,
+"validationFormat":null,"defaultValue":null,"hidden":false,"docLink":null}],"validationFormat":null,"defaultValue":null,"hidden":false,"docLink":null},{"propId":"01K37FBCPP0004WJK2TY7VPABC","name":"name","propType":"string","description":null,"children":null,"validationFormat":null,"defaultValue":null,"hidden":true,"docLink":null}],"validationFormat":null,"defaultValue":null,"hidden":false,"docLink":null}}},{"kind":"CachedDefaultVariant","id":"01J1QYBC8NPMTBSME649G5S45Q","checksum":"ce7c727674f1be1f10ccde31d388ce4c","data":{"id":"01J1QYBC8NPMTBSME649G5S45Q","variantId":"01J0PCHKVN4ZWTT1XF47N8B2PZ","displayName":"Hub Credential","category":"Docker","color":"#4695e7","isLocked":true,"description":null,"link":null,"assetFuncId":"01J0PCHKVMPDHP3FZCYRKADNYA","variantFuncIds":["01J0PCHKVX048JKRRNC7TNYTRK","01J0PCHKVX048JKRRNC7TNYTRQ"],"domainProps":{"propId":"01K37FBCPP000EV22MCWHYT0T1","name":"domain","propType":"object","description":null,"children":null,"validationFormat":null,"defaultValue":null,"hidden":false,"docLink":null}}}],
+"failed":[]}
+    `
+    cy.intercept('POST', `http://localhost:8080/api/v2/workspaces/${workspaceId}/multi_mjolnir`,
+      {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: globalHammer,
       })
 
     cy.visit('http://localhost:8080/webworkertest.html');

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -9,7 +9,7 @@ import {
 import { ChangeSetId } from "@/api/sdf/dal/change_set";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { WorkspacePk } from "@/api/sdf/dal/workspace";
-import { EntityKind } from "./types/entity_kind_types";
+import { EntityKind, GlobalEntity } from "./types/entity_kind_types";
 import {
   SharedDBInterface,
   TabDBInterface,
@@ -294,6 +294,16 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
+  async getGlobal(
+    workspaceId: string,
+    kind: GlobalEntity,
+    id: string,
+  ): Promise<typeof NOROW | AtomDocument> {
+    return await withLeader(
+      async (remote) => await remote.getGlobal(workspaceId, kind, id),
+    );
+  },
+
   async get(
     workspaceId: string,
     changeSetId: string,
@@ -413,6 +423,12 @@ const dbInterface: SharedDBInterface = {
   async niflheim(workspaceId: string, changeSetId: string): Promise<boolean> {
     return await withLeader(
       async (remote) => await remote.niflheim(workspaceId, changeSetId),
+    );
+  },
+
+  async vanaheim(workspaceId: string): Promise<boolean> {
+    return await withLeader(
+      async (remote) => await remote.vanaheim(workspaceId),
     );
   },
 

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -18,6 +18,7 @@ import {
   Connection,
   DefaultSubscriptions,
   EntityKind,
+  GlobalEntity,
   PossibleConnection,
 } from "./entity_kind_types";
 
@@ -194,6 +195,11 @@ export interface SharedDBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): Promise<DefaultSubscriptions>;
+  getGlobal(
+    workspaceId: string,
+    kind: GlobalEntity,
+    id: Id,
+  ): Promise<typeof NOROW | AtomDocument>;
   get(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -239,6 +245,7 @@ export interface SharedDBInterface {
     changeSetId: ChangeSetId,
   ): Promise<boolean>;
   niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<boolean>;
+  vanaheim(workspaceId: string): Promise<boolean>;
   exec(
     opts: ExecBaseOptions &
       ExecRowModeArrayOptions &
@@ -309,6 +316,11 @@ export interface TabDBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): DefaultSubscriptions;
+  getGlobal(
+    workspaceId: string,
+    kind: GlobalEntity,
+    id: Id,
+  ): typeof NOROW | AtomDocument;
   get(
     workspaceId: string,
     changeSetId: ChangeSetId,
@@ -363,6 +375,7 @@ export interface TabDBInterface {
   addConnStatusFn(fn: ConnStatusFn): void;
   changeSetExists(workspaceId: string, changeSetId: ChangeSetId): boolean;
   niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<boolean>;
+  vanaheim(workspaceId: string): Promise<boolean>;
   pruneAtomsForClosedChangeSet(
     workspaceId: WorkspacePk,
     changeSetId: ChangeSetId,
@@ -371,6 +384,7 @@ export interface TabDBInterface {
   oneInOne(rows: SqlValue[][]): SqlValue | typeof NOROW;
   encodeDocumentForDB(doc: object): Uint8Array;
   decodeDocumentFromDB(doc: ArrayBuffer): AtomDocument;
+  handleDeploymentPatchMessage(data: DeploymentPatchBatch): Promise<void>;
   handleWorkspacePatchMessage(data: WorkspacePatchBatch): Promise<void>;
   handleIndexMvPatch(data: WorkspaceIndexUpdate): Promise<void>;
   handleHammer(msg: WorkspaceAtomMessage): Promise<void>;
@@ -531,6 +545,10 @@ export interface IndexObjectMeta {
   workspaceSnapshotAddress: string;
   frontEndObject: IndexObject;
   indexChecksum: string;
+}
+
+export interface AtomWithData extends Common {
+  data: object;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -58,7 +58,16 @@ export enum EntityKind {
   // IGNORING THESE
   LuminorkDefaultVariant = "LuminorkDefaultVariant",
   LuminorkSchemaVariant = "LuminorkSchemaVariant",
+  // DEPLOYMENT aka GLOBAL
+  CachedSchema = "CachedSchema",
+  CachedDefaultVariant = "CachedDefaultVariant",
 }
+
+export const GLOBAL_ENTITIES = [
+  EntityKind.CachedSchema,
+  EntityKind.CachedDefaultVariant,
+] as const;
+export type GlobalEntity = (typeof GLOBAL_ENTITIES)[number];
 
 /**
  * NOTE, if you want to narrow the type of a variable

--- a/lib/edda-server/src/materialized_view/deployment.rs
+++ b/lib/edda-server/src/materialized_view/deployment.rs
@@ -618,7 +618,7 @@ where
     let op = {
         let maybe_previous_version = match frigg
             .get_current_deployment_object_with_index(
-                mv_kind,
+                mv_kind.into(),
                 &mv_id,
                 (*maybe_deployment_mv_index).clone(),
             )

--- a/lib/luminork-server/src/service/v1/schemas/get_default_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_default_variant.rs
@@ -82,7 +82,7 @@ pub async fn get_default_variant(
                 // The only cached schemas we currently build are builtins - if that changes, this logic will need to change!
                 let installed_from_upstream = (frigg
                     .get_current_deployment_object(
-                        ReferenceKind::CachedSchema,
+                        ReferenceKind::CachedSchema.into(),
                         &schema_id.to_string(),
                     )
                     .await?)
@@ -152,7 +152,10 @@ pub async fn get_default_variant(
     }
 
     match frigg
-        .get_current_deployment_object(ReferenceKind::CachedDefaultVariant, &schema_id.to_string())
+        .get_current_deployment_object(
+            ReferenceKind::CachedDefaultVariant.into(),
+            &schema_id.to_string(),
+        )
         .await?
     {
         Some(obj) => {

--- a/lib/luminork-server/src/service/v1/schemas/get_schema.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_schema.rs
@@ -80,7 +80,7 @@ pub async fn get_schema(
 
     // Fall back to MV lookup for uninstalled schemas using CachedSchema
     match frigg
-        .get_current_deployment_object(ReferenceKind::CachedSchema, &schema_id.to_string())
+        .get_current_deployment_object(ReferenceKind::CachedSchema.into(), &schema_id.to_string())
         .await
     {
         Ok(Some(obj)) => {

--- a/lib/luminork-server/src/service/v1/schemas/get_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/get_variant.rs
@@ -97,7 +97,7 @@ pub async fn get_variant(
                 // The only cached schemas we currently build are builtins - if that changes, this logic will need to change!
                 let installed_from_upstream = (frigg
                     .get_current_deployment_object(
-                        ReferenceKind::CachedSchema,
+                        ReferenceKind::CachedSchema.into(),
                         &schema_id.to_string(),
                     )
                     .await?)
@@ -164,7 +164,10 @@ pub async fn get_variant(
 
     // Phase 1 Fallback: Try CachedDefaultVariant MV (deployment-level, for uninstalled modules)
     match frigg
-        .get_current_deployment_object(ReferenceKind::CachedDefaultVariant, &schema_id.to_string())
+        .get_current_deployment_object(
+            ReferenceKind::CachedDefaultVariant.into(),
+            &schema_id.to_string(),
+        )
         .await?
     {
         Some(obj) => {

--- a/lib/luminork-server/src/service/v1/schemas/unlock_schema.rs
+++ b/lib/luminork-server/src/service/v1/schemas/unlock_schema.rs
@@ -124,7 +124,7 @@ pub async fn unlock_schema(
     // We know it is a builtin if we find a CachedSchema for its schema id
     // The only cached schemas we currently build are builtins - if that changes, this logic will need to change!
     let installed_from_upstream = (frigg
-        .get_current_deployment_object(ReferenceKind::CachedSchema, &schema_id.to_string())
+        .get_current_deployment_object(ReferenceKind::CachedSchema.into(), &schema_id.to_string())
         .await?)
         .is_some();
 

--- a/lib/luminork-server/src/service/v1/schemas/update_schema_variant.rs
+++ b/lib/luminork-server/src/service/v1/schemas/update_schema_variant.rs
@@ -142,7 +142,7 @@ pub async fn update_schema_variant(
     // We know it is a builtin if we find a CachedSchema for its schema id
     // The only cached schemas we currently build are builtins - if that changes, this logic will need to change!
     let installed_from_upstream = (frigg
-        .get_current_deployment_object(ReferenceKind::CachedSchema, &schema_id.to_string())
+        .get_current_deployment_object(ReferenceKind::CachedSchema.into(), &schema_id.to_string())
         .await?)
         .is_some();
 

--- a/lib/sdf-core/src/index.rs
+++ b/lib/sdf-core/src/index.rs
@@ -35,6 +35,8 @@ pub enum IndexError {
     Acquire(#[from] tokio::sync::AcquireError),
     #[error("change set error: {0}")]
     ChangeSet(#[from] dal::ChangeSetError),
+    #[error("index not found after fresh rebuild (v1);")]
+    DeploymentIndexNotFoundAfterFreshBuild(),
     #[error("deserializing mv index data error: {0}")]
     DeserializingMvIndexData(#[source] serde_json::Error),
     #[error("edda client error: {0}")]

--- a/lib/sdf-server/src/service/v2/workspace.rs
+++ b/lib/sdf-server/src/service/v2/workspace.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use axum::{
     Router,
     http::StatusCode,
@@ -10,17 +12,38 @@ use axum::{
         post,
     },
 };
-use sdf_core::api_error::ApiError;
+use dal::WorkspacePk;
+use sdf_core::{
+    api_error::ApiError,
+    index::IndexResult,
+};
+use telemetry::prelude::*;
 use thiserror::Error;
+use tokio::task::JoinError;
 
+use super::AccessBuilder;
 use crate::app_state::AppState;
 
+mod get_deployment_index;
 mod install_workspace;
 mod list_workspace_users;
+mod mjolnir;
 
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum WorkspaceAPIError {
+    #[error("semaphore acquire error: {0}")]
+    Acquire(#[from] tokio::sync::AcquireError),
+    #[error("deserializing mv index data error: {0}")]
+    DeserializingMvIndexData(#[source] serde_json::Error),
+    #[error("edda client error: {0}")]
+    EddaClient(#[from] edda_client::ClientError),
+    #[error("frigg error: {0}")]
+    Frigg(#[from] frigg::FriggError),
+    #[error("deployment index not found")]
+    IndexNotFound,
+    #[error("latest item not found; workspace_id={0}, kind={1}, id={2}")]
+    LatestItemNotFound(WorkspacePk, String, String),
     #[error("module index client error: {0}")]
     ModuleIndexClient(#[from] module_index_client::ModuleIndexClientError),
     #[error("module index url not set")]
@@ -31,10 +54,14 @@ pub enum WorkspaceAPIError {
     RootTenancyInstallAttempt,
     #[error("si db error: {0}")]
     SiDb(#[from] si_db::Error),
+    #[error("tokio task join error: {0}")]
+    TokioJoin(#[from] JoinError),
     #[error("transactions error: {0}")]
     Transactions(#[from] dal::TransactionsError),
     #[error("unable to parse url: {0}")]
     Url(#[from] url::ParseError),
+    #[error("timed out when watching index with duration: {0:?}")]
+    WatchIndexTimeout(Duration),
     #[error("workspace error: {0}")]
     Workspace(#[from] dal::WorkspaceError),
 }
@@ -44,7 +71,8 @@ pub type WorkspaceAPIResult<T> = Result<T, WorkspaceAPIError>;
 impl IntoResponse for WorkspaceAPIError {
     fn into_response(self) -> Response {
         let (status_code, error_message) = match self {
-            Self::Workspace(dal::WorkspaceError::WorkspaceNotFound(_)) => {
+            WorkspaceAPIError::LatestItemNotFound(_, _, _)
+            | Self::Workspace(dal::WorkspaceError::WorkspaceNotFound(_)) => {
                 (StatusCode::NOT_FOUND, self.to_string())
             }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
@@ -58,4 +86,13 @@ pub fn v2_routes() -> Router<AppState> {
     Router::new()
         .route("/install", post(install_workspace::install_workspace))
         .route("/users", get(list_workspace_users::list_workspace_users))
+        .route(
+            "/deployment_index",
+            get(get_deployment_index::get_deployment_index),
+        )
+        .route(
+            "/multi_mjolnir",
+            post(mjolnir::get_multiple_front_end_objects),
+        )
+        .route("/mjolnir", post(mjolnir::get_front_end_object))
 }

--- a/lib/sdf-server/src/service/v2/workspace/get_deployment_index.rs
+++ b/lib/sdf-server/src/service/v2/workspace/get_deployment_index.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use axum::{
+    Json,
+    extract::Path,
+    http::StatusCode,
+    response::IntoResponse,
+};
+use dal::WorkspacePk;
+use futures_lite::StreamExt;
+use sdf_core::index::{
+    FrontEndObjectMeta,
+    IndexError,
+};
+use telemetry::prelude::*;
+
+use super::{
+    AccessBuilder,
+    IndexResult,
+};
+use crate::extract::{
+    EddaClient,
+    FriggStore,
+    HandlerContext,
+};
+
+const WATCH_INDEX_TIMEOUT: Duration = Duration::from_secs(4);
+async fn request_rebuild_and_watch(
+    frigg: &frigg::FriggStore,
+    edda_client: &edda_client::EddaClient,
+) -> IndexResult<bool> {
+    let span = Span::current();
+    let mut watch = frigg.watch_deployment_index().await?;
+    let request_id = edda_client.rebuild_for_deployment().await?;
+    span.record("si.edda_request.id", request_id.to_string());
+
+    let timeout = WATCH_INDEX_TIMEOUT;
+    tokio::select! {
+        _ = tokio::time::sleep(timeout) => {
+            info!("timed out waiting for new index to be rebuilt");
+            Ok(false)
+        },
+        _ = watch.next() => Ok(true)
+    }
+}
+
+pub async fn get_deployment_index(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    FriggStore(frigg): FriggStore,
+    EddaClient(edda_client): EddaClient,
+    Path(_workspace_id): Path<WorkspacePk>,
+) -> IndexResult<impl IntoResponse> {
+    let _ctx = builder.build_head(access_builder).await?;
+    let index = match frigg.get_deployment_index().await? {
+        Some((index, _kv_revision)) => index,
+        None => {
+            info!("Index not found for deployment; attempting full build");
+            if !request_rebuild_and_watch(&frigg, &edda_client).await? {
+                // Return 202 Accepted with the same response body if the build didn't succeed in time
+                // to let the caller know the create succeeded, we're just waiting on downstream work
+                return Ok((StatusCode::ACCEPTED, Json(None)));
+            }
+            frigg
+                .get_deployment_index()
+                .await?
+                .map(|i| i.0)
+                .ok_or(IndexError::DeploymentIndexNotFoundAfterFreshBuild())?
+        }
+    };
+
+    Ok((
+        StatusCode::OK,
+        Json(Some(FrontEndObjectMeta {
+            workspace_snapshot_address: index.clone().id,
+            index_checksum: index.clone().checksum,
+
+            front_end_object: index,
+        })),
+    ))
+}

--- a/lib/sdf-server/src/service/v2/workspace/mjolnir.rs
+++ b/lib/sdf-server/src/service/v2/workspace/mjolnir.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{
+        Path,
+        Query,
+    },
+};
+use dal::WorkspacePk;
+use frigg::FriggStore;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use si_frontend_mv_types::object::FrontendObject;
+use si_frontend_types::FrontEndObjectRequest;
+use telemetry::prelude::*;
+use tokio::{
+    sync::Semaphore,
+    task::JoinSet,
+};
+
+use super::AccessBuilder;
+use crate::{
+    extract::{
+        FriggStore as FriggStoreExtractor,
+        HandlerContext,
+    },
+    service::v2::workspace::{
+        WorkspaceAPIError,
+        WorkspaceAPIResult,
+    },
+};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MultipleFrontEndObjectRequest {
+    pub requests: Vec<FrontEndObjectRequest>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MultipleFrontEndObjectResponse {
+    successful: Vec<FrontendObject>,
+    failed: Vec<FrontEndObjectRequest>,
+}
+
+pub async fn get_front_end_object(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    FriggStoreExtractor(frigg): FriggStoreExtractor,
+    Path(workspace_pk): Path<WorkspacePk>,
+    Query(request): Query<FrontEndObjectRequest>,
+) -> WorkspaceAPIResult<Json<FrontendObject>> {
+    let _ctx = builder.build_head(access_builder).await?;
+
+    let obj = frigg
+        .get_current_deployment_object(&request.kind, &request.id)
+        .await?;
+    match obj {
+        Some(o) => Ok(Json(o)),
+        None => Err(WorkspaceAPIError::LatestItemNotFound(
+            workspace_pk,
+            request.kind,
+            request.id,
+        )),
+    }
+}
+
+const BULK_CONCURRENCY_LIMIT: usize = 200;
+
+pub async fn get_multiple_front_end_objects(
+    HandlerContext(builder): HandlerContext,
+    AccessBuilder(access_builder): AccessBuilder,
+    FriggStoreExtractor(frigg): FriggStoreExtractor,
+    Path(_workspace_pk): Path<WorkspacePk>,
+    Json(request): Json<MultipleFrontEndObjectRequest>,
+) -> WorkspaceAPIResult<Json<MultipleFrontEndObjectResponse>> {
+    let concurrency_control = Arc::new(Semaphore::new(BULK_CONCURRENCY_LIMIT));
+
+    let _ctx = builder.build_head(access_builder).await?;
+
+    let mut successful = Vec::new();
+    let mut failed = Vec::new();
+
+    let mut join_set = JoinSet::new();
+
+    let maybe_mv_index = frigg.get_deployment_index().await?.map(|r| r.0);
+    let Some(mv_index_data) = maybe_mv_index else {
+        return Err(WorkspaceAPIError::IndexNotFound);
+    };
+    let mv_list = Arc::new(FriggStore::mv_list_from_deployment_mv_index_version_data(
+        mv_index_data.data,
+    )?);
+    for object_request in request.requests {
+        let mv_list_clone = mv_list.clone();
+        let frigg_clone = frigg.clone();
+        let sem_clone = concurrency_control.clone();
+        join_set.spawn(async move {
+            let _permit = sem_clone.acquire().await?;
+            Ok::<(Result<Option<FrontendObject>, _>, FrontEndObjectRequest), WorkspaceAPIError>((
+                frigg_clone
+                    .get_current_deployment_object_with_mvlist(
+                        &object_request.kind,
+                        &object_request.id,
+                        mv_list_clone.as_ref(),
+                    )
+                    .await
+                    .map_err(Into::<WorkspaceAPIError>::into),
+                object_request,
+            ))
+        });
+    }
+
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result?? {
+            (Ok(Some(obj)), _) => successful.push(obj),
+            (Ok(None), object_request) => {
+                error!("Not found {:?}", object_request);
+                failed.push(object_request);
+            }
+            (Err(error), object_request) => {
+                error!(?error);
+                failed.push(object_request);
+            }
+        };
+    }
+
+    Ok(Json(MultipleFrontEndObjectResponse { successful, failed }))
+}


### PR DESCRIPTION
# Storing Global Data
## MVs not associated with a workspace and change set

We make a new table, `global_atoms`, with the same columns as the `atoms` table. But the PK & constraint is slightly different. We aren't allowing the storage of multiple `checksum` with the same `args` and `kind`.

There is no MTM table, since this is one for the world.

The patching operations follow the same pattern. For modify patches, get the doc, apply, persist. Removals and creations are straightforward. Use the INSERT ON CONFLICT sql approach to push everything into a single statement.

## Testing Steps

### First scenario:
1. Cold start per normal
2. See hammers thrown for all the deployment MVs
3. Refresh the page
4. See zero hammers—the data has been stored

**Note**: 3k takes roughly 4 seconds

### Second scenario:
1. Delete the deployment MVs from SQLite
2. Empty Frigg of its deployment MVs and index
3. Cold start
4. The index isn't ready yet
6. The deployment MV data comes over the wire as a patch
7. Refresh the page
8. Cold start happens
9. See zero hammers—the data has been stored from the patches

**Note:** this is ~3k patches, happens really fast. So when we bring on new schemas for providers—it will be fast!

### Third scenario:
This is a slightly different code path, since it pulls the existing docs out of the DB and will the most experienced code path for users.
1. Covered in unit tests, patching an individual deployment MV.

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlYTByOXd0Z210MzQyZms0Mnh1bTZrZHJ6bDNxbDFuNXE5aTNhandiNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ffg5JsTZFqy9WVQI2z/giphy.gif"/>