### PR TITLE
fix(web): Rename Manage Workspace Tokens to Manage API Tokens

### DIFF
--- a/app/web/src/newhotness/nav/WorkspaceSettingsMenuItems.vue
+++ b/app/web/src/newhotness/nav/WorkspaceSettingsMenuItems.vue
@@ -17,7 +17,7 @@
   />
   <DropdownMenuItem
     icon="settings"
-    label="Manage Workspace Tokens"
+    label="Manage API Tokens"
     @select="openWorkspaceApiTokensHandler"
   />
   <DropdownMenuItem


### PR DESCRIPTION
<img width="263" height="285" alt="Screenshot 2025-10-11 at 00 11 35" src="https://github.com/user-attachments/assets/f2305db7-bead-4628-b00f-a44005927144" />
