### PR TITLE
componentCreate using working copy

### DIFF
--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -12,7 +12,7 @@
     "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
     "@std/assert": "jsr:@std/assert@1",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.3.2",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.4.0",
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",

--- a/bin/si-mcp-server/src/data/components.ts
+++ b/bin/si-mcp-server/src/data/components.ts
@@ -29,5 +29,5 @@ export const AttributesSchema = z.record(
     z.number().describe("a number value"),
   ]),
 ).describe(
-  "the attributes of the component; the desired state of the resource",
+  "the attributes of the component; the desired state of the resource. do not start attributes with /root",
 );


### PR DESCRIPTION
## How does this PR change the system?

This PR adjusts the `componentCreate` tool to allow for users to create components either using the default variant or their working copy of the component's schema.

#### Out of Scope:

This PR deliberately does not allow the `createComponent` tool to select a schema variant by ID, since users should not have to think about schema variants at all. Instead, the AI Agent can select either the default variant or the working copy.

## How was it tested?

The following manual tests were run via the AI Agent -

- The demo listed in [ENG-3260](https://linear.app/system-initiative/issue/ENG-3260/spike-on-issues-between-mcp-modeling-and-authoring-tools-specifically) done multiple times with wide variations on wording. All successful!
- Alternating adding a prop and function to a schema, creating a component after each edit - successful!
- Creating a brand new schema and iterating on props and functions
- Editing an existing schema and iterating on props and functions