### PR TITLE
remove context that causes wrong template generation

### DIFF
--- a/bin/si-mcp-server/src/tools/componentList.ts
+++ b/bin/si-mcp-server/src/tools/componentList.ts
@@ -23,7 +23,6 @@ const description =
   <important>
       *DO NOT USE THIS TOOL FOR TEMPLATE GENERATION:*
       - For template generation, use the template-generate tool's built-in search functionality
-      - For discovering components, use the template-generate tool's search instead
       - Only use component-list when you need to retrieve a comprehensive list of ALL components or apply
     complex regex filtering that isn't supported by search syntax
       </important>


### PR DESCRIPTION
## How does this PR change the system?

Removes one line of context in the componentList tool which was causing template generation for any component search.

#### Out of Scope:

We will want to watch for similar issues with random template generation around finding components. This change fixes this case but there may be others.

## How was it tested?

Tested locally. With the line in, the problem happens. With the line removed, it does not happen.