### PR TITLE
luminork API changes to support useWorkingCopy, better tests

### DIFF
--- a/bin/si-luminork-api-tests/README.md
+++ b/bin/si-luminork-api-tests/README.md
@@ -65,7 +65,7 @@ deno task test:watch
 ### Run a Specific Test
 
 ```bash
-deno test tests/system-status.test.ts
+deno task test tests/system-status.test.ts
 ```
 
 ### Using the Convenience Script
@@ -115,25 +115,25 @@ import { createTestClient, generateTestName } from "../src/test-utils.ts";
 Deno.test("My Custom Test", async () => {
   // Get configured API client and test configuration
   const { api, config } = await createTestClient();
-  
+
   // Create a test change set
   const response = await api.changeSets.createChangeSet(config.workspaceId, {
     name: generateTestName("my_test"),
     description: "Created by my custom test"
   });
-  
+
   // Assert response is as expected
   assertEquals(response.status, 201);
-  
+
   const changeSetId = response.data.id;
-  
+
   // List schemas in workspace
   const schemasResponse = await api.schemas.listSchemas(config.workspaceId);
-  
+
   // Create a component in the change set
   if (schemasResponse.data.items.length > 0) {
     const schemaId = schemasResponse.data.items[0].id;
-    
+
     const componentResponse = await api.components.createComponent(
       config.workspaceId,
       changeSetId,
@@ -142,10 +142,10 @@ Deno.test("My Custom Test", async () => {
         schema_id: schemaId
       }
     );
-    
+
     assertEquals(componentResponse.status, 201);
   }
-  
+
   // Clean up resources when done
   await api.changeSets.deleteChangeSet(config.workspaceId, changeSetId);
 });

--- a/bin/si-luminork-api-tests/src/api/components.ts
+++ b/bin/si-luminork-api-tests/src/api/components.ts
@@ -24,9 +24,25 @@ export interface ComponentView {
   resourceProps?: Array<unknown>;
 }
 
+// Attribute value types that can be used in component attributes
+export type AttributeValue =
+  | { $source: null | { component: string; path: string; func?: string } }
+  | string
+  | unknown[]
+  | boolean
+  | Record<string, unknown>
+  | number;
+
 export interface CreateComponentRequest {
   name: string;
   schemaName: string;
+  resourceId?: string;
+  viewName?: string;
+  managedBy?: {
+    component?: string;
+  };
+  attributes?: Record<string, AttributeValue>;
+  useWorkingCopy?: boolean;
 }
 
 export interface UpdateComponentRequest {

--- a/bin/si-luminork-api-tests/tests/schemas.test.ts
+++ b/bin/si-luminork-api-tests/tests/schemas.test.ts
@@ -4,17 +4,148 @@
  * Tests for the schemas API endpoints.
  */
 
-import {
-  assertEquals,
-  assertExists,
-} from "https://deno.land/std@0.220.1/assert/mod.ts";
-import {
-  createTestClient,
-  cleanupTestResources,
-  ConfigError,
-} from "../src/test-utils.ts";
+import { assertEquals, assertExists } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+import { cleanupTestResources, ConfigError, createTestClient } from '../src/test-utils.ts';
+import type { SchemaView } from '../src/api/schemas.ts';
+import { LuminorkApi } from '../src/api/index.ts';
 
-Deno.test("Schemas API - List and Find Schemas", async () => {
+/**
+ * Helper function to find the first installed schema in a change set
+ */
+async function findInstalledSchema(
+  api: LuminorkApi,
+  workspaceId: string,
+  changeSetId: string,
+): Promise<SchemaView | null> {
+  const listSchemasResponse = await api.schemas.listSchemas(
+    workspaceId,
+    changeSetId,
+  );
+
+  assertEquals(listSchemasResponse.status, 200);
+  assertExists(listSchemasResponse.data.schemas);
+
+  if (listSchemasResponse.data.schemas.length === 0) {
+    console.warn('No schemas found in workspace');
+    return null;
+  }
+
+  const firstSchema = listSchemasResponse.data.schemas.find(
+    (s) => s.installed,
+  );
+  if (!firstSchema) {
+    console.warn('No installed schemas found');
+    return null;
+  }
+
+  console.log(
+    `Found installed schema: ${firstSchema.schemaName} (${firstSchema.schemaId})`,
+  );
+
+  return firstSchema;
+}
+
+/**
+ * Helper function to unlock a schema
+ */
+async function unlockSchema(
+  api: LuminorkApi,
+  workspaceId: string,
+  changeSetId: string,
+  schemaId: string,
+) {
+  const unlockResponse = await api.schemas.unlockSchema(
+    workspaceId,
+    changeSetId,
+    schemaId,
+  );
+
+  assertEquals(
+    unlockResponse.status,
+    200,
+    'Unlock schema response status should be 200',
+  );
+  assertExists(unlockResponse.data.unlockedVariantId);
+  assertEquals(
+    unlockResponse.data.unlockedVariant.isLocked,
+    false,
+    'Unlocked variant should not be locked',
+  );
+
+  console.log(
+    `Successfully unlocked schema, unlocked variant ID: ${unlockResponse.data.unlockedVariantId}`,
+  );
+
+  return unlockResponse.data;
+}
+
+/**
+ * Helper function to update a schema variant with test values
+ */
+async function updateSchemaVariantWithTestValues(
+  api: LuminorkApi,
+  workspaceId: string,
+  changeSetId: string,
+  schemaId: string,
+  variantId: string,
+  displayName: string,
+) {
+  const newCode = `function main() { const asset = new AssetBuilder(); return asset.build(); }`;
+
+  const updateResponse = await api.schemas.updateSchemaVariant(
+    workspaceId,
+    changeSetId,
+    {
+      schema_id: schemaId,
+      schema_variant_id: variantId,
+      request_body: {
+        name: displayName,
+        category: 'TestCategory',
+        color: '#FF00FF',
+        description: 'Test description for unlocked schema',
+        link: 'https://example.com/test-schema',
+        code: newCode,
+      },
+    },
+  );
+
+  assertEquals(
+    updateResponse.status,
+    200,
+    'Update schema variant response status should be 200',
+  );
+  assertExists(updateResponse.data);
+
+  // Verify the updated values
+  assertEquals(
+    updateResponse.data.category,
+    'TestCategory',
+    'Category should be updated',
+  );
+  assertEquals(
+    updateResponse.data.color,
+    '#FF00FF',
+    'Color should be updated',
+  );
+  assertEquals(
+    updateResponse.data.description,
+    'Test description for unlocked schema',
+    'Description should be updated',
+  );
+  assertEquals(
+    updateResponse.data.link,
+    'https://example.com/test-schema',
+    'Link should be updated',
+  );
+
+  console.log(
+    `Successfully updated unlocked schema variant with new category: ${updateResponse.data.category}`,
+  );
+
+  return updateResponse.data;
+}
+
+Deno.test('Schemas API - List and Find Schemas', async () => {
   try {
     const { api, config } = await createTestClient();
 
@@ -25,7 +156,7 @@ Deno.test("Schemas API - List and Find Schemas", async () => {
       const createChangeSetResponse = await api.changeSets.createChangeSet(
         config.workspaceId,
         {
-          changeSetName: "schema_test_changeset",
+          changeSetName: 'schema_test_changeset',
         },
       );
 
@@ -46,7 +177,7 @@ Deno.test("Schemas API - List and Find Schemas", async () => {
       assertExists(listSchemasResponse.data.schemas);
 
       if (listSchemasResponse.data.schemas.length === 0) {
-        console.warn("No schemas found in workspace, test is limited");
+        console.warn('No schemas found in workspace, test is limited');
         return;
       }
 
@@ -69,12 +200,11 @@ Deno.test("Schemas API - List and Find Schemas", async () => {
       assertEquals(
         findSchemaResponse.status,
         200,
-        "Find schema response status should be 200",
+        'Find schema response status should be 200',
       );
 
       // Check if our schema is in the results
-      const schemaFound =
-        findSchemaResponse.data.schemaId === firstSchema.schemaId;
+      const schemaFound = findSchemaResponse.data.schemaId === firstSchema.schemaId;
 
       assertEquals(
         schemaFound,
@@ -84,7 +214,7 @@ Deno.test("Schemas API - List and Find Schemas", async () => {
 
       // Ensure we install the schema if it doesn't exist so we can guarantee we can get the schema details
       await api.components.createComponent(config.workspaceId, changeSetId, {
-        name: "Ensuring Schema Installed",
+        name: 'Ensuring Schema Installed',
         schemaName: firstSchema.schemaName,
       });
 
@@ -97,26 +227,24 @@ Deno.test("Schemas API - List and Find Schemas", async () => {
       assertEquals(getSchemaResponse.status, 200);
       assertEquals(getSchemaResponse.data.name, firstSchema.schemaName); // May need to adjust this based on actual response
 
-      // Test getting schema variant if available
       if (
-        getSchemaResponse.data.variants &&
-        getSchemaResponse.data.variants.length > 0
+        getSchemaResponse.data.variantIds &&
+        getSchemaResponse.data.variantIds.length > 0
       ) {
-        const variant = getSchemaResponse.data.variants[0];
+        const variantId = getSchemaResponse.data.variantIds[0];
 
         const getVariantResponse = await api.schemas.getSchemaVariant(
           config.workspaceId,
           changeSetId,
           firstSchema.schemaId,
-          variant.id,
+          variantId,
         );
 
         assertEquals(getVariantResponse.status, 200);
-        assertEquals(getVariantResponse.data.id, variant.id);
-        assertEquals(getVariantResponse.data.schema_id, firstSchema.schemaId);
+        assertEquals(getVariantResponse.data.variantId, variantId);
 
         console.log(
-          `Successfully retrieved schema variant with ID: ${variant.id}`,
+          `Successfully retrieved schema variant with ID: ${variantId}`,
         );
       }
     } finally {
@@ -134,91 +262,345 @@ Deno.test("Schemas API - List and Find Schemas", async () => {
   }
 });
 
-Deno.test(
-  "Schemas API - Ensure we don't get a 202 on finding and getting a schema",
-  async () => {
+Deno.test("Schemas API - Ensure we don't get a 202 on finding and getting a schema", async () => {
+  try {
+    const { api, config } = await createTestClient();
+
+    const createdChangeSetIds: string[] = [];
+
     try {
-      const { api, config } = await createTestClient();
+      // Create a change set for testing
+      const createChangeSetResponse = await api.changeSets.createChangeSet(
+        config.workspaceId,
+        {
+          changeSetName: 'schema_test_changeset',
+        },
+      );
 
-      const createdChangeSetIds: string[] = [];
+      assertEquals(createChangeSetResponse.status, 200);
+      assertExists(createChangeSetResponse.data.changeSet);
+      const changeSetId = createChangeSetResponse.data.changeSet.id;
+      createdChangeSetIds.push(changeSetId);
 
-      try {
-        // Create a change set for testing
-        const createChangeSetResponse = await api.changeSets.createChangeSet(
-          config.workspaceId,
-          {
-            changeSetName: "schema_test_changeset",
-          },
-        );
+      console.log(`Created change set with ID: ${changeSetId}`);
 
-        assertEquals(createChangeSetResponse.status, 200);
-        assertExists(createChangeSetResponse.data.changeSet);
-        const changeSetId = createChangeSetResponse.data.changeSet.id;
-        createdChangeSetIds.push(changeSetId);
+      const findSchemaResponse = await api.schemas.findSchema(
+        config.workspaceId,
+        { name: 'AWS::Neptune::DBCluster' },
+        changeSetId,
+      );
 
-        console.log(`Created change set with ID: ${changeSetId}`);
+      assertEquals(
+        findSchemaResponse.status,
+        200,
+        'Find schema response status should be 200',
+      );
+      assertEquals(
+        findSchemaResponse.data.schemaName,
+        'AWS::Neptune::DBCluster',
+      );
+      assertEquals(findSchemaResponse.data.category, 'AWS::Neptune');
+      assertEquals(findSchemaResponse.data.installed, false);
 
-        const findSchemaResponse = await api.schemas.findSchema(
-          config.workspaceId,
-          { name: "AWS::Neptune::DBCluster" },
-          changeSetId,
-        );
+      const getSchemaResponse = await api.schemas.getSchema(
+        config.workspaceId,
+        changeSetId,
+        findSchemaResponse.data.schemaId,
+      );
+      assertEquals(
+        getSchemaResponse.status,
+        200,
+        'Get schema response status should be 200',
+      );
+      assertEquals(
+        getSchemaResponse.data.name,
+        'AWS::Neptune::DBCluster',
+        'Ensure we have a schema name that matches',
+      );
 
-        assertEquals(
-          findSchemaResponse.status,
-          200,
-          "Find schema response status should be 200",
-        );
-        assertEquals(
-          findSchemaResponse.data.schemaName,
-          "AWS::Neptune::DBCluster",
-        );
-        assertEquals(findSchemaResponse.data.category, "AWS::Neptune");
-        assertEquals(findSchemaResponse.data.installed, false);
+      const getDefaultSchemaResponse = await api.schemas.getDefaultSchemaVariant(
+        config.workspaceId,
+        changeSetId,
+        findSchemaResponse.data.schemaId,
+      );
+      assertEquals(
+        getDefaultSchemaResponse.status,
+        200,
+        'Get schema response status should be 200',
+      );
+    } finally {
+      // Clean up any change sets
+      await cleanupTestResources(
+        api,
+        config.workspaceId,
+        createdChangeSetIds,
+      );
+    }
+  } catch (error: unknown) {
+    if (error instanceof ConfigError) {
+      console.warn(
+        `Skipping test due to configuration error: ${error.message}`,
+      );
+      return;
+    }
+    throw error;
+  }
+});
 
-        const getSchemaResponse = await api.schemas.getSchema(
-          config.workspaceId,
-          changeSetId,
-          findSchemaResponse.data.schemaId,
-        );
-        assertEquals(
-          getSchemaResponse.status,
-          200,
-          "Get schema response status should be 200",
-        );
-        assertEquals(
-          getSchemaResponse.data.name,
-          "AWS::Neptune::DBCluster",
-          "Ensure we have a schema name that matches",
-        );
+Deno.test('Schemas API - Unlocking a schema', async () => {
+  try {
+    const { api, config } = await createTestClient();
 
-        const getDefaultSchemaResponse =
-          await api.schemas.getDefaultSchemaVariant(
-            config.workspaceId,
-            changeSetId,
-            findSchemaResponse.data.schemaId,
-          );
-        assertEquals(
-          getDefaultSchemaResponse.status,
-          200,
-          "Get schema response status should be 200",
-        );
-      } finally {
-        // Clean up any change sets
-        await cleanupTestResources(
-          api,
-          config.workspaceId,
-          createdChangeSetIds,
-        );
-      }
-    } catch (error: unknown) {
-      if (error instanceof ConfigError) {
-        console.warn(
-          `Skipping test due to configuration error: ${error.message}`,
-        );
+    const createdChangeSetIds: string[] = [];
+
+    try {
+      // Create a change set for testing
+      const createChangeSetResponse = await api.changeSets.createChangeSet(
+        config.workspaceId,
+        {
+          changeSetName: 'unlock_schema_test_changeset',
+        },
+      );
+
+      assertEquals(createChangeSetResponse.status, 200);
+      assertExists(createChangeSetResponse.data.changeSet);
+      const changeSetId = createChangeSetResponse.data.changeSet.id;
+      createdChangeSetIds.push(changeSetId);
+
+      console.log(`Created change set with ID: ${changeSetId}`);
+
+      // Find an installed schema
+      const schema = await findInstalledSchema(api, config.workspaceId, changeSetId);
+      if (!schema) {
+        console.warn('Test is limited - no installed schemas found');
         return;
       }
-      throw error;
+
+      // Get the schema details to find its default variant
+      const getSchemaResponse = await api.schemas.getSchema(
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+      );
+      assertEquals(getSchemaResponse.status, 200);
+      assertExists(getSchemaResponse.data.defaultVariantId);
+
+      const defaultVariantId = getSchemaResponse.data.defaultVariantId;
+
+      // Get the default variant to check if it's locked
+      const getVariantResponse = await api.schemas.getSchemaVariant(
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+        defaultVariantId,
+      );
+
+      assertEquals(getVariantResponse.status, 200);
+      assertExists(getVariantResponse.data);
+
+      console.log(
+        `Default variant is locked: ${getVariantResponse.data.isLocked}`,
+      );
+
+      // Unlock the schema
+      const unlockedData = await unlockSchema(
+        api,
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+      );
+
+      assertEquals(
+        unlockedData.schemaId,
+        schema.schemaId,
+        'Schema ID should match',
+      );
+
+      // If the original variant was locked, verify we got a new variant
+      if (getVariantResponse.data.isLocked) {
+        assertEquals(
+          unlockedData.unlockedVariantId !== defaultVariantId,
+          true,
+          'Unlocked variant should be different from locked default variant',
+        );
+      } else {
+        // If it was already unlocked, we should get the same variant back
+        assertEquals(
+          unlockedData.unlockedVariantId,
+          defaultVariantId,
+          'Should return existing unlocked variant',
+        );
+      }
+    } finally {
+      // Clean up any change sets
+      await cleanupTestResources(api, config.workspaceId, createdChangeSetIds);
     }
-  },
-);
+  } catch (error: unknown) {
+    if (error instanceof ConfigError) {
+      console.warn(
+        `Skipping test due to configuration error: ${error.message}`,
+      );
+      return;
+    }
+    throw error;
+  }
+});
+
+Deno.test('Schemas API - Editing an unlocked schema with no components', async () => {
+  try {
+    const { api, config } = await createTestClient();
+
+    const createdChangeSetIds: string[] = [];
+
+    try {
+      // Create a change set for testing
+      const createChangeSetResponse = await api.changeSets.createChangeSet(
+        config.workspaceId,
+        {
+          changeSetName: 'edit_unlocked_schema_test_changeset',
+        },
+      );
+
+      assertEquals(createChangeSetResponse.status, 200);
+      assertExists(createChangeSetResponse.data.changeSet);
+      const changeSetId = createChangeSetResponse.data.changeSet.id;
+      createdChangeSetIds.push(changeSetId);
+
+      console.log(`Created change set with ID: ${changeSetId}`);
+
+      // Find an installed schema
+      const schema = await findInstalledSchema(api, config.workspaceId, changeSetId);
+      if (!schema) {
+        console.warn('Test is limited - no installed schemas found');
+        return;
+      }
+
+      // Unlock the schema
+      const unlockedData = await unlockSchema(
+        api,
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+      );
+
+      // Update the unlocked variant with test values
+      await updateSchemaVariantWithTestValues(
+        api,
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+        unlockedData.unlockedVariantId,
+        unlockedData.unlockedVariant.displayName,
+      );
+    } finally {
+      // Clean up any change sets
+      await cleanupTestResources(api, config.workspaceId, createdChangeSetIds);
+    }
+  } catch (error: unknown) {
+    if (error instanceof ConfigError) {
+      console.warn(
+        `Skipping test due to configuration error: ${error.message}`,
+      );
+      return;
+    }
+    throw error;
+  }
+});
+
+Deno.test('Schemas API - Editing an unlocked schema with components', async () => {
+  try {
+    const { api, config } = await createTestClient();
+
+    const createdChangeSetIds: string[] = [];
+
+    try {
+      // Create a change set for testing
+      const createChangeSetResponse = await api.changeSets.createChangeSet(
+        config.workspaceId,
+        {
+          changeSetName: 'edit_unlocked_schema_with_components_changeset',
+        },
+      );
+
+      assertEquals(createChangeSetResponse.status, 200);
+      assertExists(createChangeSetResponse.data.changeSet);
+      const changeSetId = createChangeSetResponse.data.changeSet.id;
+      createdChangeSetIds.push(changeSetId);
+
+      console.log(`Created change set with ID: ${changeSetId}`);
+
+      // Find an installed schema
+      const schema = await findInstalledSchema(api, config.workspaceId, changeSetId);
+      if (!schema) {
+        console.warn('Test is limited - no installed schemas found');
+        return;
+      }
+
+      // Create three components before unlocking
+      console.log('Creating 3 components before unlocking...');
+      for (let i = 1; i <= 3; i++) {
+        const createComponentResponse = await api.components.createComponent(
+          config.workspaceId,
+          changeSetId,
+          {
+            name: `Test Component Before Unlock ${i}`,
+            schemaName: schema.schemaName,
+          },
+        );
+        assertEquals(createComponentResponse.status, 200);
+        console.log(
+          `Created component ${i}: ${createComponentResponse.data.component.id}`,
+        );
+      }
+
+      // Unlock the schema
+      const unlockedData = await unlockSchema(
+        api,
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+      );
+
+      // Update the unlocked variant with test values
+      await updateSchemaVariantWithTestValues(
+        api,
+        config.workspaceId,
+        changeSetId,
+        schema.schemaId,
+        unlockedData.unlockedVariantId,
+        unlockedData.unlockedVariant.displayName,
+      );
+
+      // Create three more components after editing using the working copy
+      console.log('Creating 3 components after editing...');
+      for (let i = 1; i <= 3; i++) {
+        const createComponentResponse = await api.components.createComponent(
+          config.workspaceId,
+          changeSetId,
+          {
+            name: `Test Component After Edit ${i}`,
+            schemaName: schema.schemaName,
+            useWorkingCopy: true,
+          },
+        );
+        assertEquals(createComponentResponse.status, 200);
+        console.log(
+          `Created component ${i}: ${createComponentResponse.data.component.id}`,
+        );
+      }
+
+      console.log('Successfully created components before and after editing unlocked schema');
+    } finally {
+      // Clean up any change sets
+      await cleanupTestResources(api, config.workspaceId, createdChangeSetIds);
+    }
+  } catch (error: unknown) {
+    if (error instanceof ConfigError) {
+      console.warn(
+        `Skipping test due to configuration error: ${error.message}`,
+      );
+      return;
+    }
+    throw error;
+  }
+});

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -140,6 +140,8 @@ pub enum ComponentsError {
         "Cannot set secrets directly on a non-secret defining component, use attributes instead"
     )]
     NotSecretDefiningComponent(ComponentId),
+    #[error("No working copy exists for schema with id: {0}")]
+    NoWorkingCopy(SchemaId),
     #[error("output socket error: {0}")]
     OutputSocket(#[from] dal::socket::output::OutputSocketError),
     #[error("prop error: {0}")]


### PR DESCRIPTION
## How does this PR change the system?

Changes two Luminork API endpoints to support the ability to create components using the unlocked schema variant or the default variant. We are calling this `useWorkingCopy`

- `create_component` has been modified to take an optional boolean parameter `useWorkingCopy` and adjust which schema variant is used to create the component accordingly. If`useWorkingCopy` is set to true but no unlocked variant exists yet, the endpoint throws an error.
- `update_schema_variant` has been modified to allow for the updated schema variant id after regeneration to be different than the previous schema variant id, which happens when the schema variant is updated with components of the variant existing. The newer variant id is used for the rest of the endpoint.

To ensure that these changes to the Luminork endpoint did not break anything, extensive testing (manual and automated) was required. This led to revamping sections of the `si-luminork-api-tests` accordingly.

This work also involved investigation of the other MCP tools to see if any of them would need similar adjustments - at this time such changes are not necessary.

#### Screenshots:

<img width="1861" height="867" alt="Screenshot 2025-10-15 at 5 46 51 PM" src="https://github.com/user-attachments/assets/959c4556-c10e-421e-bc4b-d110aa76073d" />

#### Out of Scope:

We are deliberately not adding the ability to create a component for a specific schema variant by its id. Users of the API can only create a component with the default variant or the working copy.

We may want additional Luminork tests in the future, the ones added here are just specific to these changes.

The corresponding changes to the MCP `componentCreate` tool to allow for useWorkingCopy will be [in another PR](https://github.com/systeminit/si/pull/7522) to ensure that they only land after these changes are live.

## How was it tested?

A LOT of manual and automated testing! Ensured that the MCP tool will work whether it is the new or old version. Ensured that the Luminork API endpoints also work as they do now with these changes.