### PR TITLE
feat(luminork): default to overlay actions and mgmt funcs for builtins

### DIFF
--- a/lib/dal-materialized-views/src/luminork/schema/variant/default.rs
+++ b/lib/dal-materialized-views/src/luminork/schema/variant/default.rs
@@ -24,13 +24,17 @@ pub async fn assemble(
     let default_variant_id = Schema::default_variant_id(&ctx, schema_id).await?;
     let schema_variant = SchemaVariant::get_by_id(&ctx, default_variant_id).await?;
 
-    let variant_func_ids: Vec<_> = SchemaVariant::all_func_ids(&ctx, default_variant_id)
-        .await?
-        .into_iter()
-        .collect();
+    let mut variant_func_ids = SchemaVariant::all_func_ids(&ctx, default_variant_id).await?;
+    let overlay_func_ids = Schema::all_overlay_func_ids(&ctx, schema_id).await?;
+    variant_func_ids.extend(overlay_func_ids);
 
-    let func_details =
-        build_func_details(&ctx, schema_variant.id(), variant_func_ids.clone()).await?;
+    let func_details = build_func_details(
+        &ctx,
+        schema_id,
+        schema_variant.id(),
+        variant_func_ids.clone(),
+    )
+    .await?;
 
     let domain_props = {
         let domain =

--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -36,6 +36,7 @@ use base64::{
 use chrono::Utc;
 use si_events::FuncRunId;
 use si_frontend_types::FuncSummary;
+use si_id::SchemaId;
 use si_layer_cache::LayerDbError;
 use telemetry::prelude::*;
 use thiserror::Error;
@@ -355,6 +356,22 @@ impl FuncAuthoringClient {
     ) -> FuncAuthoringResult<Func> {
         SchemaVariant::error_if_locked(ctx, schema_variant_id).await?;
         let func = create::create_action_func(ctx, name, action_kind, schema_variant_id).await?;
+        Ok(func)
+    }
+
+    /// Creates a new Action Func overlay and returns it
+    #[instrument(
+        name = "func.authoring.create_new_action_func_overlay",
+        level = "info",
+        skip(ctx)
+    )]
+    pub async fn create_new_action_func_overlay(
+        ctx: &DalContext,
+        name: Option<String>,
+        action_kind: ActionKind,
+        schema_id: SchemaId,
+    ) -> FuncAuthoringResult<Func> {
+        let func = create::create_action_func_overlay(ctx, name, action_kind, schema_id).await?;
         Ok(func)
     }
 

--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -94,6 +94,10 @@ pub enum FuncBindingError {
         "action with kind ({0}) already exists for schema variant ({1}), cannot have two non-manual actions for the same kind in the same schema variant"
     )]
     ActionKindAlreadyExists(ActionKind, SchemaVariantId),
+    #[error(
+        "action with kind ({0}) already exists for schema ({1}), cannot have two non-manual actions for the same kind in the same schema"
+    )]
+    ActionKindAlreadyExistsForSchema(ActionKind, SchemaId),
     #[error("action prototype error: {0}")]
     ActionPrototype(#[from] Box<ActionPrototypeError>),
     #[error("action prototype missing")]

--- a/lib/dal/src/management/prototype.rs
+++ b/lib/dal/src/management/prototype.rs
@@ -883,7 +883,7 @@ impl ManagementPrototype {
             ));
         }
 
