### PR TITLE
feat: Remove large auto-suggestions for Azure schemas

### DIFF
--- a/bin/clover/src/pipelines/azure/pipeline.ts
+++ b/bin/clover/src/pipelines/azure/pipeline.ts
@@ -3,17 +3,18 @@ import { PipelineOptions } from "../types.ts";
 import { generateDefaultFuncsFromConfig } from "../generic/index.ts";
 import { getExistingSpecs } from "../../specUpdates.ts";
 import { generateIntrinsicFuncs } from "../generic/generateIntrinsicFuncs.ts";
-import { createSuggestionsForPrimaryIdentifiers } from "../generic/createSuggestionsAcrossAssets.ts";
+// import { createSuggestionsForPrimaryIdentifiers } from "../generic/createSuggestionsAcrossAssets.ts";
 import { reorderProps } from "../generic/reorderProps.ts";
 import { updateSchemaIdsForExistingSpecs } from "../generic/updateSchemaIdsForExistingSpecs.ts";
 import { generateAssetFuncs } from "../generic/generateAssetFuncs.ts";
 import { applyAssetOverrides } from "../generic/applyAssetOverrides.ts";
 import { addDefaultProps } from "./pipeline-steps/addDefaultProps.ts";
-import path from "node:path";
-import { azureRestApiSpecsRepo } from "./provider.ts";
-import { readAzureSwaggerSpec } from "./schema.ts";
+import {
+  findLatestAzureOpenApiSpecFiles,
+  initAzureRestApiSpecsRepo,
+  readAzureSwaggerSpec,
+} from "./schema.ts";
 import { parseAzureSpec } from "./spec.ts";
