### PR TITLE
chore: regenerate sdk and api docs

### DIFF
--- a/app/docs/src/reference/public-api.md
+++ b/app/docs/src/reference/public-api.md
@@ -1649,6 +1649,32 @@ Schemas management endpoints
 ```json
 {
   "schemaId": "01H9ZQD35JPMBGHH69BT0Q79VZ",
+  "unlockedVariant": {
+    "assetFuncId": "01H9ZQD35JPMBGHH69BT0Q75XY",
+    "category": "AWS::EC2",
+    "color": "#FF5733",
+    "description": "Amazon EC2 Instance resource type",
+    "displayName": "AWS EC2 Instance",
+    "domainProps": {},
+    "installedFromUpstream": false,
+    "isDefaultVariant": true,
+    "isLocked": false,
+    "link": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html",
+    "variantFuncIds": [
+      "01H9ZQD35JPMBGHH69BT0Q75AA",
+      "01H9ZQD35JPMBGHH69BT0Q75BB"
+    ],
+    "variantFuncs": [
+      {
+        "funcKind": {
+          "actionKind": "Create",
+          "kind": "action"
+        },
+        "id": "01H9ZQD35JPMBGHH69BT0Q79VZ"
+      }
+    ],
+    "variantId": "01H9ZQD35JPMBGHH69BT0Q79VZ"
+  },
   "unlockedVariantId": "01H9ZQD35JPMBGHH69BT0Q75XY"
 }
 ```
