### PR TITLE
feat(clover): add azure mgmt funcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,7 +3267,6 @@ dependencies = [
  "forklift-server",
  "innit-client",
  "si-service",
- "telemetry-utils",
 ]
 
 [[package]]

--- a/bin/clover/src/pipelines/azure/funcs.ts
+++ b/bin/clover/src/pipelines/azure/funcs.ts
@@ -45,7 +45,24 @@ export const CODE_GENERATION_FUNC_SPECS = {} as const satisfies Record<
   FuncSpecInfo
 >;
 
-export const MANAGEMENT_FUNCS = {} as const satisfies Record<
+export const MANAGEMENT_FUNCS = {
+  "Discover on Azure": {
+    id: "a82d730eac534eac4ce84954a8c1a19a817553c23bdccfcc5fc33f14c21ca923",
+    backendKind: "management",
+    responseType: "management",
+    displayName: "Discover on Azure",
+    path: "./src/pipelines/azure/funcs/management/discover.ts",
+    handlers: ["list", "read"],
+  },
+  "Import from Azure": {
+    id: "61d66b00cf1db372a49903bdd9c2f864ad0da606c320604623acdd72c4df6c37",
+    backendKind: "management",
+    responseType: "management",
+    displayName: "Import from Azure",
+    path: "./src/pipelines/azure/funcs/management/import.ts",
+    handlers: ["read"],
+  },
+} as const satisfies Record<
   string,
   FuncSpecInfo & { handlers: CfHandlerKind[] }
 >;

