### PR TITLE
chore: stop using `#[error(transparent)]` in Error variants

### DIFF
--- a/lib/bedrock-server/src/routes.rs
+++ b/lib/bedrock-server/src/routes.rs
@@ -61,9 +61,9 @@ pub fn public_routes(state: AppState) -> Router {
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum AppError {
-    #[error(transparent)]
+    #[error("parameter store client error: {0}")]
     ParameterStoreClient(#[from] ParameterStoreClientError),
-    #[error(transparent)]
+    #[error("server error: {0}")]
     Server(#[from] ServerError),
 }
 

--- a/lib/bedrock-server/src/server.rs
+++ b/lib/bedrock-server/src/server.rs
@@ -57,11 +57,11 @@ use crate::{
 pub enum ServerError {
     #[error("AWS credentials error: {0}")]
     AwsCredentials(String),
-    #[error(transparent)]
+    #[error("certificate client error: {0}")]
     CertificateClient(#[from] PrivateCertManagerClientError),
     #[error("hyper server error")]
     Hyper(#[from] hyper::Error),
-    #[error(transparent)]
+    #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("failed to setup signal handler")]
     Tls(#[from] si_tls::TlsError),

--- a/lib/config-file/src/parameter_provider.rs
+++ b/lib/config-file/src/parameter_provider.rs
@@ -18,7 +18,7 @@ use tracing::{
 pub enum ParameterError {
     #[error("Failed to fetch parameters: {0}")]
     Fetch(String),
-    #[error(transparent)]
+    #[error("other error: {0}")]
     Other(#[from] Box<dyn Error + Send + Sync>),
 }
 

--- a/lib/cyclone-server/src/config.rs
+++ b/lib/cyclone-server/src/config.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 pub enum ConfigError {
     #[error("config builder")]
     Builder(#[from] ConfigBuilderError),
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     #[error("no socket addrs where resolved")]
     NoSocketAddrResolved,

--- a/lib/cyclone-server/src/execution.rs
+++ b/lib/cyclone-server/src/execution.rs
@@ -96,7 +96,7 @@ pub enum ExecutionError {
     ChildRecvIO(#[source] io::Error),
     #[error("failed to send child process message")]
     ChildSendIO(#[source] io::Error),
-    #[error(transparent)]
+    #[error("child shutdown error: {0}")]
     ChildShutdown(#[from] ShutdownError),
     #[error("failed to spawn child process; program={0}")]
     ChildSpawn(#[source] io::Error, PathBuf),

--- a/lib/dal/src/component.rs
+++ b/lib/dal/src/component.rs
@@ -291,9 +291,9 @@ pub enum ComponentError {
     OutputSocketNotFoundForComponentId(OutputSocketId, ComponentId),
     #[error("output socket {0} has more than one attribute value")]
     OutputSocketTooManyAttributeValues(OutputSocketId),
-    #[error(transparent)]
+    #[error("parse float error: {0}")]
     ParseFloat(#[from] ParseFloatError),
-    #[error(transparent)]
+    #[error("parse int error: {0}")]
     ParseInt(#[from] ParseIntError),
     #[error("prop error: {0}")]
     Prop(#[from] Box<PropError>),

--- a/lib/dal/src/diagram.rs
+++ b/lib/dal/src/diagram.rs
@@ -160,9 +160,9 @@ pub enum DiagramError {
     NodeWeight(#[from] Box<NodeWeightError>),
     #[error("output socket error: {0}")]
     OutputSocket(#[from] Box<OutputSocketError>),
-    #[error(transparent)]
+    #[error("parse float error: {0}")]
     ParseFloat(#[from] ParseFloatError),
-    #[error(transparent)]
+    #[error("parse int error: {0}")]
     ParseInt(#[from] ParseIntError),
     #[error("pg error: {0}")]
     Pg(#[from] PgError),

--- a/lib/dal/src/job/definition/dependent_values_update.rs
+++ b/lib/dal/src/job/definition/dependent_values_update.rs
@@ -91,9 +91,9 @@ pub enum DependentValueUpdateError {
     SchemaVariant(#[from] Box<SchemaVariantError>),
     #[error("status update error: {0}")]
     StatusUpdate(#[from] Box<StatusUpdateError>),
-    #[error(transparent)]
+    #[error("tokio task error: {0}")]
     TokioTask(#[from] JoinError),
-    #[error(transparent)]
+    #[error("transactions error: {0}")]
     Transactions(#[from] Box<TransactionsError>),
     #[error("workspace snapshot error: {0}")]
     WorkspaceSnapshot(#[from] Box<WorkspaceSnapshotError>),

--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -88,9 +88,9 @@ pub enum ManagementFuncJobError {
     NoPendingExecution(ComponentId, ManagementPrototypeId, ChangeSetId),
     #[error("serde json error: {0}")]
     Serde(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("tokio task error: {0}")]
     TokioTask(#[from] JoinError),
-    #[error(transparent)]
+    #[error("transactions error: {0}")]
     Transactions(#[from] Box<TransactionsError>),
     #[error(
         "management func {0} for component {1} waited too long for dependent values to be calculated"

--- a/lib/dal/src/job/processor.rs
+++ b/lib/dal/src/job/processor.rs
@@ -26,9 +26,9 @@ pub enum JobQueueProcessorError {
     MissingWorkspacePk,
     #[error("pinga client error: {0}")]
     PingaClient(#[from] Box<pinga_client::ClientError>),
-    #[error(transparent)]
+    #[error("serde error: {0}")]
     Serde(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("transport error: {0}")]
     Transport(Box<dyn std::error::Error + Sync + Send + 'static>),
 }
 

--- a/lib/dal/src/key_pair.rs
+++ b/lib/dal/src/key_pair.rs
@@ -69,7 +69,7 @@ pub enum KeyPairError {
     Transactions(#[from] TransactionsError),
     #[error("cannot get key for different workspace")]
     UnauthorizedKeyAccess,
-    #[error(transparent)]
+    #[error("workspace error: {0}")]
     Workspace(#[from] Box<WorkspaceError>),
 }
 

--- a/lib/dal/src/qualification.rs
+++ b/lib/dal/src/qualification.rs
@@ -61,9 +61,9 @@ pub struct QualificationSummary {
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum QualificationSummaryError {
-    #[error(transparent)]
+    #[error("component error: {0}")]
     Component(#[from] Box<ComponentError>),
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] PgError),
 }
 
@@ -173,7 +173,7 @@ pub enum QualificationError {
     Prop(#[from] PropError),
     #[error("error serializing/deserializing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("validation resolver error: {0}")]
     ValidationResolver(#[from] ValidationError),
 }
 

--- a/lib/dal/src/socket/input.rs
+++ b/lib/dal/src/socket/input.rs
@@ -71,9 +71,9 @@ pub enum InputSocketError {
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error(transparent)]
+    #[error("component error: {0}")]
     ComponentError(#[from] Box<ComponentError>),
-    #[error(transparent)]
+    #[error("connection annotation error: {0}")]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
     #[error("found too many matches for input and socket: {0}, {1}")]
     FoundTooManyForInputSocketId(InputSocketId, ComponentId),

--- a/lib/dal/src/socket/output.rs
+++ b/lib/dal/src/socket/output.rs
@@ -82,7 +82,7 @@ pub enum OutputSocketError {
     AttributeValue(#[from] Box<AttributeValueError>),
     #[error("change set error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error(transparent)]
+    #[error("connection annotation error: {0}")]
     ConnectionAnnotation(#[from] ConnectionAnnotationError),
     #[error("found too many matches for output and socket: {0}, {1}")]
     FoundTooManyForOutputSocketId(OutputSocketId, ComponentId),

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -112,23 +112,23 @@ pub enum WorkspaceError {
     ExportingFromSystemActor,
     #[error("Trying to import a changeset that does not have a valid base: {0}")]
     ImportingOrphanChangeset(ChangeSetId),
-    #[error(transparent)]
+    #[error("key pair error: {0}")]
     KeyPair(#[from] KeyPairError),
     #[error("LayerDb error: {0}")]
     LayerDb(#[from] LayerDbError),
-    #[error(transparent)]
+    #[error("nats error: {0}")]
     Nats(#[from] NatsError),
     #[error("no user in context")]
     NoUserInContext,
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] PgError),
-    #[error(transparent)]
+    #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("si db error: {0}")]
     SiDb(#[from] si_db::Error),
     #[error("strum parse error: {0}")]
     StrumParse(#[from] strum::ParseError),
-    #[error(transparent)]
+    #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
     #[error("unknown snapshot kind {0} for workspace: {1}")]
     UnknownSnapshotKind(String, WorkspacePk),

--- a/lib/dal/src/workspace_integrations.rs
+++ b/lib/dal/src/workspace_integrations.rs
@@ -17,7 +17,7 @@ use crate::{
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum WorkspaceIntegrationsError {
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),

--- a/lib/dal/src/ws_event.rs
+++ b/lib/dal/src/ws_event.rs
@@ -101,7 +101,7 @@ pub enum WsEventError {
     NoWorkspaceInTenancy,
     #[error("number parse string error: {0}")]
     ParseIntError(#[from] ParseIntError),
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] PgError),
     #[error("schema variant error: {0}")]
     SchemaVariant(#[from] SchemaVariantError),

--- a/lib/innit-client/src/lib.rs
+++ b/lib/innit-client/src/lib.rs
@@ -46,9 +46,9 @@ const DEFAULT_ENVIRONMENT: &str = "local";
 pub enum InnitClientError {
     #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
-    #[error(transparent)]
+    #[error("certificate client error: {0}")]
     CertificateClient(#[from] PrivateCertManagerClientError),
-    #[error(transparent)]
+    #[error("config error: {0}")]
     Config(#[from] config::ConfigError),
     #[error("Deserialization error: {0}")]
     Deserialization(serde_json::Error),
@@ -64,7 +64,7 @@ pub enum InnitClientError {
     Request(#[from] reqwest::Error),
     #[error("Serialization error: {0}")]
     Serialization(serde_json::Error),
-    #[error(transparent)]
+    #[error("tls error: {0}")]
     Tls(#[from] si_tls::TlsError),
     #[error("Url parse error: {0}")]
     UrlParse(#[from] url::ParseError),

--- a/lib/innit-server/src/routes.rs
+++ b/lib/innit-server/src/routes.rs
@@ -59,9 +59,9 @@ async fn system_status_route() -> Json<Value> {
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum AppError {
-    #[error(transparent)]
+    #[error("parameter store client error: {0}")]
     ParameterStoreClient(#[from] ParameterStoreClientError),
-    #[error(transparent)]
+    #[error("server error: {0}")]
     Server(#[from] ServerError),
 }
 

--- a/lib/innit-server/src/server.rs
+++ b/lib/innit-server/src/server.rs
@@ -64,17 +64,17 @@ use crate::{
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum ServerError {
-    #[error(transparent)]
+    #[error("certificate client error: {0}")]
     CertificateClient(#[from] PrivateCertManagerClientError),
     #[error("hyper server error")]
     Hyper(#[from] hyper::Error),
     #[error("Parameter Store error: {0}")]
     ParameterStore(#[from] ParameterStoreClientError),
-    #[error(transparent)]
+    #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("failed to setup signal handler")]
     Signal(#[source] io::Error),
-    #[error(transparent)]
+    #[error("tls error: {0}")]
     Tls(#[from] si_tls::TlsError),
 }
 

--- a/lib/innitctl/src/lib.rs
+++ b/lib/innitctl/src/lib.rs
@@ -26,7 +26,7 @@ pub mod config;
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum InnitCtlError {
-    #[error(transparent)]
+    #[error("config error: {0}")]
     Config(#[from] config::ConfigError),
     #[error("handlebars error: {0}")]
     HandlebarsRender(#[from] handlebars::RenderError),

--- a/lib/luminork-server/src/config.rs
+++ b/lib/luminork-server/src/config.rs
@@ -62,15 +62,15 @@ const DEFAULT_AUTH_API_URL: &str = "https://auth-api.systeminit.com";
 pub enum ConfigError {
     #[error("config builder")]
     Builder(#[from] ConfigBuilderError),
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     #[error("error configuring for development")]
     Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
-    #[error(transparent)]
+    #[error("layer cache error: {0}")]
     LayerCache(#[from] LayerDbError),
     #[error("no socket addrs where resolved")]
     NoSocketAddrResolved,
-    #[error(transparent)]
+    #[error("settings error: {0}")]
     Settings(#[from] si_settings::SettingsError),
     #[error("failed to resolve socket addrs")]
     SocketAddrResolve(#[source] std::io::Error),

--- a/lib/luminork-server/src/routes.rs
+++ b/lib/luminork-server/src/routes.rs
@@ -622,11 +622,11 @@ async fn serve_swagger_ui() -> impl IntoResponse {
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum AppError {
-    #[error(transparent)]
+    #[error("nats error: {0}")]
     Nats(#[from] NatsError),
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] PgError),
-    #[error(transparent)]
+    #[error("server error: {0}")]
     Server(#[from] ServerError),
 }
 

--- a/lib/module-index-server/src/config.rs
+++ b/lib/module-index-server/src/config.rs
@@ -35,11 +35,11 @@ use crate::s3::S3Config;
 pub enum ConfigError {
     #[error("config builder")]
     Builder(#[from] ConfigBuilderError),
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     #[error("error configuring for development")]
     Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
-    #[error(transparent)]
+    #[error("settings error: {0}")]
     Settings(#[from] si_settings::SettingsError),
 }
 

--- a/lib/module-index-server/src/routes.rs
+++ b/lib/module-index-server/src/routes.rs
@@ -103,9 +103,9 @@ async fn system_status_route() -> Json<Value> {
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum AppError {
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] PgError),
-    #[error(transparent)]
+    #[error("server error: {0}")]
     Server(#[from] ServerError),
 }
 

--- a/lib/module-index-server/src/server.rs
+++ b/lib/module-index-server/src/server.rs
@@ -100,11 +100,11 @@ pub enum ServerError {
     Hyper(#[from] hyper::Error),
     #[error("jwt public key error: {0}")]
     JwtPublicKey(#[from] JwtPublicSigningKeyError),
-    #[error(transparent)]
+    #[error("pg pool error: {0}")]
     PgPool(#[from] Box<PgPoolError>),
-    #[error(transparent)]
+    #[error("posthog error: {0}")]
     Posthog(#[from] si_posthog::PosthogError),
-    #[error(transparent)]
+    #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("failed to setup signal handler")]
     Signal(#[source] io::Error),

--- a/lib/pinga-server/src/config.rs
+++ b/lib/pinga-server/src/config.rs
@@ -37,13 +37,13 @@ const DEFAULT_CONCURRENCY_LIMIT: usize = 64;
 pub enum ConfigError {
     #[error("config builder")]
     Builder(#[from] ConfigBuilderError),
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     #[error("error configuring for development")]
     Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
-    #[error(transparent)]
+    #[error("layer cache error: {0}")]
     LayerCache(#[from] LayerDbError),
-    #[error(transparent)]
+    #[error("settings error: {0}")]
     Settings(#[from] si_settings::SettingsError),
 }
 

--- a/lib/rebaser-server/src/config.rs
+++ b/lib/rebaser-server/src/config.rs
@@ -47,13 +47,13 @@ const DEFAULT_SNAPSHOT_EVICTION_GRACE_PERIOD: Duration =
 pub enum ConfigError {
     #[error("config builder")]
     Builder(#[from] ConfigBuilderError),
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     #[error("error configuring for development")]
     Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
-    #[error(transparent)]
+    #[error("layer cache error: {0}")]
     LayerCache(#[from] LayerDbError),
-    #[error(transparent)]
+    #[error("settings error: {0}")]
     Settings(#[from] si_settings::SettingsError),
 }
 

--- a/lib/sdf-server/src/config.rs
+++ b/lib/sdf-server/src/config.rs
@@ -62,15 +62,15 @@ const DEFAULT_AUTH_API_URL: &str = "https://auth-api.systeminit.com";
 pub enum ConfigError {
     #[error("config builder")]
     Builder(#[from] ConfigBuilderError),
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     #[error("error configuring for development")]
     Development(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
-    #[error(transparent)]
+    #[error("layer cache error: {0}")]
     LayerCache(#[from] LayerDbError),
     #[error("no socket addrs where resolved")]
     NoSocketAddrResolved,
-    #[error(transparent)]
+    #[error("settings error: {0}")]
     Settings(#[from] si_settings::SettingsError),
     #[error("failed to resolve socket addrs")]
     SocketAddrResolve(#[source] std::io::Error),

--- a/lib/sdf-server/src/service/dev.rs
+++ b/lib/sdf-server/src/service/dev.rs
@@ -17,15 +17,15 @@ use crate::AppState;
 #[derive(Debug, Error)]
 #[allow(clippy::large_enum_variant)]
 pub enum DevError {
-    #[error(transparent)]
+    #[error("builtin error: {0}")]
     Builtin(#[from] dal::BuiltinsError),
-    #[error(transparent)]
+    #[error("func error: {0}")]
     Func(#[from] dal::FuncError),
     #[error("Function not found")]
     FuncNotFound,
-    #[error(transparent)]
+    #[error("nats error: {0}")]
     Nats(#[from] si_data_nats::NatsError),
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] si_data_pg::PgError),
     #[error("si db error: {0}")]
     SiDb(#[from] si_db::Error),

--- a/lib/sdf-server/src/service/v2/action.rs
+++ b/lib/sdf-server/src/service/v2/action.rs
@@ -72,21 +72,21 @@ use crate::{
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum ActionRequestError {
-    #[error(transparent)]
+    #[error("action error: {0}")]
     Action(#[from] dal::action::ActionError),
     #[error("action already enqueued: {0}")]
     ActionAlreadyEnqueued(ActionPrototypeId),
     #[error("action history is missing a field - this is a bug!: {0}")]
     ActionHistoryFieldMissing(String),
-    #[error(transparent)]
+    #[error("action prototype error: {0}")]
     ActionPrototype(#[from] ActionPrototypeError),
     #[error("changeset error: {0}")]
     ChangeSet(#[from] ChangeSetError),
-    #[error(transparent)]
+    #[error("component error: {0}")]
     Component(#[from] ComponentError),
     #[error("component {0} not found")]
     ComponentNotFound(ComponentId),
-    #[error(transparent)]
+    #[error("func error: {0}")]
     Func(#[from] FuncError),
     #[error("Cannot cancel Running or Dispatched actions. ActionId {0}")]
     InvalidActionCancellation(ActionId),

--- a/lib/sdf-server/src/service/v2/view.rs
+++ b/lib/sdf-server/src/service/v2/view.rs
@@ -79,7 +79,7 @@ pub enum ViewError {
     MaterializedView(#[from] Box<dal_materialized_views::Error>),
     #[error("there is already a view called {0}")]
     NameAlreadyInUse(String),
-    #[error(transparent)]
+    #[error("parse int error: {0}")]
     ParseInt(#[from] ParseIntError),
     #[error("paste error")]
     Paste,

--- a/lib/sdf-v1-routes-session/src/lib.rs
+++ b/lib/sdf-v1-routes-session/src/lib.rs
@@ -38,21 +38,21 @@ pub mod restore_authentication;
 pub enum SessionError {
     #[error("auth api error: {0}")]
     AuthApiError(String),
-    #[error(transparent)]
+    #[error("context transactions error: {0}")]
     ContextTransactions(#[from] TransactionsError),
     #[error("ulid decode error: {0}")]
     Decode(#[from] ulid::DecodeError),
     #[error("json serialize failed")]
     JSONSerialize(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("key pair error: {0}")]
     KeyPair(#[from] KeyPairError),
     #[error("login failed")]
     LoginFailed,
-    #[error(transparent)]
+    #[error("nats error: {0}")]
     Nats(#[from] si_data_nats::NatsError),
     #[error("Permissions error: {0}")]
     Permissions(#[from] permissions::Error),
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] si_data_pg::PgError),
     #[error("http error: {0}")]
     Request(#[from] reqwest::Error),
@@ -60,9 +60,9 @@ pub enum SessionError {
     SiDb(#[from] si_db::Error),
     #[error("SpiceDb error: {0}")]
     SpiceDb(#[from] SpiceDbError),
-    #[error(transparent)]
+    #[error("workspace error: {0}")]
     Workspace(#[from] WorkspaceError),
-    #[error(transparent)]
+    #[error("workspace integration error: {0}")]
     WorkspaceIntegration(#[from] WorkspaceIntegrationsError),
     #[error("workspace {0} not yet migrated to new snapshot graph version. Migration required")]
     WorkspaceNotYetMigrated(WorkspacePk),

--- a/lib/si-crypto/src/symmetric.rs
+++ b/lib/si-crypto/src/symmetric.rs
@@ -35,7 +35,7 @@ pub enum SymmetricCryptoError {
     #[error("failed to decode base64 encoded key")]
     Base64Decode(#[source] base64::DecodeError),
     /// When a file fails to be canonicalized
-    #[error(transparent)]
+    #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
     /// When a cipertext fails to decrypt
     #[error("error when decrypting ciphertext")]

--- a/lib/si-data-pg/src/lib.rs
+++ b/lib/si-data-pg/src/lib.rs
@@ -114,7 +114,7 @@ const CONNECTION_RECYCLING_METHOD: &str = r#"
 #[remain::sorted]
 #[derive(thiserror::Error, Debug)]
 pub enum PgError {
-    #[error(transparent)]
+    #[error("pg error: {0}")]
     Pg(#[from] tokio_postgres::Error),
     #[error("transaction not exclusively referenced when commit attempted; arc_strong_count={0}")]
     TxnCommitNotExclusive(usize),

--- a/lib/si-pkg/src/pkg.rs
+++ b/lib/si-pkg/src/pkg.rs
@@ -90,11 +90,11 @@ use crate::{
 pub enum SiPkgError {
     #[error("component pkg node {0} missing position child")]
     ComponentMissingPosition(String),
-    #[error(transparent)]
+    #[error("graph error: {0}")]
     Graph(#[from] GraphError),
-    #[error(transparent)]
+    #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error(transparent)]
+    #[error("memory error: {0}")]
     Memory(#[from] TarWriterError),
     #[error("node not found with hash={0}")]
     NodeWithHashNotFound(Hash),
@@ -108,11 +108,11 @@ pub enum SiPkgError {
     PropTreeInvalid(String),
     #[error("Schema Variant missing required child: {0}")]
     SchemaVariantChildNotFound(&'static str),
-    #[error(transparent)]
+    #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
+    #[error("spec error: {0}")]
     Spec(#[from] SpecError),
-    #[error(transparent)]
+    #[error("tar read error: {0}")]
     TarRead(#[from] TarReadError),
     #[error("unexpected pkg node type; expected={0}, actual={1}")]
     UnexpectedPkgNodeType(&'static str, &'static str),

--- a/lib/si-pkg/src/spec.rs
+++ b/lib/si-pkg/src/spec.rs
@@ -165,7 +165,7 @@ impl TryFrom<PkgSpecBuilder> for PkgSpec {
 pub enum SpecError {
     #[error("Can't convert {0} to LeafInputLocation")]
     LeafInputLocationConversionError(String),
-    #[error(transparent)]
+    #[error("serde json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     /// Uninitialized field
     #[error("{0} must be initialized")]

--- a/lib/si-pool-noodle/src/instance/cyclone/local_http.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_http.rs
@@ -76,16 +76,16 @@ use crate::instance::{
 #[derive(Debug, Error)]
 pub enum LocalHttpInstanceError {
     /// Spec builder error.
-    #[error(transparent)]
+    #[error("builder error: {0}")]
     Builder(#[from] LocalHttpInstanceSpecBuilderError),
     /// Error when waiting for child process to shutdown.
-    #[error(transparent)]
+    #[error("child shutdown error: {0}")]
     ChildShutdown(#[from] ShutdownError),
     /// Failed to spawn a child process.
     #[error("failed to spawn cyclone child process")]
     ChildSpawn(#[source] io::Error),
     /// Cyclone client error.
-    #[error(transparent)]
+    #[error("client error: {0}")]
     Client(#[from] ClientError),
     /// Instance has exhausted its predefined request count.
     #[error("no remaining requests, cyclone server is considered unhealthy")]
@@ -94,7 +94,7 @@ pub enum LocalHttpInstanceError {
     #[error("error when binding local socket")]
     SocketBind(#[source] io::Error),
     /// Cyclone client `watch` endpoint error.
-    #[error(transparent)]
+    #[error("watch error: {0}")]
     Watch(#[from] WatchError),
     /// Cyclone client `watch` session ended earlier than expected.
     #[error("server closed watch session before expected")]

--- a/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
+++ b/lib/si-pool-noodle/src/instance/cyclone/local_uds.rs
@@ -100,16 +100,16 @@ use crate::instance::{
 #[derive(Debug, Error)]
 pub enum LocalUdsInstanceError {
     /// Spec builder error.
-    #[error(transparent)]
+    #[error("builder error: {0}")]
     Builder(#[from] LocalUdsInstanceSpecBuilderError),
     /// Error when waiting for child process to shutdown.
-    #[error(transparent)]
+    #[error("child shutdown error: {0}")]
     ChildShutdown(#[from] ShutdownError),
     /// Failed to spawn a child process.
     #[error("failed to spawn cyclone child process: {0}")]
     ChildSpawn(#[source] io::Error),
     /// Cyclone client error.
-    #[error(transparent)]
+    #[error("client error: {0}")]
     Client(#[from] Box<ClientError>),
     /// Failed to build a container.
     #[error("failed to build a cyclone container: {0}")]
@@ -118,14 +118,14 @@ pub enum LocalUdsInstanceError {
     #[error("failed to spawn cyclone container: {0}")]
     ContainerRun(#[source] Error),
     /// Error when shutting down a container.
-    #[error(transparent)]
+    #[error("container shutdown error: {0}")]
     ContainerShutdown(#[from] Error),
     /// Docker api not found
     #[error("no docker api")]
     DockerAPINotFound,
     #[cfg(target_os = "linux")]
     /// Failed to firecracker jail.
-    #[error("failed in working with a jail: {0}")]
+    #[error("firecracker error: {0}")]
     Firecracker(#[from] FirecrackerJailError),
     /// Failed to create firecracker-setup file.
     #[error("failed to create firecracker-setup file: {0}")]
@@ -149,7 +149,7 @@ pub enum LocalUdsInstanceError {
     #[error("failed to create temp socket: {0}")]
     TempSocket(#[source] io::Error),
     /// Cyclone client `watch` endpoint error.
-    #[error(transparent)]
+    #[error("watch error: {0}")]
     Watch(#[from] Box<WatchError>),
     /// Cyclone client `watch` session ended earlier than expected.
     #[error("server closed watch session before expected")]

--- a/lib/si-settings/src/lib.rs
+++ b/lib/si-settings/src/lib.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 #[remain::sorted]
 #[derive(Error, Debug)]
 pub enum SettingsError {
-    #[error(transparent)]
+    #[error("config file error: {0}")]
     ConfigFile(#[from] config_file::ConfigFileError),
 }
 

--- a/lib/si-std/src/canonical_file.rs
+++ b/lib/si-std/src/canonical_file.rs
@@ -29,7 +29,7 @@ pub enum CanonicalFileError {
     #[error("no file_name after canonicalized join: {0}")]
     NoFileNameAfterJoin(String),
     // needed only for the test
-    #[error(transparent)]
+    #[error("var error: {0}")]
     VarError(#[from] std::env::VarError),
 }
 

--- a/lib/telemetry-application-rs/src/lib.rs
+++ b/lib/telemetry-application-rs/src/lib.rs
@@ -155,7 +155,7 @@ const DEFAULT_NEVER_MODULES: &[&str] = &["h2", "hyper"];
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error(transparent)]
+    #[error("directives parse error: {0}")]
     DirectivesParse(#[from] ParseError),
     #[error("file appender error: {0}")]
     FileAppender(#[from] logroller::LogRollerError),
@@ -165,11 +165,11 @@ pub enum Error {
     Signal(#[source] io::Error),
     #[error("failed to parse span event fmt token: {0}")]
     SpanEventParse(String),
-    #[error(transparent)]
+    #[error("trace error: {0}")]
     Trace(#[from] TraceError),
-    #[error(transparent)]
+    #[error("try init error: {0}")]
     TryInit(#[from] TryInitError),
-    #[error(transparent)]
+    #[error("update error: {0}")]
     Update(#[from] reload::Error),
 }
 

--- a/lib/veritech-client/src/lib.rs
+++ b/lib/veritech-client/src/lib.rs
@@ -76,7 +76,7 @@ pub enum ClientError {
     Subscriber(#[from] SubscriberError),
     #[error("tokio join error: {0}")]
     TokioJoinError(#[from] tokio::task::JoinError),
-    #[error(transparent)]
+    #[error("transport error: {0}")]
     Transport(Box<dyn std::error::Error + Sync + Send + 'static>),
 }
 

--- a/lib/veritech-server/src/config.rs
+++ b/lib/veritech-server/src/config.rs
@@ -58,7 +58,7 @@ const DEFAULT_HEARTBEAT_APP_PUBLISH_TIMEOUT_DURATION: Duration =
 #[remain::sorted]
 #[derive(Debug, Error)]
 pub enum ConfigError {
-    #[error(transparent)]
+    #[error("builder error: {0}")]
     Builder(#[from] ConfigBuilderError),
     #[error("canonical file error: {0}")]
     CanonicalFile(#[from] CanonicalFileError),
@@ -66,7 +66,7 @@ pub enum ConfigError {
     CycloneSpecBuild(#[source] Box<dyn std::error::Error + 'static + Sync + Send>),
     #[error("no socket addrs where resolved")]
     NoSocketAddrResolved,
-    #[error(transparent)]
+    #[error("settings error: {0}")]
     Settings(#[from] si_settings::SettingsError),
     #[error("failed to resolve socket addrs")]
     SocketAddrResolve(#[source] std::io::Error),


### PR DESCRIPTION
This change fixes an old mistake (made by this author) where the use of `transparent` was mis-understood. The `transparent` usage wouldn't add an error message and makes it harder to track error chains.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMXRsazZkamNqdXh5ZGRmYzA3YnYyYmd1bTh0cXdqM24wOTJ3MDZ4ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/RUsnFjfcsYHHor35Dw/giphy.gif"/>