@@ -5958,6 +5984,32 @@ xor
 ```json
 {
   "schemaId": "01H9ZQD35JPMBGHH69BT0Q79VZ",
+  "unlockedVariant": {
+    "assetFuncId": "01H9ZQD35JPMBGHH69BT0Q75XY",
+    "category": "AWS::EC2",
+    "color": "#FF5733",
+    "description": "Amazon EC2 Instance resource type",
+    "displayName": "AWS EC2 Instance",
+    "domainProps": {},
+    "installedFromUpstream": false,
+    "isDefaultVariant": true,
+    "isLocked": false,
+    "link": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html",
+    "variantFuncIds": [
+      "01H9ZQD35JPMBGHH69BT0Q75AA",
+      "01H9ZQD35JPMBGHH69BT0Q75BB"
+    ],
+    "variantFuncs": [
+      {
+        "funcKind": {
+          "actionKind": "Create",
+          "kind": "action"
+        },
+        "id": "01H9ZQD35JPMBGHH69BT0Q79VZ"
+      }
+    ],
+    "variantId": "01H9ZQD35JPMBGHH69BT0Q79VZ"
+  },
   "unlockedVariantId": "01H9ZQD35JPMBGHH69BT0Q75XY"
 }
 
@@ -5968,6 +6020,7 @@ xor
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |schemaId|string|true|none|none|
+|unlockedVariant|[GetSchemaVariantV1Response](#schemagetschemavariantv1response)|true|none|none|
 |unlockedVariantId|string|true|none|none|
 
 ## [UpdateComponentV1Request](#tocS_UpdateComponentV1Request)

--- a/generated-sdks/python/system_initiative_api_client/models/unlocked_schema_v1_response.py
+++ b/generated-sdks/python/system_initiative_api_client/models/unlocked_schema_v1_response.py
@@ -19,6 +19,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List
+from system_initiative_api_client.models.get_schema_variant_v1_response import GetSchemaVariantV1Response
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -27,8 +28,9 @@ class UnlockedSchemaV1Response(BaseModel):
     UnlockedSchemaV1Response
     """ # noqa: E501
     schema_id: StrictStr = Field(alias="schemaId")
+    unlocked_variant: GetSchemaVariantV1Response = Field(alias="unlockedVariant")
     unlocked_variant_id: StrictStr = Field(alias="unlockedVariantId")
-    __properties: ClassVar[List[str]] = ["schemaId", "unlockedVariantId"]
+    __properties: ClassVar[List[str]] = ["schemaId", "unlockedVariant", "unlockedVariantId"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -69,6 +71,9 @@ class UnlockedSchemaV1Response(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of unlocked_variant
+        if self.unlocked_variant:
+            _dict['unlockedVariant'] = self.unlocked_variant.to_dict()
         return _dict
 
     @classmethod
@@ -82,6 +87,7 @@ class UnlockedSchemaV1Response(BaseModel):
 
         _obj = cls.model_validate({
             "schemaId": obj.get("schemaId"),
+            "unlockedVariant": GetSchemaVariantV1Response.from_dict(obj["unlockedVariant"]) if obj.get("unlockedVariant") is not None else None,
             "unlockedVariantId": obj.get("unlockedVariantId")
         })
         return _obj

--- a/generated-sdks/python/test/test_unlocked_schema_v1_response.py
+++ b/generated-sdks/python/test/test_unlocked_schema_v1_response.py
@@ -36,11 +36,85 @@ class TestUnlockedSchemaV1Response(unittest.TestCase):
         if include_optional:
             return UnlockedSchemaV1Response(
                 schema_id = '01H9ZQD35JPMBGHH69BT0Q79VZ',
+                unlocked_variant = system_initiative_api_client.models.get_schema_variant_v1_response.GetSchemaVariantV1Response(
+                    asset_func_id = '01H9ZQD35JPMBGHH69BT0Q75XY', 
+                    category = 'AWS::EC2', 
+                    color = '#FF5733', 
+                    description = 'Amazon EC2 Instance resource type', 
+                    display_name = 'AWS EC2 Instance', 
+                    domain_props = system_initiative_api_client.models.prop_schema_v1.PropSchemaV1(
+                        children = [
+                            system_initiative_api_client.models.prop_schema_v1.PropSchemaV1(
+                                default_value = null, 
+                                description = '', 
+                                doc_link = '', 
+                                hidden = True, 
+                                name = '', 
+                                prop_id = '', 
+                                prop_type = '', 
+                                validation_format = '', )
+                            ], 
+                        default_value = null, 
+                        description = '', 
+                        doc_link = '', 
+                        hidden = True, 
+                        name = '', 
+                        prop_id = '', 
+                        prop_type = '', 
+                        validation_format = '', ), 
+                    installed_from_upstream = False, 
+                    is_default_variant = True, 
+                    is_locked = False, 
+                    link = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html', 
+                    variant_func_ids = [01H9ZQD35JPMBGHH69BT0Q75AA, 01H9ZQD35JPMBGHH69BT0Q75BB], 
+                    variant_funcs = [
+                        system_initiative_api_client.models.schema_variant_func.SchemaVariantFunc(
+                            func_kind = null, 
+                            id = '01H9ZQD35JPMBGHH69BT0Q79VZ', )
+                        ], 
+                    variant_id = '01H9ZQD35JPMBGHH69BT0Q79VZ', ),
                 unlocked_variant_id = '01H9ZQD35JPMBGHH69BT0Q75XY'
             )
         else:
             return UnlockedSchemaV1Response(
                 schema_id = '01H9ZQD35JPMBGHH69BT0Q79VZ',
+                unlocked_variant = system_initiative_api_client.models.get_schema_variant_v1_response.GetSchemaVariantV1Response(
+                    asset_func_id = '01H9ZQD35JPMBGHH69BT0Q75XY', 
+                    category = 'AWS::EC2', 
+                    color = '#FF5733', 
+                    description = 'Amazon EC2 Instance resource type', 
+                    display_name = 'AWS EC2 Instance', 
+                    domain_props = system_initiative_api_client.models.prop_schema_v1.PropSchemaV1(
+                        children = [
+                            system_initiative_api_client.models.prop_schema_v1.PropSchemaV1(
+                                default_value = null, 
+                                description = '', 
+                                doc_link = '', 
+                                hidden = True, 
+                                name = '', 
+                                prop_id = '', 
+                                prop_type = '', 
+                                validation_format = '', )
+                            ], 
+                        default_value = null, 
+                        description = '', 
+                        doc_link = '', 
+                        hidden = True, 
+                        name = '', 
+                        prop_id = '', 
+                        prop_type = '', 
+                        validation_format = '', ), 
+                    installed_from_upstream = False, 
+                    is_default_variant = True, 
+                    is_locked = False, 
+                    link = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html', 
+                    variant_func_ids = [01H9ZQD35JPMBGHH69BT0Q75AA, 01H9ZQD35JPMBGHH69BT0Q75BB], 
+                    variant_funcs = [
+                        system_initiative_api_client.models.schema_variant_func.SchemaVariantFunc(
+                            func_kind = null, 
+                            id = '01H9ZQD35JPMBGHH69BT0Q79VZ', )
+                        ], 
+                    variant_id = '01H9ZQD35JPMBGHH69BT0Q79VZ', ),
                 unlocked_variant_id = '01H9ZQD35JPMBGHH69BT0Q75XY',
         )
         """

--- a/generated-sdks/typescript/api.ts
+++ b/generated-sdks/typescript/api.ts
@@ -2587,6 +2587,12 @@ export interface UnlockedSchemaV1Response {
     'schemaId': string;
     /**
      * 
+     * @type {GetSchemaVariantV1Response}
+     * @memberof UnlockedSchemaV1Response
+     */
+    'unlockedVariant': GetSchemaVariantV1Response;
+    /**
+     * 
      * @type {string}
      * @memberof UnlockedSchemaV1Response
      */


### PR DESCRIPTION
Re-generates SDK and API docs after:

- https://github.com/systeminit/si/pull/7509

## In short: [:link:](https://giphy.com/)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdldXVia2F3ZnhpNndlaHk2cmR2N29wajlpYmR0Z3l0aWFmZ3Q2OXEwYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/gF8jhb7lTPGzqzfZ0h/giphy.gif"/>