-import { assert } from "node:console";
 
 export async function generateAzureSpecs(
   options: PipelineOptions,
@@ -27,7 +28,7 @@ export async function generateAzureSpecs(
   specs = addDefaultProps(specs);
   specs = generateDefaultFuncsFromConfig(specs, azureConfig);
   specs = generateIntrinsicFuncs(specs);
-  specs = createSuggestionsForPrimaryIdentifiers(specs);
+  // specs = createSuggestionsForPrimaryIdentifiers(specs);
 
   // Apply provider-specific overrides
   specs = applyAssetOverrides(specs, azureConfig);
@@ -39,82 +40,13 @@ export async function generateAzureSpecs(
   return specs;
 }
 
-const EXCLUDE_SPECS = [
-  // The dereferencer has trouble with # formats like "$ref": "#/parameters/projectTask" for whatever reason
-  "/azure-rest-api-specs/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMaker.json",
-  "/azure-rest-api-specs/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/stable/2025-06-30/datamigration.json",
-  "/azure-rest-api-specs/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2025-09-01/machineLearningServices.json",
-  "/azure-rest-api-specs/specification/managementgroups/resource-manager/Microsoft.Management/ManagementGroups/stable/2023-04-01/management.json",
-  "/azure-rest-api-specs/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/stable/2025-09-01/Metadata.json",
-  "/azure-rest-api-specs/specification/workloads/resource-manager/Microsoft.Workloads/stable/2023-04-01/monitors.json",
-  "/azure-rest-api-specs/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/stable/2025-09-01/ContentTemplates.json",
-  "/azure-rest-api-specs/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/stable/2025-09-01/ContentPackages.json",
-];
+async function getLatestAzureSpecs(options: PipelineOptions) {
+  const specsRepo = await initAzureRestApiSpecsRepo(options);
+  console.log(`Loading Azure specs from ${specsRepo} ...`);
 
-async function* findLatestAzureSpecFiles(dir: string): AsyncGenerator<string> {
-  // Update the bin/clover/src/provider-schemas/azure-rest-api-specs submodule
-  const command = new Deno.Command("git", {
-    args: ["submodule", "update", "--init"],
-  });
-  const { code, stderr } = await command.output();
-  if (code !== 0) {
-    const errorText = new TextDecoder().decode(stderr);
-    throw new Error(`Failed to update Azure specs: ${errorText}`);
-  }
-
-  // Now find the latest stable (or preview if no stable) version in each service directory
-  let latest: { parent: "stable" | "preview"; version: string } | undefined;
-  for await (const entry of Deno.readDir(dir)) {
-    if (entry.isDirectory) {
-      const entryPath = path.join(dir, entry.name);
-      // If it's a "stable" directory, look for the latest version and yield its specs
-      if (entry.name === "stable" || entry.name === "preview") {
-        // Pick the directory with the latest version
-        for await (const version of Deno.readDir(entryPath)) {
-          if (version.isDirectory) {
-            if (
-              !latest ||
-              (latest.parent === entry.name && version.name > latest.version) ||
-              (latest.parent === "preview" && entry.name === "stable")
-            ) {
-              latest = { parent: entry.name, version: version.name };
-            }
-          }
-        }
-
-        if (entry.name === "stable") {
-          assert(latest, `No latest version in ${entryPath}`);
-        }
-      } else {
-        yield* findLatestAzureSpecFiles(entryPath);
-      }
-    }
-  }
-
-  if (latest) {
-    // Read the specs
-    const latestVersionDir = path.join(dir, latest.parent, latest.version);
-    let foundFiles = false;
-    for await (const spec of Deno.readDir(latestVersionDir)) {
-      if (spec.isFile && spec.name.endsWith(".json")) {
-        const specPath = path.join(latestVersionDir, spec.name);
-        foundFiles = true;
-        if (!EXCLUDE_SPECS.some((s) => specPath.endsWith(s))) {
-          yield specPath;
-        }
-      }
-    }
-    assert(foundFiles, `No spec files found in ${latestVersionDir}`);
-  }
-}
-
-export async function getLatestAzureSpecs(options: PipelineOptions) {
   const specs: ExpandedPkgSpec[] = [];
-
-  const specsRoot = path.join(azureRestApiSpecsRepo(options), "specification");
-  console.log(`Loading Azure specs from ${specsRoot} ...`);
   let processed = 0;
-  for await (const specPath of findLatestAzureSpecFiles(specsRoot)) {
+  for await (const specPath of findLatestAzureOpenApiSpecFiles(specsRepo)) {
     try {
       const openApiSpec = await readAzureSwaggerSpec(specPath);
       const schemas = parseAzureSpec(openApiSpec);

--- a/bin/clover/src/pipelines/azure/provider.ts
+++ b/bin/clover/src/pipelines/azure/provider.ts
@@ -1,7 +1,5 @@
-import path from "node:path";
 import {
   CfProperty,
-  CommonCommandOptions,
   FetchSchemaOptions,
   PipelineOptions,
   PropertyNormalizationContext,
@@ -18,13 +16,10 @@ import {
 } from "./funcs.ts";
 import { normalizeAzureProperty } from "./spec.ts";
 import { generateAzureSpecs } from "./pipeline.ts";
-
-export function azureRestApiSpecsRepo(options: CommonCommandOptions) {
-  return path.join(options.providerSchemasPath, "azure-rest-api-specs");
-}
+import { initAzureRestApiSpecsRepo } from "./schema.ts";
 
 async function azureFetchSchema(options: FetchSchemaOptions) {
-  const specsRepo = azureRestApiSpecsRepo(options);
+  const specsRepo = initAzureRestApiSpecsRepo(options);
   console.log(`Updating Azure specs in ${specsRepo} ...`);
 
   // Update the bin/clover/src/provider-schemas/azure-rest-api-specs submodule

--- a/bin/clover/src/pipelines/azure/schema.ts
+++ b/bin/clover/src/pipelines/azure/schema.ts
@@ -3,10 +3,12 @@ import type {
   CfHandlerKind,
   CfObjectProperty,
   CfProperty,
+  CommonCommandOptions,
 } from "../types.ts";
 import { JSONSchema } from "../draft_07.ts";
 import assert from "node:assert";
 import $RefParser from "@apidevtools/json-schema-ref-parser";
+import path from "node:path";
 
 type JSONPointer = string;
 
@@ -177,6 +179,20 @@ export function isAzureObjectProperty(o: unknown): o is AzureObjectProperty {
   return !("type" in o && o.type !== "object");
 }
 
+export async function initAzureRestApiSpecsRepo(options: CommonCommandOptions) {
+  // Update the bin/clover/src/provider-schemas/azure-rest-api-specs submodule
+  const command = new Deno.Command("git", {
+    args: ["submodule", "update", "--init"],
+  });
+  const { code, stderr } = await command.output();
+  if (code !== 0) {
+    const errorText = new TextDecoder().decode(stderr);
+    throw new Error(`Failed to update Azure specs: ${errorText}`);
+  }
+
+  return path.join(options.providerSchemasPath, "azure-rest-api-specs");
+}
+
 export async function readAzureSwaggerSpec(filePath: string) {
   const fileUrl = new URL(`file://${filePath}`);
 
@@ -230,4 +246,73 @@ function flattenAllOfProperties({
   }
 
   return schema;
+}
+
+const EXCLUDE_SPECS = [
+  // The dereferencer has trouble with # formats like "$ref": "#/parameters/projectTask" for whatever reason
+  "/azure-rest-api-specs/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMaker.json",
+  "/azure-rest-api-specs/specification/datamigration/resource-manager/Microsoft.DataMigration/DataMigration/stable/2025-06-30/datamigration.json",
+  "/azure-rest-api-specs/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2025-09-01/machineLearningServices.json",
+  "/azure-rest-api-specs/specification/managementgroups/resource-manager/Microsoft.Management/ManagementGroups/stable/2023-04-01/management.json",
+  "/azure-rest-api-specs/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/stable/2025-09-01/Metadata.json",
+  "/azure-rest-api-specs/specification/workloads/resource-manager/Microsoft.Workloads/stable/2023-04-01/monitors.json",
+  "/azure-rest-api-specs/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/stable/2025-09-01/ContentTemplates.json",
+  "/azure-rest-api-specs/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/stable/2025-09-01/ContentPackages.json",
+];
+
+/**
+ * Find all the latest Azure OpenAPI spec files
+ */
+export async function* findLatestAzureOpenApiSpecFiles(specsRepo: string) {
+  const specsRoot = path.join(specsRepo, "specification");
+  for await (const specDir of findLatestAzureOpenApiSpecDirs(specsRoot)) {
+    // Read the spec
+    let foundFiles = false;
+    for await (const spec of Deno.readDir(specDir)) {
+      if (spec.isFile && spec.name.endsWith(".json")) {
+        foundFiles = true;
+        const specPath = path.join(specDir, spec.name);
+        if (!EXCLUDE_SPECS.some((s) => specPath.endsWith(s))) {
+          yield specPath;
+        }
+      }
+    }
+    assert(foundFiles, `No spec files found in ${specDir}`);
+  }
+}
+
+async function* findLatestAzureOpenApiSpecDirs(
+  dir: string,
+): AsyncGenerator<string> {
+  // Now find the latest stable (or preview if no stable) version in each service directory
+  let latest: { parent: "stable" | "preview"; version: string } | undefined;
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isDirectory) {
+      const entryPath = path.join(dir, entry.name);
+      // If it's a "stable" or "preview" directory, look for the latest version and yield its specs
+      if (entry.name === "stable" || entry.name === "preview") {
+        // Pick the directory with the latest version
+        for await (const version of Deno.readDir(entryPath)) {
+          if (version.isDirectory) {
+            if (
+              !latest ||
+              (latest.parent === entry.name && version.name > latest.version) ||
+              (latest.parent === "preview" && entry.name === "stable")
+            ) {
+              latest = { parent: entry.name, version: version.name };
+            }
+          }
+        }
+
+        if (entry.name === "stable") {
+          assert(latest, `No latest version in ${entryPath}`);
+        }
+      } else {
+        yield* findLatestAzureOpenApiSpecDirs(entryPath);
+      }
+    }
+  }
+  if (latest) {
+    yield path.join(dir, latest.parent, latest.version);
+  }
 }


### PR DESCRIPTION
We aren't generating VirtualMachines schemas for Azure right now because it's bigger than 4MB.

This fixes that by disabling auto-suggestions altogether for Azure; we'll follow up and get auto-suggestions working again when we've got Azure components working end to end.

This PR also moves Azure schema walking into schema.ts and makes the walk faster (though we're not sure exactly how it did that, it definitely did).

## How was it tested?

- [X] Manual test: VirtualMachines asset is created
- [X] Manual test: (regression check) creating a component still works

## In short: [:link:](https://giphy.com/)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaGIwZ3hwdjFuYXR3ZzFobXpvNHZwajVxMW1nMzM1OGdmZGV1d2c1bCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/oYapDjZA6bnrQAwbi6/giphy.gif"/>
