### PR TITLE
refactor(clover): allow providers to pass in domain and resource_value

### DIFF
--- a/bin/clover/src/pipelines/aws/pipeline.ts
+++ b/bin/clover/src/pipelines/aws/pipeline.ts
@@ -1,5 +1,4 @@
 import { loadCfDatabase } from "../../cfDb.ts";
-import { pkgSpecFromCf } from "./spec.ts";
 import { awsProviderConfig } from "./provider.ts";
 import { generateDefaultFuncsFromConfig } from "../generic/index.ts";
 import { addDefaultPropsAndSockets } from "./pipeline-steps/addDefaultPropsAndSockets.ts";
@@ -34,19 +33,7 @@ export async function generateAwsSpecs(options: {
   const existing_specs = await getExistingSpecs(options);
   const inferred = await loadInferred(options.inferred);
 
-  const cfSchemas = Object.values(db);
-
-  let specs = [] as ExpandedPkgSpec[];
-
-  for (const cfSchema of cfSchemas) {
-    try {
-      const pkg = pkgSpecFromCf(cfSchema);
-
-      specs.push(pkg);
-    } catch (e) {
-      console.log(`Error Building: ${cfSchema.typeName}: ${e}`);
-    }
-  }
+  let specs = awsProviderConfig.parseRawSchema(db);
 
   // EXECUTE PIPELINE STEPS
 

--- a/bin/clover/src/pipelines/aws/provider.ts
+++ b/bin/clover/src/pipelines/aws/provider.ts
@@ -1,6 +1,5 @@
 import { normalizeProperty } from "../../cfDb.ts";
-import { normalizeOnlyProperties } from "../generic/index.ts";
-import { ExpandedPropSpecFor, OnlyProperties } from "../../spec/props.ts";
+import { ExpandedPropSpecFor } from "../../spec/props.ts";
 import {
   CfProperty,
   PipelineOptions,
@@ -20,6 +19,7 @@ import {
 } from "./funcs.ts";
 import type { CfSchema } from "./schema.ts";
 import { generateAwsSpecs } from "./pipeline.ts";
+import { parseSchema } from "./spec.ts";
 
 function cfCategory(schema: CfSchema): string {
   const [metaCategory, category] = schema.typeName.split("::");
@@ -71,16 +71,6 @@ function awsIsChildRequired(
   return true;
 }
 
-function awsClassifyProperties(schema: SuperSchema): OnlyProperties {
-  const cfSchema = schema as CfSchema;
-  return {
-    createOnly: normalizeOnlyProperties(cfSchema.createOnlyProperties),
-    readOnly: normalizeOnlyProperties(cfSchema.readOnlyProperties),
-    writeOnly: normalizeOnlyProperties(cfSchema.writeOnlyProperties),
-    primaryIdentifier: normalizeOnlyProperties(cfSchema.primaryIdentifier),
-  };
-}
-
 async function awsLoadSchemas(options: PipelineOptions) {
   return await generateAwsSpecs(options);
 }
@@ -117,7 +107,7 @@ export const awsProviderConfig: ProviderConfig = {
   functions: awsProviderFunctions,
   funcSpecs: awsProviderFuncSpecs,
   loadSchemas: awsLoadSchemas,
-  classifyProperties: awsClassifyProperties,
+  parseRawSchema: parseSchema,
   fetchSchema: awsFetchSchema,
   metadata: {
     color: "#FF9900",

--- a/bin/clover/src/pipelines/aws/spec.ts
+++ b/bin/clover/src/pipelines/aws/spec.ts
@@ -1,7 +1,91 @@
 import { ExpandedPkgSpec } from "../../spec/pkgs.ts";
-import { makeModule } from "../generic/index.ts";
+import { OnlyProperties } from "../../spec/props.ts";
+import { makeModule, normalizeOnlyProperties } from "../generic/index.ts";
+import { CfProperty } from "../types.ts";
 import { awsProviderConfig } from "./provider.ts";
-import type { CfSchema } from "./schema.ts";
+import type { CfDb, CfSchema } from "./schema.ts";
+
+function pruneProperties(
+  properties: Record<string, CfProperty>,
+  onlyProperties: OnlyProperties,
+  keepReadOnly: boolean,
+  pathPrefix: string = "",
+): Record<string, CfProperty> {
+  const readOnlySet = new Set(onlyProperties.readOnly);
+  const result: Record<string, CfProperty> = {};
+
+  for (const [name, prop] of Object.entries(properties)) {
+    if (!prop) continue;
+
+    const cfProp = prop as CfProperty;
+    const currentPath = pathPrefix ? `${pathPrefix}/${name}` : name;
+    // Check both the simple name and the full path to handle both normalized and non-normalized readOnly lists
+    const isReadOnly = readOnlySet.has(name) || readOnlySet.has(currentPath);
+    const shouldKeep = keepReadOnly ? isReadOnly : !isReadOnly;
+
+    // Check if this is an object with nested properties
+    if (
+      typeof cfProp === "object" && cfProp !== null && "properties" in cfProp &&
+      cfProp.properties
+    ) {
+      const prunedChildren = pruneProperties(
+        cfProp.properties as Record<string, CfProperty>,
+        onlyProperties,
+        keepReadOnly,
+        currentPath,
+      );
+
+      // Only include if this object has matching children
+      // Never include empty objects - they are pruned entirely
+      if (Object.keys(prunedChildren).length > 0) {
+        result[name] = { ...cfProp, properties: prunedChildren };
+      }
+    } else if (shouldKeep) {
+      result[name] = cfProp;
+    }
+  }
+
+  return result;
+}
+
+function cleanProperties(
+  properties: Record<string, CfProperty>,
+): Record<string, CfProperty> {
+  const cleaned: Record<string, CfProperty> = {};
+  for (const [name, prop] of Object.entries(properties)) {
+    const cfProp = prop as CfProperty;
+    if (cfProp.type || cfProp.oneOf || cfProp.anyOf) {
+      cleaned[name] = cfProp;
+    }
+  }
+  return cleaned;
+}
+
+function splitAwsProperties(
+  schema: CfSchema,
+  onlyProperties: OnlyProperties,
+): {
+  domainProperties: Record<string, CfProperty>;
+  resourceValueProperties: Record<string, CfProperty>;
+} {
+  const domainProperties = cleanProperties(
+    pruneProperties(
+      schema.properties as Record<string, CfProperty>,
+      onlyProperties,
+      false, // keep writable properties
+    ),
+  );
+
+  const resourceValueProperties = cleanProperties(
+    pruneProperties(
+      schema.properties as Record<string, CfProperty>,
+      onlyProperties,
+      true, // keep readOnly properties
+    ),
+  );
+
+  return { domainProperties, resourceValueProperties };
+}
 
 export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
   const [metaCategory, category, name] = cfSchema.typeName.split("::");
@@ -10,12 +94,68 @@ export function pkgSpecFromCf(cfSchema: CfSchema): ExpandedPkgSpec {
     throw `Bad typeName: ${cfSchema.typeName}`;
   }
 
-  const onlyProperties = awsProviderConfig.classifyProperties(cfSchema);
+  const onlyProperties: OnlyProperties = {
+    createOnly: normalizeOnlyProperties(cfSchema.createOnlyProperties),
+    readOnly: normalizeOnlyProperties(cfSchema.readOnlyProperties),
+    writeOnly: normalizeOnlyProperties(cfSchema.writeOnlyProperties),
+    primaryIdentifier: normalizeOnlyProperties(cfSchema.primaryIdentifier),
+  };
+
+  const { domainProperties, resourceValueProperties } = splitAwsProperties(
+    cfSchema,
+    onlyProperties,
+  );
 
   return makeModule(
     cfSchema,
     cfSchema.description,
     onlyProperties,
     awsProviderConfig,
+    domainProperties,
+    resourceValueProperties,
   );
+}
+
+export function parseSchema(rawSchema: unknown): ExpandedPkgSpec[] {
+  const cfDb = rawSchema as CfDb;
+  const specs: ExpandedPkgSpec[] = [];
+
+  for (const cfSchema of Object.values(cfDb)) {
+    const [metaCategory, category, name] = cfSchema.typeName.split("::");
+
+    if (!["AWS", "Alexa"].includes(metaCategory) || !category || !name) {
+      console.log(`Skipping invalid typeName: ${cfSchema.typeName}`);
+      continue;
+    }
+
+    const onlyProperties: OnlyProperties = {
+      createOnly: normalizeOnlyProperties(cfSchema.createOnlyProperties),
+      readOnly: normalizeOnlyProperties(cfSchema.readOnlyProperties),
+      writeOnly: normalizeOnlyProperties(cfSchema.writeOnlyProperties),
+      primaryIdentifier: normalizeOnlyProperties(cfSchema.primaryIdentifier),
+    };
+
+    const { domainProperties, resourceValueProperties } = splitAwsProperties(
+      cfSchema,
+      onlyProperties,
+    );
+
+    try {
+      const spec = makeModule(
+        cfSchema,
+        cfSchema.description,
+        onlyProperties,
+        awsProviderConfig,
+        domainProperties,
+        resourceValueProperties,
+      );
+
+      specs.push(spec);
+    } catch (error) {
+      console.log(`Error processing ${cfSchema.typeName}: ${error}`);
+      continue;
+    }
+  }
+
+  return specs;
 }

--- a/bin/clover/src/pipelines/azure/pipeline.ts
+++ b/bin/clover/src/pipelines/azure/pipeline.ts
@@ -1,10 +1,7 @@
 import { ExpandedPkgSpec } from "../../spec/pkgs.ts";
 import { PipelineOptions } from "../types.ts";
 import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
-import {
-  generateDefaultFuncsFromConfig,
-  generateSpecsFromRawSchema,
-} from "../generic/index.ts";
+import { generateDefaultFuncsFromConfig } from "../generic/index.ts";
 import { getExistingSpecs } from "../../specUpdates.ts";
 import { generateIntrinsicFuncs } from "../generic/generateIntrinsicFuncs.ts";
 import { createSuggestionsForPrimaryIdentifiers } from "../generic/createSuggestionsAcrossAssets.ts";
@@ -31,7 +28,7 @@ export async function generateAzureSpecs(
       const filePath = join(schemasDir, entry.name);
       const rawSchema = JSON.parse(await Deno.readTextFile(filePath));
 
-      const serviceSpecs = generateSpecsFromRawSchema(rawSchema, azureConfig);
+      const serviceSpecs = azureConfig.parseRawSchema(rawSchema);
       specs.push(...serviceSpecs);
     }
   } catch (error) {

--- a/bin/clover/src/pipelines/azure/provider.ts
+++ b/bin/clover/src/pipelines/azure/provider.ts
@@ -6,7 +6,7 @@ import {
   ProviderConfig,
   SuperSchema,
 } from "../types.ts";
-import { ExpandedPropSpecFor, OnlyProperties } from "../../spec/props.ts";
+import { ExpandedPropSpecFor } from "../../spec/props.ts";
 import { type JsonSchema } from "./schema.ts";
 import {
   cleanupRepo,
@@ -23,7 +23,6 @@ import {
 } from "./funcs.ts";
 import { normalizeAzureProperty, parseAzureSchema } from "./spec.ts";
 import { generateAzureSpecs } from "./pipeline.ts";
-import { normalizeOnlyProperties } from "../generic/index.ts";
 
 async function azureFetchSchema() {
   let repoPath: string | null = null;
@@ -102,25 +101,6 @@ function azureNormalizeProperty(
   return normalizeAzureProperty(propToNormalize as JsonSchema) as CfProperty;
 }
 
-function azureClassifyProperties(schema: SuperSchema): OnlyProperties {
-  const inferredOnlyProperties = (schema as any)._inferredOnlyProperties as
-    | OnlyProperties
-    | undefined;
-
-  if (!inferredOnlyProperties) {
-    throw new Error("Expected Azure schema to have _inferredOnlyProperties");
-  }
-
-  return {
-    createOnly: normalizeOnlyProperties(inferredOnlyProperties.createOnly),
-    readOnly: inferredOnlyProperties.readOnly,
-    writeOnly: normalizeOnlyProperties(inferredOnlyProperties.writeOnly),
-    primaryIdentifier: normalizeOnlyProperties(
-      inferredOnlyProperties.primaryIdentifier,
-    ),
-  };
-}
-
 async function azureLoadSchemas(
   options: PipelineOptions,
 ) {
@@ -142,7 +122,6 @@ export const azureProviderConfig: ProviderConfig = {
   },
   loadSchemas: azureLoadSchemas,
   parseRawSchema: parseAzureSchema,
-  classifyProperties: azureClassifyProperties,
   normalizeProperty: azureNormalizeProperty,
   isChildRequired: azureIsChildRequired,
   overrides: {

--- a/bin/clover/src/pipelines/dummy/pipeline.ts
+++ b/bin/clover/src/pipelines/dummy/pipeline.ts
@@ -5,10 +5,7 @@ import { createSuggestionsForPrimaryIdentifiers } from "../generic/createSuggest
 import { reorderProps } from "../generic/reorderProps.ts";
 import { updateSchemaIdsForExistingSpecs } from "../generic/updateSchemaIdsForExistingSpecs.ts";
 import { generateAssetFuncs } from "../generic/generateAssetFuncs.ts";
-import {
-  generateDefaultFuncsFromConfig,
-  generateSpecsFromRawSchema,
-} from "../generic/index.ts";
+import { generateDefaultFuncsFromConfig } from "../generic/index.ts";
 import { applyAssetOverrides } from "../generic/applyAssetOverrides.ts";
 import { dummyProviderConfig } from "./provider.ts";
 
@@ -23,19 +20,12 @@ export async function generateDummySpecs(options: {
 
   const existing_specs = await getExistingSpecs(options);
 
-  // Generate base specs from dummy schemas using the new generic helper
-  // Pass null as rawSchema since dummy uses parseRawSchema to return hardcoded schemas
-  specs = generateSpecsFromRawSchema(null, dummyProviderConfig);
+  specs = dummyProviderConfig.parseRawSchema({});
 
-  // Run through standard pipeline steps
   specs = generateIntrinsicFuncs(specs);
   specs = createSuggestionsForPrimaryIdentifiers(specs);
-
   specs = generateDefaultFuncsFromConfig(specs, dummyProviderConfig);
-
-  // Apply provider-specific overrides
   specs = applyAssetOverrides(specs, dummyProviderConfig);
-
   specs = reorderProps(specs);
   specs = generateAssetFuncs(specs);
   specs = updateSchemaIdsForExistingSpecs(existing_specs, specs);

--- a/bin/clover/src/pipelines/dummy/spec.ts
+++ b/bin/clover/src/pipelines/dummy/spec.ts
@@ -1,8 +1,31 @@
 import { ExpandedPkgSpec } from "../../spec/pkgs.ts";
 import { OnlyProperties } from "../../spec/props.ts";
 import { makeModule } from "../generic/index.ts";
+import { CfProperty, SuperSchema } from "../types.ts";
 import { dummyProviderConfig } from "./provider.ts";
 import { databaseSchema, serverSchema } from "./schema.ts";
+
+function splitDummyProperties(
+  schema: SuperSchema,
+  onlyProperties: OnlyProperties,
+): {
+  domainProperties: Record<string, CfProperty>;
+  resourceValueProperties: Record<string, CfProperty>;
+} {
+  const readOnlySet = new Set(onlyProperties.readOnly);
+  const domainProperties: Record<string, CfProperty> = {};
+  const resourceValueProperties: Record<string, CfProperty> = {};
+
+  for (const [name, prop] of Object.entries(schema.properties)) {
+    if (readOnlySet.has(name)) {
+      resourceValueProperties[name] = prop as CfProperty;
+    } else {
+      domainProperties[name] = prop as CfProperty;
+    }
+  }
+
+  return { domainProperties, resourceValueProperties };
+}
 
 export function pkgSpecFromDummy(): ExpandedPkgSpec[] {
   const schemas = [serverSchema, databaseSchema];
@@ -16,11 +39,18 @@ export function pkgSpecFromDummy(): ExpandedPkgSpec[] {
       primaryIdentifier: ["id"],
     };
 
+    const { domainProperties, resourceValueProperties } = splitDummyProperties(
+      schema,
+      onlyProperties,
+    );
+
     const module = makeModule(
       schema,
       schema.description,
       onlyProperties,
       dummyProviderConfig,
+      domainProperties,
+      resourceValueProperties,
     );
 
     specs.push(module);

--- a/bin/clover/src/pipelines/generic/index.ts
+++ b/bin/clover/src/pipelines/generic/index.ts
@@ -43,97 +43,19 @@ export function normalizeOnlyProperties(props: string[] | undefined): string[] {
   return newProps;
 }
 
-/**
- * Recursively prunes a properties tree based on readOnly classification.
- * This handles nested properties by walking the entire tree.
- * Empty parent objects are removed entirely.
- *
- * @param properties - The properties tree to prune
- * @param onlyProperties - Classification of properties (readOnly, writeOnly, etc.)
- * @param keepReadOnly - If true, keep readOnly properties; if false, keep writable properties
- * @param pathPrefix - Current path in the tree (for nested property matching)
- * @returns Pruned properties tree
- */
-function pruneProperties(
-  properties: Record<string, CfProperty>,
-  onlyProperties: OnlyProperties,
-  keepReadOnly: boolean,
-  pathPrefix: string = "",
-): Record<string, CfProperty> {
-  const readOnlySet = new Set(onlyProperties.readOnly);
-  const result: Record<string, CfProperty> = {};
-
-  for (const [name, prop] of Object.entries(properties)) {
-    if (!prop) continue;
-
-    const cfProp = prop as CfProperty;
-    const currentPath = pathPrefix ? `${pathPrefix}/${name}` : name;
-    // Check both the simple name and the full path to handle both normalized and non-normalized readOnly lists
-    const isReadOnly = readOnlySet.has(name) || readOnlySet.has(currentPath);
-    const shouldKeep = keepReadOnly ? isReadOnly : !isReadOnly;
-
-    // Check if this is an object with nested properties
-    if (
-      typeof cfProp === "object" && cfProp !== null && "properties" in cfProp &&
-      cfProp.properties
-    ) {
-      const prunedChildren = pruneProperties(
-        cfProp.properties as Record<string, CfProperty>,
-        onlyProperties,
-        keepReadOnly,
-        currentPath,
-      );
-
-      // Only include if this object has matching children
-      // Never include empty objects - they are pruned entirely
-      if (Object.keys(prunedChildren).length > 0) {
-        result[name] = { ...cfProp, properties: prunedChildren };
-      }
-    } else if (shouldKeep) {
-      result[name] = cfProp;
-    }
-  }
-
-  return result;
-}
-
 export function makeModule(
   schema: SuperSchema,
   description: string,
   onlyProperties: OnlyProperties,
   providerConfig: ProviderConfig,
+  domainProperties: Record<string, CfProperty>,
+  resourceValueProperties: Record<string, CfProperty>,
 ) {
   const { createDocLink: docFn, getCategory: categoryFn } =
     providerConfig.functions;
   const color = providerConfig.metadata?.color || "#FF9900"; // Default to AWS orange
 
-  // Recursively split properties into domain (writable) and resource_value (readOnly)
-  const domainProperties = pruneProperties(
-    schema.properties as Record<string, CfProperty>,
-    onlyProperties,
-    false, // keep writable properties
-  );
-  const resourceValueProperties = pruneProperties(
-    schema.properties as Record<string, CfProperty>,
-    onlyProperties,
-    true, // keep readOnly properties
-  );
-
-  // Filter out properties that don't have type or schema composition
-  for (const [name, prop] of Object.entries(domainProperties)) {
-    const cfProp = prop as CfProperty;
-    if (!cfProp.type && !cfProp.oneOf && !cfProp.anyOf) {
-      delete domainProperties[name];
-    }
-  }
-  for (const [name, prop] of Object.entries(resourceValueProperties)) {
-    const cfProp = prop as CfProperty;
-    if (!cfProp.type && !cfProp.oneOf && !cfProp.anyOf) {
-      delete resourceValueProperties[name];
-    }
-  }
-
-  // Create prop specs using the pruned properties
+  // Create prop specs using the provided properties
   const domain = createDefaultPropFromCf(
     "domain",
     domainProperties,
@@ -256,33 +178,6 @@ export function generateDefaultFuncsFromConfig(
     (domainId: string) =>
       createQualificationFuncs(config.funcSpecs.qualification, domainId),
   );
-
-  return specs;
-}
-
-/**
- * Generate ExpandedPkgSpecs from raw schemas using a ProviderConfig.
- * This is a generic helper that can be used by any provider that has
- * implemented parseRawSchema and classifyProperties hooks.
- *
- * @param rawSchema - Raw schema data in provider's native format
- * @param config - Provider configuration with parsing and classification hooks
- * @returns Array of ExpandedPkgSpecs ready for pipeline processing
- */
-export function generateSpecsFromRawSchema(
-  rawSchema: unknown,
-  config: ProviderConfig,
-): ExpandedPkgSpec[] {
-  // Parse raw schema into normalized SuperSchemas
-  const schemas = config.parseRawSchema
-    ? config.parseRawSchema(rawSchema)
-    : (rawSchema as SuperSchema[]);
-
-  // Transform each schema into a spec
-  const specs: ExpandedPkgSpec[] = schemas.map((schema) => {
-    const onlyProperties = config.classifyProperties(schema);
-    return makeModule(schema, schema.description, onlyProperties, config);
-  });
 
   return specs;
 }

--- a/bin/clover/src/pipelines/hetzner/pipeline-steps/createCredential.ts
+++ b/bin/clover/src/pipelines/hetzner/pipeline-steps/createCredential.ts
@@ -50,6 +50,8 @@ function createCredentialSpec(
     credential.description,
     onlyProperties,
     hetznerProviderConfig,
+    credential.properties,
+    {},
   );
 
   const [schema] = spec.schemas;

--- a/bin/clover/src/pipelines/hetzner/pipeline.ts
+++ b/bin/clover/src/pipelines/hetzner/pipeline.ts
@@ -8,7 +8,7 @@ import { createSuggestionsForPrimaryIdentifiers } from "../generic/createSuggest
 import { reorderProps } from "../generic/reorderProps.ts";
 import { updateSchemaIdsForExistingSpecs } from "../generic/updateSchemaIdsForExistingSpecs.ts";
 import { generateAssetFuncs } from "../generic/generateAssetFuncs.ts";
-import { generateDefaultFuncsFromConfig, generateSpecsFromRawSchema } from "../generic/index.ts";
+import { generateDefaultFuncsFromConfig } from "../generic/index.ts";
 import { addDefaultProps } from "./pipeline-steps/addDefaultProps.ts";
 import { applyAssetOverrides } from "../generic/applyAssetOverrides.ts";
 import { hetznerProviderConfig } from "./provider.ts";
@@ -24,8 +24,8 @@ export async function generateHetznerSpecs(options: {
 
   const existing_specs = await getExistingSpecs(options);
 
-  // Generate base specs from Hetzner schema using the new generic helper
-  specs = generateSpecsFromRawSchema(rawSchema, hetznerProviderConfig);
+  specs = hetznerProviderConfig.parseRawSchema(rawSchema);
+
   specs = addDefaultProps(specs);
 
   specs = generateDefaultFuncsFromConfig(specs, hetznerProviderConfig);


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

* refactor how we make modules to allow providers to pass in the domain and resource_value instead of relying on read_only flags to do pruning
  * This allows the different providers to have more control over the semantics of prop tree shape. 
  * Providers have been updated as such
* We now make it so Hetzner assets use post/put for the domain (user-creatable props) and get for the resource_value.
  * This ensures that creating things like Servers with IPs can use the required id value while the resource_value ends up with the full IP object returned from the api

#### Screenshots:

<img width="919" height="1781" alt="image" src="https://github.com/user-attachments/assets/f3335e92-d5d3-4704-9ce9-7a573cc40a65" />



## How was it tested?

The PR here is only showing changes to the Hetzner assets, which is what we want. I will diff comment a few here to validate.

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlcXhtNG9pcTUybXJ1M3drdWhhaTd5amRiODQzZnI0ZThhanBzYjV0dSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/U3PFGB8kCBVf7EN4Fk/giphy.gif"/>