### PR TITLE
fix(web): Fix an issue where pinning a component wasn't working

### DIFF
--- a/app/web/src/newhotness/ComponentContextMenu.vue
+++ b/app/web/src/newhotness/ComponentContextMenu.vue
@@ -295,7 +295,9 @@ const rightClickMenuItems = computed(() => {
       label: "Pin",
       shortcut: "P",
       icon: "pin",
-      onSelect: () => emit("pin", componentId),
+      onSelect: () => {
+        emit("pin", componentId);
+      },
     });
   }
 


### PR DESCRIPTION
Pinning a component wasn't working - the pinned state would immediately reset back to 'default' mode after clicking "Pin" on a component.

A race condition existed between two watchers that both tried to update the URL query parameters:

  1. gridMode watcher - When pinning, it would:
    - Set gridMode to 'pinned'
    - Call clearSelection()
    - Push route with pinned query parameter
  2. selectedComponentIndexes watcher - Would trigger when clearSelection() was called and:
    - Spread the current route query
    - Push its own route update
    - Overwrite/remove the pinned parameter

  This caused the route to update without the pinned parameter, triggering setSelectionsFromQuery() to reset gridMode back to 'default'.


 Added an early return in the selectedComponentIndexes watcher (lines 1867-1870) to prevent it from pushing a competing route update when  selections are cleared during pinning:

This ensures that when entering pinned mode, only the gridMode watcher updates the route, eliminating the race condition.