### PR TITLE
changing UI language to "Working Copy"

### DIFF
--- a/app/web/src/components/EditingPill.vue
+++ b/app/web/src/components/EditingPill.vue
@@ -6,7 +6,7 @@
       color: `#${text.toHex()}`,
     }"
   >
-    EDITING
+    Working Copy
   </div>
 </template>
 
@@ -29,7 +29,7 @@ watch(
 
 const text = computed(() => {
   const textBgHsl = primaryColor.value.toHsl();
-  textBgHsl.l = textBgHsl.l > 0.5 ? 0.08 : 0.95;
+  textBgHsl.l = textBgHsl.l > 0.5 ? 0 : 1;
   return tinycolor(textBgHsl);
 });
 </script>


### PR DESCRIPTION
## How does this PR change the system?

Changes the UI terminology to be in line with "Working Copy" from [these changes](https://github.com/systeminit/si/pull/7526) to Luminork.

#### Screenshots:

<img width="664" height="475" alt="Screenshot 2025-10-16 at 4 50 49 PM" src="https://github.com/user-attachments/assets/24ecb6b9-343b-4d03-bc43-6a79568583bf" />

#### Out of Scope:

We will likely change the design of the EditingPill in the future to be more accessible in terms of color/contrast.