### PR TITLE
fix(mcp-server): Change si-mcp-server upgradeComponents to use searchApi

### DIFF
--- a/bin/si-mcp-server/src/tools/upgradeComponents.ts
+++ b/bin/si-mcp-server/src/tools/upgradeComponents.ts
@@ -1,10 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import {
-  ComponentsApi,
-  SearchComponentsV1Request,
-} from "@systeminit/api-client";
+import { ComponentsApi, SearchApi } from "@systeminit/api-client";
 import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
 import {
   errorResponse,
@@ -15,7 +12,8 @@ import {
 
 const name = "upgrade-components";
 const title = "Upgrade a list of components";
-const description = `<description>Find a list of components to upgrade. You can filter the list of components to upgrade using a schema category, e.g. AWS::EC2. On failure, returns error details. *Always* ensure that components can be upgraded before trying to upgrade them.</description><usage>Use this tool to upgrade a list of components in a change set. You can filter the components to upgrade by passing a schema category. A schema category is in the form provider::service, e.g AWS::EC2. To see all of its information after it has been updated, use the component-get tool.</usage>`;
+const description =
+  `<description>Find a list of components to upgrade. You can filter the list of components to upgrade using a schema category, e.g. AWS::EC2. On failure, returns error details. *Always* ensure that components can be upgraded before trying to upgrade them.</description><usage>Use this tool to upgrade a list of components in a change set. You can filter the components to upgrade by passing a schema category. A schema category is in the form provider::service, e.g AWS::EC2. To see all of its information after it has been updated, use the component-get tool.</usage>`;
 
 const UpgradeComponentInputSchemaRaw = {
   changeSetId: z
@@ -70,25 +68,18 @@ export function upgradeComponentsTool(server: McpServer) {
     async ({ changeSetId, schemaCategory }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
         const siComponentsApi = new ComponentsApi(apiConfig);
+        const siSearchApi = new SearchApi(apiConfig);
 
         try {
-          const searchRequest: SearchComponentsV1Request = {
-            upgradable: true,
-          };
+          const searchString = [
+            "isUpgradable:true",
+            schemaCategory && `category:${schemaCategory}`,
+          ].filter(Boolean).join(" ");
 
-          if (schemaCategory) {
-            searchRequest.schemaCategory = schemaCategory;
-          }
-
-          const upgradableResp = await siComponentsApi.searchComponents({
+          const upgradableResp = await siSearchApi.search({
             workspaceId: WORKSPACE_ID,
             changeSetId: changeSetId,
-            searchComponentsV1Request: searchRequest,
-          });
-
-          // Coercing the API response as a List of strings as it's picked up weird in the API!
-          const SearchComponentsV1ResponseSchema = z.object({
-            components: z.array(z.string()),
+            q: searchString,
           });
 
           const result: UpgradeComponentResult = {
@@ -96,17 +87,14 @@ export function upgradeComponentsTool(server: McpServer) {
           };
 
           if (upgradableResp.status === 200) {
-            const parsed = SearchComponentsV1ResponseSchema.parse(
-              upgradableResp.data,
-            );
-            const components = parsed.components;
+            const components = upgradableResp.data.components;
 
-            for (const componentId of components) {
-              console.debug(`Starting upgrade of ${componentId}`);
+            for (const component of components) {
+              console.debug(`Starting upgrade of ${component.name}`);
               await siComponentsApi.upgradeComponent({
                 workspaceId: WORKSPACE_ID,
                 changeSetId: changeSetId,
-                componentId,
+                componentId: component.id,
               });
             }
             return successResponse(result);


### PR DESCRIPTION
Tested this locally with creating an AWS::EC2::Subnet editing variant then asking:

```
using the account-deno workspace, can you upgrade all of the AWS::EC2::Subnet components
```

```
Great! I found 6 AWS::EC2::Subnet components in the account-demo change set. Now let me upgrade all of them using the AWS::EC2 schema
  category filter.

⏺ si-mcp-server - upgrade-components (MCP)(changeSetId: "01K779TQWFCYZA60YT41DWV7BZ", schemaCategory: "AWS::EC2")
  ⎿  <response>{"status":"success","data":{"success":true}}</response>

⏺ ✅ Successfully upgraded all AWS::EC2::Subnet components in the account-demo change set!

  I found and upgraded 6 subnet components:
  - paul-demo-from-api-subnet-pub-1
  - paul-demo-from-api-subnet-pub-2
  - paul-demo-from-api-subnet-pub-3
  - paul-demo-from-api-subnet-priv-1
  - paul-demo-from-api-subnet-priv-2
  - paul-demo-from-api-subnet-priv-3

  All AWS::EC2 components in the change set have been upgraded to the latest version.
  ```