-        let Some(schema_variant_id) = node_ids.first() else {
+        let Some(schema_variant_id) = schema_variant_sources.first() else {
             return Ok(None);
         };
 

--- a/lib/dal/src/schema/variant.rs
+++ b/lib/dal/src/schema/variant.rs
@@ -317,12 +317,14 @@ impl SchemaVariant {
             Self::list_all_sockets(ctx, self.id()).await?;
         output_sockets.sort_by_cached_key(|os| os.id());
         input_sockets.sort_by_cached_key(|is| is.id());
-        let func_ids: Vec<_> = Self::all_func_ids(ctx, self.id())
+        let mut func_ids: Vec<_> = Self::all_func_ids(ctx, self.id())
             .await?
             .into_iter()
             .collect();
 
         let schema = Schema::get_by_id(ctx, schema_id).await?;
+        let schema_func_ids = Schema::all_overlay_func_ids(ctx, schema_id).await?;
+        func_ids.extend(schema_func_ids);
 
         let is_default = Schema::default_variant_id_opt(ctx, schema_id).await? == Some(self.id());
         let mut props = Self::all_props(ctx, self.id()).await?;

--- a/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/action_prototype_node_weight.rs
@@ -1,3 +1,4 @@
+use petgraph::prelude::*;
 use serde::{
     Deserialize,
     Serialize,
@@ -8,12 +9,25 @@ use si_events::{
     ulid::Ulid,
 };
 
+use super::traits::CorrectTransformsResult;
 use crate::{
+    EdgeWeight,
+    EdgeWeightKind,
     EdgeWeightKindDiscriminants,
+    NodeWeightDiscriminants,
+    WorkspaceSnapshotGraphVCurrent,
     action::prototype::ActionKind,
     workspace_snapshot::{
-        graph::LineageId,
-        node_weight::traits::CorrectTransforms,
+        NodeInformation,
+        graph::{
+            LineageId,
+            detector::Update,
+        },
+        node_weight::{
+            NodeWeight,
+            category_node_weight::CategoryNodeKind,
+            traits::CorrectTransforms,
+        },
     },
 };
 
@@ -107,4 +121,137 @@ impl ActionPrototypeNodeWeight {
     }
 }
 
-impl CorrectTransforms for ActionPrototypeNodeWeight {}
+impl CorrectTransforms for ActionPrototypeNodeWeight {
+    fn correct_transforms(
+        &self,
+        graph: &WorkspaceSnapshotGraphVCurrent,
+        mut updates: Vec<Update>,
+        _from_different_change_set: bool,
+    ) -> CorrectTransformsResult<Vec<Update>> {
+        let mut new_overlay_schema_sources = vec![];
+        let this_kind = self.kind();
+
+        for update in &updates {
+            match update {
+                Update::NewEdge {
+                    source,
+                    destination,
+                    edge_weight,
+                } if destination.id.into_inner() == self.id().inner()
+                        && EdgeWeightKindDiscriminants::ActionPrototype == edge_weight.kind().into()
+                        // Schemas are content nodes
+                        && source.node_weight_kind == NodeWeightDiscriminants::Content =>
+                {
+                    new_overlay_schema_sources.push(source.id);
+                }
+                _ => {}
+            }
+        }
+
+        struct ConflictingPrototype<'a> {
+            schema_source_weight: &'a NodeWeight,
+            prototype_target_weight: &'a NodeWeight,
+            prototype_target_idx: NodeIndex,
+        }
+
+        let mut conflicting_prototype_idxes = Vec::new();
+
+        let overlay_category_node_information: Option<NodeInformation> = CategoryNodeKind::Overlays
+            .static_id()
+            .and_then(|overlay_id| graph.get_node_weight_by_id_opt(overlay_id).map(Into::into));
+
+        for overlay_schema_source_id in new_overlay_schema_sources {
+            let Some(schema_source_idx) = graph.get_node_index_by_id_opt(overlay_schema_source_id)
+            else {
+                continue;
+            };
+            let Some(schema_source_weight) = graph.get_node_weight_opt(schema_source_idx) else {
+                continue;
+            };
+
+            graph
+                .outgoing_edges(
+                    schema_source_idx,
+                    EdgeWeightKindDiscriminants::ActionPrototype,
+                )
+                .filter_map(|edge_ref| {
+                    graph
+                        .get_node_weight_opt(edge_ref.target())
+                        .and_then(|weight| match weight {
+                            NodeWeight::ActionPrototype(inner_weight)
+                                if inner_weight.kind() == this_kind =>
+                            {
+                                Some((weight, edge_ref.target()))
+                            }
+                            _ => None,
+                        })
+                })
+                .for_each(|(prototype_target_weight, prototype_target_idx)| {
+                    conflicting_prototype_idxes.push(ConflictingPrototype {
+                        schema_source_weight,
+                        prototype_target_weight,
+                        prototype_target_idx,
+                    });
+                });
+        }
+
+        // Remove the conflicting prototype by adding a remove edge update
+        // between it and the schema source, and between it and the overlay
+        // category. but also find any actions that are using the prototype,
+        // and shift them over to this new prototype.
+        for conflicting_prototype in conflicting_prototype_idxes {
+            updates.push(Update::RemoveEdge {
+                source: conflicting_prototype.schema_source_weight.into(),
+                destination: conflicting_prototype.prototype_target_weight.into(),
+                edge_kind: EdgeWeightKindDiscriminants::ActionPrototype,
+            });
+
+            // Remove overlay category edge
+            if let Some(overlay_node_info) = overlay_category_node_information {
+                updates.push(Update::RemoveEdge {
+                    source: overlay_node_info,
+                    destination: conflicting_prototype.prototype_target_weight.into(),
+                    edge_kind: EdgeWeightKindDiscriminants::Use,
+                });
+            }
+
+            let actions_using_prototype = graph
+                .incoming_edges(
+                    conflicting_prototype.prototype_target_idx,
+                    EdgeWeightKindDiscriminants::Use,
+                )
+                .filter_map(|edge_ref| {
+                    graph
+                        .get_node_weight_opt(edge_ref.source())
+                        .and_then(|weight| {
+                            if let NodeWeight::Action(_) = weight {
+                                Some(weight)
+                            } else {
+                                None
+                            }
+                        })
+                });
+
+            for action_node_weight in actions_using_prototype {
+                // Remove edge from action to conflicting prototype
+                updates.push(Update::RemoveEdge {
+                    source: action_node_weight.into(),
+                    destination: conflicting_prototype.prototype_target_weight.into(),
+                    edge_kind: EdgeWeightKindDiscriminants::Use,
+                });
+
+                // Add edge from action to self
+                updates.push(Update::NewEdge {
+                    source: action_node_weight.into(),
+                    destination: NodeInformation {
+                        node_weight_kind: NodeWeightDiscriminants::ActionPrototype,
+                        id: self.id().into(),
+                    },
+                    edge_weight: EdgeWeight::new(EdgeWeightKind::new_use()),
+                });
+            }
+        }
+
+        Ok(updates)
+    }
+}

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,3 +1,4 @@
+mod action_prototype;
 mod attribute_value;
 mod component;
 mod ordering;

--- a/lib/dal/tests/integration_test/node_weight/action_prototype.rs
+++ b/lib/dal/tests/integration_test/node_weight/action_prototype.rs
@@ -1,0 +1,216 @@
+use base64::Engine;
+use dal::{
+    DalContext,
+    Func,
+    Schema,
+    action::{
+        Action,
+        prototype::{
+            ActionKind,
+            ActionPrototype,
+        },
+    },
+};
+use dal_test::{
+    Result,
+    helpers::{
+        ChangeSetTestHelpers,
+        create_component_for_default_schema_name_in_default_view,
+    },
+    test,
+};
+use pretty_assertions_sorted::assert_eq;
+
+/// Ensure that if a schema level action prototype is created in one change set,
+/// and one for the same kind is created in another change set, a correction will
+/// prevent two action prototypes for the same kind.
+#[test]
+async fn schema_level_action_prototype_across_change_sets(ctx: &mut DalContext) -> Result<()> {
+    let first_change_set_id = ctx.change_set_id();
+    let schema = Schema::get_by_name(ctx, "swifty").await?;
+    let default_schema_variant_id = Schema::default_variant_id(ctx, schema.id()).await?;
+
+    // Create a schema-level Create action prototype in the first change set
+    let create_action_code_cs1 = "async function main() {
+                return { payload: { \"change_set\": \"first\"}, status: \"ok\" };
+            }";
+
+    let create_func_cs1 = Func::new(
+        ctx,
+        "test:schemaCreateActionSwiftyCS1",
+        None::<String>,
+        None::<String>,
+        None::<String>,
+        false,
+        false,
+        dal::FuncBackendKind::JsAction,
+        dal::FuncBackendResponseType::Action,
+        "main".into(),
+        Some(base64::engine::general_purpose::STANDARD_NO_PAD.encode(create_action_code_cs1)),
+        false,
+    )
+    .await?;
+
+    let schema_action_prototype_cs1 = ActionPrototype::new(
+        ctx,
+        ActionKind::Create,
+        "test:schemaCreateActionSwiftyCS1".into(),
+        None,
+        schema.id(),
+        create_func_cs1.id,
+    )
+    .await?;
+
+    // Verify this is now the default Create action for the schema
+    let default_create = ActionPrototype::find_by_kind_for_schema_or_variant(
+        ctx,
+        ActionKind::Create,
+        default_schema_variant_id,
+    )
+    .await?
+    .pop()
+    .expect("should have one create action");
+
+    assert_eq!(schema_action_prototype_cs1.id(), default_create.id());
+
+    // Create a component to verify it uses the first prototype
+    let component_cs1 =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "component_cs1")
+            .await?;
+
+    let mut actions_cs1 = Action::find_for_component_id(ctx, component_cs1.id()).await?;
+    assert_eq!(1, actions_cs1.len());
+
+    let action_id_cs1 = actions_cs1.pop().expect("should have one action");
+    let prototype_id_cs1 = Action::prototype_id(ctx, action_id_cs1).await?;
+    assert_eq!(schema_action_prototype_cs1.id(), prototype_id_cs1);
+
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx)
+        .await
+        .expect("unable to commit");
+
+    // Fork head
+    let second_change_set =
+        ChangeSetTestHelpers::fork_from_head_change_set_with_name(ctx, "Second Change Set").await?;
+
+    // Create another schema-level Create action prototype in the second change set
+    let create_action_code_cs2 = "async function main() {
+                return { payload: { \"change_set\": \"second\"}, status: \"ok\" };
+            }";
+
+    let create_func_cs2 = Func::new(
+        ctx,
+        "test:schemaCreateActionSwiftyCS2",
+        None::<String>,
+        None::<String>,
+        None::<String>,
+        false,
+        false,
+        dal::FuncBackendKind::JsAction,
+        dal::FuncBackendResponseType::Action,
+        "main".into(),
+        Some(base64::engine::general_purpose::STANDARD_NO_PAD.encode(create_action_code_cs2)),
+        false,
+    )
+    .await?;
+
+    let schema_action_prototype_cs2 = ActionPrototype::new(
+        ctx,
+        ActionKind::Create,
+        "test:schemaCreateActionSwiftyCS2".into(),
+        None,
+        schema.id(),
+        create_func_cs2.id,
+    )
+    .await?;
+
+    // Verify the second change set uses the new prototype
+    let default_create_cs2 = ActionPrototype::find_by_kind_for_schema_or_variant(
+        ctx,
+        ActionKind::Create,
+        default_schema_variant_id,
+    )
+    .await?
+    .pop()
+    .expect("should have one create action");
+
+    assert_eq!(schema_action_prototype_cs2.id(), default_create_cs2.id());
+
+    // Create a component in the second change set
+    let component_cs2 =
+        create_component_for_default_schema_name_in_default_view(ctx, "swifty", "component_cs2")
+            .await?;
+
+    let mut actions_cs2 = Action::find_for_component_id(ctx, component_cs2.id()).await?;
+    assert_eq!(1, actions_cs2.len());
+
+    let action_id_cs2 = actions_cs2.pop().expect("should have one action");
+    let prototype_id_cs2 = Action::prototype_id(ctx, action_id_cs2).await?;
+    assert_eq!(schema_action_prototype_cs2.id(), prototype_id_cs2);
+
+    // Commit the second change set
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // Switch to first chagne set and apply it to base
+    ctx.update_visibility_and_snapshot_to_visibility(first_change_set_id)
+        .await?;
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+
+    // Back to second change set
+    ctx.update_visibility_and_snapshot_to_visibility(second_change_set.id)
+        .await?;
+
+    // Check that there's only one Create action prototype for the schema in this change set
+    let create_prototypes = ActionPrototype::find_by_kind_for_schema_or_variant(
+        ctx,
+        ActionKind::Create,
+        default_schema_variant_id,
+    )
+    .await?;
+
+    assert_eq!(
+        1,
+        create_prototypes.len(),
+        "exactly one create action prototype"
+    );
+
+    let current_prototype = create_prototypes
+        .first()
+        .expect("should have one prototype");
+
+    // Verify that components in the second change set use the correct prototype
+    let mut actions_cs2_after = Action::find_for_component_id(ctx, component_cs2.id()).await?;
+    assert_eq!(1, actions_cs2_after.len());
+
+    let action_id_cs2_after = actions_cs2_after.pop().expect("should have one action");
+    let prototype_id_cs2_after = Action::prototype_id(ctx, action_id_cs2_after).await?;
+
+    // The action should use the prototype that exists in this change set
+    assert_eq!(
+        current_prototype.id(),
+        prototype_id_cs2_after,
+        "action should use the correct prototype"
+    );
+
+    // Create a new component to ensure new actions use the correct prototype
+    let component_cs2_new = create_component_for_default_schema_name_in_default_view(
+        ctx,
+        "swifty",
+        "component_cs2_new",
+    )
+    .await?;
+
+    let mut actions_cs2_new = Action::find_for_component_id(ctx, component_cs2_new.id()).await?;
+    assert_eq!(1, actions_cs2_new.len());
+
+    let action_id_cs2_new = actions_cs2_new.pop().expect("should have one action");
+    let prototype_id_cs2_new = Action::prototype_id(ctx, action_id_cs2_new).await?;
+
+    assert_eq!(
+        current_prototype.id(),
+        prototype_id_cs2_new,
+        "New component action should use the correct prototype"
+    );
+
+    Ok(())
+}

--- a/lib/rebaser-server/src/rebase.rs
+++ b/lib/rebaser-server/src/rebase.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use audit_logs_stream::AuditLogsStreamError;
 use dal::{
     DalContext,
+    SchemaError,
     TransactionsError,
     Workspace,
     WorkspaceError,
@@ -446,6 +447,8 @@ async fn rebase_legacy(
 pub(crate) enum SendEddaUpdatesError {
     #[error("edda client error: {0}")]
     EddaClient(#[from] edda_client::ClientError),
+    #[error("schema error: {0}")]
+    Schema(#[from] SchemaError),
     #[error("transactions error: {0}")]
     Transactions(#[from] TransactionsError),
     #[error("workspace snapshot error: {0}")]
@@ -467,6 +470,7 @@ pub(crate) async fn send_updates_to_edda_split_snapshot(
             "rebaser.perform_rebase.detect_changes_for_edda_request"
         ))
         .await?;
+
     let change_batch_address = ctx.write_change_batch(changes).await?;
     let edda_update_request_id = edda
         .update_from_workspace_snapshot(

--- a/lib/sdf-server/src/service/v2/fs.rs
+++ b/lib/sdf-server/src/service/v2/fs.rs
@@ -993,6 +993,7 @@ async fn create_func(
                     func_id: func.id,
                     func_display_name: func.display_name.clone(),
                     schema_variant_id: Some(unlocked_variant.id()),
+                    schema_id: None,
                     component_id: None,
                     subject_name: unlocked_variant.display_name().to_string(),
                 },

--- a/lib/sdf-server/src/service/v2/fs/bindings.rs
+++ b/lib/sdf-server/src/service/v2/fs/bindings.rs
@@ -737,6 +737,7 @@ async fn create_management_binding(
             func_id: func.id,
             func_display_name: func.display_name.clone(),
             schema_variant_id: Some(schema_variant_id),
+            schema_id: None,
             component_id: None,
             subject_name: schema_variant.display_name().to_owned(),
         },

--- a/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
+++ b/lib/sdf-server/src/service/v2/func/binding/create_binding.rs
@@ -401,6 +401,7 @@ pub async fn create_binding(
                                     func_id: func.id,
                                     func_display_name: func.display_name.clone(),
                                     schema_variant_id: Some(schema_variant_id),
+                                    schema_id: None,
                                     component_id: None,
                                     subject_name: schema_variant.display_name().to_owned(),
                                 },

--- a/lib/sdf-server/src/service/v2/func/create_func.rs
+++ b/lib/sdf-server/src/service/v2/func/create_func.rs
@@ -384,6 +384,7 @@ pub async fn create_func(
                         func_id: func.id,
                         func_display_name: func.display_name.clone(),
                         schema_variant_id: Some(schema_variant_id),
+                        schema_id: None,
                         component_id: None,
                         subject_name: schema_variant_name,
                     },

--- a/lib/si-events-rs/src/audit_log/v1.rs
+++ b/lib/si-events-rs/src/audit_log/v1.rs
@@ -109,6 +109,7 @@ pub enum AuditLogKindV1 {
         func_id: FuncId,
         func_display_name: Option<String>,
         schema_variant_id: Option<SchemaVariantId>,
+        schema_id: Option<SchemaId>,
         component_id: Option<ComponentId>,
         subject_name: String,
     },
@@ -585,6 +586,7 @@ pub enum AuditLogMetadataV1 {
         schema_variant_id: Option<SchemaVariantId>,
         component_id: Option<ComponentId>,
         subject_name: String,
+        schema_id: Option<SchemaId>,
     },
     #[serde(rename_all = "camelCase")]
     AttachQualificationFunc {
@@ -1223,12 +1225,14 @@ impl From<Kind> for Metadata {
                 schema_variant_id,
                 component_id,
                 subject_name,
+                schema_id,
             } => Self::AttachManagementFunc {
                 func_id,
                 func_display_name,
                 schema_variant_id,
                 component_id,
                 subject_name,
+                schema_id,
             },
             Kind::AttachQualificationFunc {
                 func_id,


### PR DESCRIPTION
When an action or management function is created in luminork, default to creating an "overlay" (schema parented) function and prototype instead of a variant-level function. This will allow the custom functions to persist between upgrades, and does not require locking the variant.

In order to make this work with our materialized views, adds a post-processing step to change detection that adds SchemaVariant changes to the change set to force the SchemaVariant related materialized views to rebuild so that they reflect these new functions.

Tests:

1. Create a new management function for a builtin via luminork. Observe that it is available in the management functions dropdown in the UI. Try to run it.

2. See that the function exists in the list of functions when you fetch the schema variant in luminork.

3. Create an action for a builtin via luminork. Confirm you cannot create a second action of that type. Add a component and enqueue that action. Apply to head. See that the action that ran was the new one, and not the default one for that variant.

4. See that the action function exists in the func list when you fetch the variant via luminork.


Additional tests:

  Use luminork to create a new create action for one change set, and a
  new create action in another change set, both for the same schema.
  Apply one of the change sets to head. Ensure that create actions work
  when applying the second change set after the first has been applied.