--- a/bin/clover/src/pipelines/azure/funcs/management/discover.ts
+++ b/bin/clover/src/pipelines/azure/funcs/management/discover.ts
@@ -1,0 +1,264 @@
+async function main({
+  thisComponent,
+}: Input): Promise<Output> {
+  const component = thisComponent;
+  const tenantId = requestStorage.getEnv("AZURE_TENANT_ID");
+  const clientId = requestStorage.getEnv("AZURE_CLIENT_ID");
+  const clientSecret = requestStorage.getEnv("AZURE_CLIENT_SECRET");
+
+  if (!tenantId || !clientId || !clientSecret) {
+    throw new Error("Azure credentials not found");
+  }
+
+  const subscriptionId = _.get(
+    component.properties,
+    ["domain", "subscriptionId"],
+    "",
+  );
+  const resourceGroup = _.get(
+    component.properties,
+    ["domain", "resourceGroup"],
+    "",
+  );
+  const resourceType = _.get(
+    component.properties,
+    ["domain", "extra", "AzureResourceType"],
+    "",
+  );
+  const apiVersion = _.get(
+    component.properties,
+    ["domain", "extra", "apiVersion"],
+    "2023-01-01",
+  );
+  const propUsageMapJson = _.get(
+    component.properties,
+    ["domain", "extra", "PropUsageMap"],
+    "{}",
+  );
+
+  if (!subscriptionId) {
+    return {
+      status: "error",
+      message: "subscriptionId is required in domain",
+    };
+  }
+
+  if (!resourceType) {
+    return {
+      status: "error",
+      message: "AzureResourceType not found in domain.extra",
+    };
+  }
+
+  // Convert Azure::Service::Resource to Microsoft.Service/resources format
+  const parts = resourceType.split("::");
+  if (parts.length !== 3 || parts[0] !== "Azure") {
+    return {
+      status: "error",
+      message: `Invalid Azure resource type format: ${resourceType}`,
+    };
+  }
+
+  const providerNamespace = `Microsoft.${parts[1]}`;
+  const resourceTypeName = parts[2];
+
+  // Parse PropUsageMap to get updatable properties
+  let updatableProperties: Set<string>;
+  let createOnlyProperties: Set<string>;
+  try {
+    const propUsageMap = JSON.parse(propUsageMapJson);
+    updatableProperties = new Set(propUsageMap.updatable || []);
+    createOnlyProperties = new Set(propUsageMap.createOnly || []);
+  } catch (e) {
+    console.warn(
+      `Failed to parse PropUsageMap for ${resourceType}, using empty set:`,
+      e,
+    );
+    updatableProperties = new Set();
+    createOnlyProperties = new Set();
+  }
+
+  console.log(`Discovering ${resourceType} resources...`);
+
+  const token = await getAzureToken(tenantId, clientId, clientSecret);
+
+  // Build refinement filter from domain properties
+  const refinement = _.cloneDeep(thisComponent.properties.domain);
+  delete refinement["extra"];
+  delete refinement["location"];
+  // Remove any empty values, as they are never refinements
+  for (const [key, value] of Object.entries(refinement)) {
+    if (_.isEmpty(value)) {
+      delete refinement[key];
+    } else if (_.isPlainObject(value)) {
+      refinement[key] = _.pickBy(
+        value,
+        (v) => !_.isEmpty(v) || _.isNumber(v) || _.isBoolean(v),
+      );
+      if (_.isEmpty(refinement[key])) {
+        delete refinement[key];
+      }
+    }
+  }
+
+  const listUrl =
+    `https://management.azure.com/subscriptions/${subscriptionId}/providers/${providerNamespace}/${resourceTypeName}?api-version=${apiVersion}`;
+
+  // Handle pagination with nextLink
+  let resources: any[] = [];
+  let nextLink: string | null = listUrl;
+
+  while (nextLink) {
+    const listResponse = await fetch(nextLink, {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+      },
+    });
+
+    if (!listResponse.ok) {
+      const errorText = await listResponse.text();
+      return {
+        status: "error",
+        message:
+          `Azure API Error: ${listResponse.status} ${listResponse.statusText} - ${errorText}`,
+      };
+    }
+
+    const listData = await listResponse.json();
+    resources = resources.concat(listData.value || []);
+    nextLink = listData.nextLink || null;
+
+    if (nextLink) {
+      console.log(`Fetching next page: ${nextLink}`);
+    }
+  }
+
+  console.log(`Found ${resources.length} resources`);
+
+  const create: Output["ops"]["create"] = {};
+  const actions = {};
+  let importCount = 0;
+
+  for (const resource of resources) {
+    const resourceId = resource.id;
+
+    console.log(`Importing ${resourceId}`);
+
+    // Fetch the full resource details
+    const resourceUrl =
+      `https://management.azure.com${resourceId}?api-version=${apiVersion}`;
+    const resourceResponse = await fetch(resourceUrl, {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+      },
+    });
+
+    if (!resourceResponse.ok) {
+      console.log(
+        `Failed to fetch ${resourceId}, skipping (status: ${resourceResponse.status})`,
+      );
+      continue;
+    }
+
+    const fullResource = await resourceResponse.json();
+
+    // Build domain by only including updatable properties from the resource
+    // CreateOnly properties are immutable on existing resources, so we don't copy them
+    const domainProperties: Record<string, any> = {
+      subscriptionId,
+      resourceGroup,
+    };
+
+    // Copy updatable properties from the resource
+    for (const [key, value] of Object.entries(fullResource)) {
+      if (updatableProperties.has(key) && value != null) {
+        domainProperties[key] = value;
+      }
+    }
+
+    const properties = {
+      si: {
+        resourceId,
+      },
+      domain: {
+        ...domainProperties,
+        extra: component.properties?.domain?.extra || {
+          AzureResourceType: resourceType,
+          apiVersion: apiVersion,
+        },
+      },
+      resource: fullResource,
+    };
+
+    // Apply refinement filter
+    if (_.isEmpty(refinement) || _.isMatch(properties.domain, refinement)) {
+      const newAttributes: Output["ops"]["create"][string]["attributes"] = {};
+      for (const [skey, svalue] of Object.entries(component.sources || {})) {
+        // Skip createOnly attributes - they can only be set on new components
+        // Extract the property name from the path (e.g., "/domain/location" -> "location")
+        const propName = skey.split("/").pop();
+        if (propName && createOnlyProperties.has(propName)) {
+          continue;
+        }
+        newAttributes[skey] = {
+          $source: svalue,
+        };
+      }
+
+      create[resourceId] = {
+        kind: resourceType,
+        properties,
+        attributes: newAttributes,
+      };
+      actions[resourceId] = {
+        remove: ["create"],
+      };
+      importCount++;
+    } else {
+      console.log(
+        `Skipping import of ${resourceId}; it did not match refinements`,
+      );
+    }
+  }
+
+  return {
+    status: "ok",
+    message: `Discovered ${importCount} ${resourceType} resources`,
+    ops: {
+      create,
+      actions,
+    },
+  };
+}
+
+async function getAzureToken(
+  tenantId: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<string> {
+  const tokenUrl =
+    `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: "https://management.azure.com/.default",
+    grant_type: "client_credentials",
+  });
+
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to get Azure token: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}

--- a/bin/clover/src/pipelines/azure/funcs/management/import.ts
+++ b/bin/clover/src/pipelines/azure/funcs/management/import.ts
@@ -1,0 +1,196 @@
+async function main({
+  thisComponent,
+}: Input): Promise<Output> {
+  const component = thisComponent;
+  const tenantId = requestStorage.getEnv("AZURE_TENANT_ID");
+  const clientId = requestStorage.getEnv("AZURE_CLIENT_ID");
+  const clientSecret = requestStorage.getEnv("AZURE_CLIENT_SECRET");
+
+  if (!tenantId || !clientId || !clientSecret) {
+    throw new Error("Azure credentials not found");
+  }
+
+  const resourceId = _.get(component.properties, ["si", "resourceId"], "");
+  const resourceType = _.get(
+    component.properties,
+    ["domain", "extra", "AzureResourceType"],
+    "",
+  );
+  const apiVersion = _.get(
+    component.properties,
+    ["domain", "extra", "apiVersion"],
+    "2023-01-01",
+  );
+  const propUsageMapJson = _.get(
+    component.properties,
+    ["domain", "extra", "PropUsageMap"],
+    "{}",
+  );
+
+  if (!resourceId) {
+    return {
+      status: "error",
+      message: "Resource ID not found in si.resourceId",
+    };
+  }
+
+  if (!resourceType) {
+    return {
+      status: "error",
+      message: "AzureResourceType not found in domain.extra",
+    };
+  }
+
+  // Parse PropUsageMap to get updatable properties
+  let updatableProperties: Set<string>;
+  let createOnlyProperties: Set<string>;
+  try {
+    const propUsageMap = JSON.parse(propUsageMapJson);
+    updatableProperties = new Set(propUsageMap.updatable || []);
+    createOnlyProperties = new Set(propUsageMap.createOnly || []);
+  } catch (e) {
+    console.warn(
+      `Failed to parse PropUsageMap for ${resourceType}, using empty set:`,
+      e,
+    );
+    updatableProperties = new Set();
+    createOnlyProperties = new Set();
+  }
+
+  console.log(`Importing Azure resource: ${resourceId}`);
+
+  const token = await getAzureToken(tenantId, clientId, clientSecret);
+  const url =
+    `https://management.azure.com${resourceId}?api-version=${apiVersion}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Authorization": `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    return {
+      status: "error",
+      message:
+        `Azure API Error: ${response.status} ${response.statusText} - ${errorText}`,
+    };
+  }
+
+  const resource = await response.json();
+
+  // Build domain properties by only including writable properties from the resource
+  const resourceDomainProperties: Record<string, any> = {
+    subscriptionId: _.get(
+      component.properties,
+      ["domain", "subscriptionId"],
+      "",
+    ),
+    resourceGroup: _.get(component.properties, ["domain", "resourceGroup"], ""),
+  };
+
+  // Copy updatable properties from the resource
+  for (const [key, value] of Object.entries(resource)) {
+    if (updatableProperties.has(key) && value != null) {
+      resourceDomainProperties[key] = value;
+    }
+  }
+
+  const resourcePayload = _.get(
+    component.properties,
+    ["resource", "payload"],
+    "",
+  );
+
+  // Merge properties: start with existing, overlay resource properties
+  const properties = {
+    ...component.properties,
+    domain: {
+      extra: component.properties?.domain?.extra || {
+        AzureResourceType: resourceType,
+        apiVersion: apiVersion,
+      },
+      ...component.properties?.domain,
+      ...resourceDomainProperties,
+    },
+  };
+
+  // Only set resource if there's no existing payload
+  let needsRefresh = true;
+  if (!resourcePayload) {
+    properties.resource = resource;
+    needsRefresh = false;
+  }
+
+  const newAttributes: Output["ops"]["create"][string]["attributes"] = {};
+  for (const [skey, svalue] of Object.entries(component.sources || {})) {
+    // Skip createOnly attributes - they can only be set on new components
+    // Extract the property name from the path (e.g., "/domain/location" -> "location")
+    const propName = skey.split("/").pop();
+    if (propName && createOnlyProperties.has(propName)) {
+      continue;
+    }
+    newAttributes[skey] = {
+      $source: svalue,
+    };
+  }
+
+  const ops = {
+    update: {
+      self: {
+        properties,
+        attributes: newAttributes,
+      },
+    },
+    actions: {
+      self: {
+        remove: ["create"],
+        add: [] as string[],
+      },
+    },
+  };
+
+  if (needsRefresh) {
+    ops.actions.self.add.push("refresh");
+  } else {
+    ops.actions.self.remove.push("refresh");
+  }
+
+  return {
+    status: "ok",
+    message: `Imported ${resourceType}: ${resource.name}`,
+    ops,
+  };
+}
+
+async function getAzureToken(
+  tenantId: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<string> {
+  const tokenUrl =
+    `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: "https://management.azure.com/.default",
+    grant_type: "client_credentials",
+  });
+
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to get Azure token: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Adds import and discover funcs for Azure. I believe that the resource_value/domains are currently incorrect, but we are at least populating what we have here correctly.

Not that we needed to add back normalizing the only props to ensure we could build the PropUsageMap correctly.

This includes some flashy stuff like walking pagination and refinements, lifted without shame from AWS.

#### Screenshots:

<img width="482" height="156" alt="image" src="https://github.com/user-attachments/assets/db6a5555-d6c5-47c0-bbbf-c85011abd544" />

One discovered, one imported.

<img width="712" height="306" alt="image" src="https://github.com/user-attachments/assets/6f4f949e-c377-419b-ae6c-09d58962d053" />

## How was it tested?

Checkout them screenshots. This will not generate any changes for other providers.

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdleHV5bnVzOGNtaWxzcmJ4d2wydGh2OGJwNXpobDFvcTY5NTg5OHUyYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/qgQUggAC3Pfv687qPC/giphy.gif"/>