### PR TITLE
Using deployment mvs for "add component" list

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -31,6 +31,7 @@ import {
   ConnStatusFn,
 } from "@/workers/types/dbinterface";
 import {
+  CachedDefaultVariant,
   Connection,
   EntityKind,
   GlobalEntity,
@@ -42,6 +43,7 @@ import { DefaultMap } from "@/utils/defaultmap";
 import * as rainbow from "@/newhotness/logic_composables/rainbow_counter";
 import { sdfApiInstance as sdf } from "@/store/apis.web";
 import { WorkspaceMetadata, WorkspacePk } from "@/api/sdf/dal/workspace";
+import { SchemaId } from "@/api/sdf/dal/schema";
 import {
   cachedAppEmitter,
   SHOW_CACHED_APP_NOTIFICATION_EVENT,
@@ -507,6 +509,42 @@ export const bifrostList = async <T>(args: {
   console.log("🌈 bifrost queryList", args.kind, args.id, end - start, "ms");
   if (!maybeAtomDoc) return null;
   return reactive(JSON.parse(maybeAtomDoc));
+};
+
+export const getKind = async <T>(args: {
+  workspaceId: WorkspacePk;
+  changeSetId: ChangeSetId;
+  kind: Exclude<EntityKind, GlobalEntity>;
+}): Promise<T[]> => {
+  if (!initCompleted.value) throw new Error("You must wait for initialization");
+
+  const start = performance.now();
+  const records = await db.getKind(
+    args.workspaceId,
+    args.changeSetId,
+    args.kind,
+  );
+  const end = performance.now();
+  // eslint-disable-next-line no-console
+  console.log("🌈 bifrost getKind", end - start, "ms");
+  return records.map((r) => JSON.parse(r));
+};
+
+export const getDefaultSchemaVariants = async (): Promise<
+  Record<SchemaId, CachedDefaultVariant>
+> => {
+  if (!initCompleted.value) throw new Error("You must wait for initialization");
+
+  const start = performance.now();
+  const records = await db.getDefaultSchemaVariants();
+  const end = performance.now();
+  // eslint-disable-next-line no-console
+  console.log("🌈 bifrost getDefaultSchemaVariants", end - start, "ms");
+  const parsed: Record<SchemaId, CachedDefaultVariant> = {};
+  Object.entries(records).forEach(([k, v]) => {
+    parsed[k] = JSON.parse(v);
+  });
+  return parsed;
 };
 
 /**

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -339,6 +339,18 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
+  async getKind(workspaceId, changeSetId, kind) {
+    return await withLeader(
+      async (remote) => await remote.getKind(workspaceId, changeSetId, kind),
+    );
+  },
+
+  async getDefaultSchemaVariants() {
+    return await withLeader(
+      async (remote) => await remote.getDefaultSchemaVariants(),
+    );
+  },
+
   async queryAttributes(
     workspaceId: WorkspacePk,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -127,7 +127,7 @@ export type Listable =
   | EntityKind.ComponentList
   | EntityKind.IncomingConnectionsList
   | EntityKind.ViewList;
-export type Gettable = Exclude<EntityKind, Listable>;
+export type Gettable = Exclude<Exclude<EntityKind, Listable>, GlobalEntity>;
 
 export interface QueryAttributesTerm {
   key: string;
@@ -218,6 +218,12 @@ export interface SharedDBInterface {
     kind: Listable,
     id: Id,
   ): Promise<string>;
+  getKind(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+    kind: Exclude<EntityKind, GlobalEntity>,
+  ): Promise<string[]>;
+  getDefaultSchemaVariants(): Promise<Record<string, string>>;
   /**
    * Query AttributeTree MVs in a changeset, looking for components that match the given terms.
    *
@@ -333,6 +339,12 @@ export interface TabDBInterface {
     kind: Gettable,
     id: Id,
   ): boolean;
+  getDefaultSchemaVariants(): Record<string, string>;
+  getKind(
+    workspaceId: string,
+    changeSetId: ChangeSetId,
+    kind: Exclude<EntityKind, GlobalEntity>,
+  ): string[];
   getList(
     workspaceId: string,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -27,7 +27,6 @@ export enum EntityKind {
   ActionViewList = "ActionViewList",
   AttributeTree = "AttributeTree",
   AuditLogsForComponent = "AuditLogsForComponent",
-  CachedSchemas = "CachedSchemas",
   Component = "Component",
   ComponentDiff = "ComponentDiff",
   ComponentDetails = "ComponentDetails",
@@ -48,7 +47,6 @@ export enum EntityKind {
   QueryAttributes = "QueryAttributes",
   SchemaMembers = "SchemaMembers",
   SchemaVariant = "SchemaVariant",
-  SchemaVariantCategories = "SchemaVariantCategories",
   SecretDefinition = "SecretDefinition",
   View = "View",
   ViewComponentList = "ViewComponentList",
@@ -60,7 +58,9 @@ export enum EntityKind {
   LuminorkSchemaVariant = "LuminorkSchemaVariant",
   // DEPLOYMENT aka GLOBAL
   CachedSchema = "CachedSchema",
+  CachedSchemaVariant = "CachedSchemaVariant",
   CachedDefaultVariant = "CachedDefaultVariant",
+  DefaultSchemaIdAndVariant = "DefaultSchemaIdAndVariant",
 }
 
 export const GLOBAL_ENTITIES = [
@@ -148,23 +148,6 @@ export interface RawViewList {
   views: Reference<EntityKind.View>[];
 }
 
-export interface BifrostSchemaVariantCategories {
-  id: string; // workspace id
-  categories: Categories;
-}
-
-export interface EddaSchemaVariantCategories {
-  id: string; // workspace id
-  categories: Array<{
-    displayName: string;
-    schemaVariants: Array<{
-      type: "uninstalled" | "installed";
-      id: string;
-    }>;
-  }>;
-  uninstalled: Record<string, UninstalledVariant>;
-}
-
 export interface BifrostActionViewList {
   id: ChangeSetId;
   actions: ActionProposedView[];
@@ -247,7 +230,10 @@ export interface UninstalledVariant {
   isLocked: boolean;
 }
 
-export type CategoryVariant = SchemaVariant | UninstalledVariant;
+export type CategoryVariant =
+  | SchemaVariant
+  | UninstalledVariant
+  | CachedDefaultVariant;
 
 export type Categories = {
   displayName: string;
@@ -729,4 +715,53 @@ export interface AuditLog {
     role?: null | string;
     tokenId?: null | string;
   };
+}
+
+export interface CachedSchema {
+  id: string;
+  name: string;
+  defaultVariantId: string;
+  variantIds: string[];
+}
+
+export interface SchemaProp {
+  propId: PropId;
+  name: string;
+  propType: string;
+  description?: string;
+  children?: SchemaProp[];
+  validationFormat?: string;
+  defaultValue?: JSON | number | string | boolean;
+  hidden?: boolean;
+  docLink?: string;
+}
+
+export interface CachedSchemaVariant {
+  id: SchemaVariantId;
+  variantId: SchemaVariantId;
+  displayName: string;
+  category: string;
+  color: string;
+  isLocked: boolean;
+  description?: string;
+  link?: string;
+  assetFuncId: FuncId;
+  variantFuncIds: FuncId[];
+  isDefaultVariant: boolean;
+  domainProps?: SchemaProp;
+}
+
+export interface CachedDefaultVariant {
+  id: SchemaId; // <<-- notice the difference!
+  variantId: SchemaVariantId;
+  displayName: string;
+  category: string;
+  color: string;
+  isLocked: boolean;
+  description?: string;
+  link?: string;
+  assetFuncId: FuncId;
+  variantFuncIds: FuncId[];
+  isDefaultVariant: boolean;
+  domainProps?: SchemaProp;
 }


### PR DESCRIPTION
## How does this PR change the system?

Now that we have `DefaultSchemaVariant` MVs we do not need the `SchemaVariantCategories` MV, we can just use all the `SchemaVariant` MVs we have.

We can delete the ch0nky `SchemaVariantCategories` MV entirely!

## How was it tested?
NOTE: my [bracket] additions there are just a sanity check to make sure it wasn't showing dupes and showed installed over defaults... that won't be in the finished product.

<img width="695" height="521" alt="image" src="https://github.com/user-attachments/assets/1b56723d-d174-4c5c-96c2-2f398d566f55" />

1. Install a "default" schema, make sure it creates a component
2. Open the list, see that one you installed be labelled as "installed"
3. Install a "installed" schema, make sure it creates a component
4. Unlock an installed schema, make sure you see installed and editing

Less ch0nky!!!
<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNmZucmJwaWIwZ2EzeTk3cWlueDhnbGZmOTdzZmZvMmNvYjF1dTNnZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/49fOKNkUD7Bgje7G5p/giphy.gif"/>