### PR TITLE
fix: add region and aws cred to aws example in schema tool

### DIFF
--- a/bin/si-mcp-server/src/tools/schemaCreateEditGet.ts
+++ b/bin/si-mcp-server/src/tools/schemaCreateEditGet.ts
@@ -46,70 +46,100 @@ const schemaCreateEditGetInputSchemaRaw = {
     .describe(
       `
       <description>A typescript function, starting with "function main() {", defining the schema's properties using an AssetBuilder. Documentation on how to write this function can be found at https://docs.systeminit.com/reference/asset/schema</description>
-      <good-example>
+      <aws-good-example>
         const asset = new AssetBuilder();
 
         const stringProp = new PropBuilder()
-          .setName("StringProp")
-          .setKind("string")
-          .setDocumentation("Documentation text explaining this prop goes here.")
-          .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
-          .build();
+            .setName("StringProp")
+            .setKind("string")
+            .setDocumentation("Documentation text explaining this prop goes here.")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+            .build();
 
         const integerProp = new PropBuilder()
-          .setName("IntegerProp")
-          .setKind("integer")
-          .setDocumentation("Documentation text explaining this prop goes here.")
-          .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
-          .build();
+            .setName("IntegerProp")
+            .setKind("integer")
+            .setDocumentation("Documentation text explaining this prop goes here.")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind("text").build())
+            .build();
 
         const booleanProp = new PropBuilder()
-          .setName("BooleanProp")
-          .setKind("boolean")
-          .setDocumentation("Documentation text explaining this prop goes here.")
-          .setWidget(new PropWidgetDefinitionBuilder().setKind("checkbox").build())
-          .build();
+            .setName("BooleanProp")
+            .setKind("boolean")
+            .setDocumentation("Documentation text explaining this prop goes here.")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind("checkbox").build())
+            .build();
 
         const codeEditorProp = new PropBuilder()
-          .setName("CodeEditorProp")
-          .setKind("string")
-          .setDocumentation("Documentation text explaining this prop goes here.")
-          .setWidget(new PropWidgetDefinitionBuilder().setKind("codeEditor").build())
-          .build();
+            .setName("CodeEditorProp")
+            .setKind("string")
+            .setDocumentation("Documentation text explaining this prop goes here.")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind("codeEditor").build())
+            .build();
 
         const passwordProp = new PropBuilder()
-          .setName("PasswordProp")
-          .setKind("string")
-          .setDocumentation("Documentation text explaining this prop goes here.")
-          .setWidget(new PropWidgetDefinitionBuilder().setKind("password").build())
-          .build();
+            .setName("PasswordProp")
+            .setKind("string")
+            .setDocumentation("Documentation text explaining this prop goes here.")
+            .setWidget(new PropWidgetDefinitionBuilder().setKind("password").build())
+            .build();
 
         const objectProp = new PropBuilder()
-          .setName("ObjectProp")
-          .setKind("object")
-          .addChild(booleanProp)
-          .build();
+            .setName("ObjectProp")
+            .setKind("object")
+            .addChild(booleanProp)
+            .build();
 
         const arrayProp = new PropBuilder()
-          .setName("ArrayProp")
-          .setKind("array")
-          .setEntry(passwordProp)
-          .build();
+            .setName("ArrayProp")
+            .setKind("array")
+            .setEntry(passwordProp)
+            .build();
 
         const mapProp = new PropBuilder()
-          .setName("MapProp")
-          .setKind("map")
-          .setEntry(integerProp)
-          .build();
+            .setName("MapProp")
+            .setKind("map")
+            .setEntry(integerProp)
+            .build();
+
+        const extraProp = new PropBuilder()
+            .setName("extra")
+            .setKind("object")
+            .setHidden(false)
+            .setWidget(new PropWidgetDefinitionBuilder()
+                .setKind("header")
+                .build())
+            .addChild(
+                new PropBuilder()
+                .setName("Region")
+                .setKind("string")
+                .setHidden(false)
+                .setWidget(new PropWidgetDefinitionBuilder()
+                    .setKind("text")
+                    .build())
+                .suggestSource({
+                    schema: "Region",
+                    prop: "/domain/region"
+                })
+                .build()
+            )
+            .build();
+
+        const AWSCredentialSecretProp = new SecretPropBuilder()
+            .setName("AWS Credential")
+            .setSecretKind("AWS Credential")
+            .build();
 
         asset.addProp(stringProp);
         asset.addProp(codeEditorProp);
         asset.addProp(objectProp);
         asset.addProp(arrayProp);
         asset.addProp(mapProp);
+        asset.addProp(extraProp);
+        asset.addSecretProp(AWSCredentialSecretProp)
 
         return asset.build();
-      </good-example>
+      </aws-good-example>
       `,
     ),
 };


### PR DESCRIPTION
Added missing example region and aws credential props from assetbuilder  function.