### PR TITLE
Azure: generate network resources with circular types

### DIFF
--- a/bin/clover/deno.json
+++ b/bin/clover/deno.json
@@ -6,6 +6,7 @@
   },
   "imports": {
     "@apidevtools/json-schema-ref-parser": "npm:@apidevtools/json-schema-ref-parser@^11.9.3",
+    "@apidevtools/swagger-parser": "npm:@apidevtools/swagger-parser@^12.1.0",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
     "@std/assert": "jsr:@std/assert@^1.0.14",
     "@types/lodash": "npm:@types/lodash@^4.17.20",
@@ -13,6 +14,7 @@
     "json-schema-typed": "npm:json-schema-typed@^8.0.1",
     "lodash": "npm:lodash@^4.17.21",
     "openai": "npm:openai@^4.104.0",
+    "openapi-types": "npm:openapi-types@^12.1.3",
     "ulid": "https://deno.land/x/ulid@v0.3.0/mod.ts",
     "pluralize": "npm:pluralize@^8.0.0",
     "cf-db": "../../lib/jsr-systeminit/cf-db",

--- a/bin/clover/deno.lock
+++ b/bin/clover/deno.lock
@@ -12,6 +12,7 @@
     "jsr:@systeminit/remove-empty@*": "0.1.3",
     "npm:@apidevtools/json-schema-ref-parser@11.9.3": "11.9.3",
     "npm:@apidevtools/json-schema-ref-parser@^11.9.3": "11.9.3",
+    "npm:@apidevtools/swagger-parser@^12.1.0": "12.1.0_openapi-types@12.1.3_ajv@8.17.1",
     "npm:@hapi/hoek@9.3.0": "9.3.0",
     "npm:@hapi/topo@5.1.0": "5.1.0",
     "npm:@sideway/address@4.1.5": "4.1.5",
@@ -32,6 +33,7 @@
     "npm:lodash@4.17.21": "4.17.21",
     "npm:lodash@^4.17.21": "4.17.21",
     "npm:openai@^4.104.0": "4.104.0",
+    "npm:openapi-types@^12.1.3": "12.1.3",
     "npm:pluralize@8": "8.0.0",
     "npm:toml@*": "3.0.0"
   },
@@ -90,6 +92,31 @@
         "@jsdevtools/ono",
         "@types/json-schema",
         "js-yaml"
+      ]
+    },
+    "@apidevtools/json-schema-ref-parser@14.0.1": {
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "dependencies": [
+        "@types/json-schema",
+        "js-yaml"
+      ]
+    },
+    "@apidevtools/openapi-schemas@2.1.0": {
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
+    },
+    "@apidevtools/swagger-methods@3.0.2": {
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser@12.1.0_openapi-types@12.1.3_ajv@8.17.1": {
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "dependencies": [
+        "@apidevtools/json-schema-ref-parser@14.0.1",
+        "@apidevtools/openapi-schemas",
+        "@apidevtools/swagger-methods",
+        "ajv",
+        "ajv-draft-04",
+        "call-me-maybe",
+        "openapi-types"
       ]
     },
     "@hapi/hoek@9.3.0": {
@@ -177,6 +204,21 @@
         "humanize-ms"
       ]
     },
+    "ajv-draft-04@1.0.0_ajv@8.17.1": {
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dependencies": [
+        "ajv"
+      ]
+    },
+    "ajv@8.17.1": {
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
     "argparse@2.0.1": {
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
@@ -189,6 +231,9 @@
         "es-errors",
         "function-bind"
       ]
+    },
+    "call-me-maybe@1.0.2": {
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "combined-stream@1.0.8": {
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
@@ -259,8 +304,14 @@
         "yoctocolors"
       ]
     },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-json-patch@3.1.1": {
       "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+    },
+    "fast-uri@3.1.0": {
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
     },
     "figures@6.1.0": {
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
@@ -375,6 +426,9 @@
         "argparse"
       ]
     },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "json-schema-typed@8.0.1": {
       "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg=="
     },
@@ -424,6 +478,9 @@
         "node-fetch"
       ]
     },
+    "openapi-types@12.1.3": {
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
+    },
     "parse-ms@4.0.0": {
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
     },
@@ -444,6 +501,9 @@
       "dependencies": [
         "parse-ms"
       ]
+    },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "shebang-command@2.0.0": {
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
@@ -1259,6 +1319,7 @@
       "jsr:@cliffy/command@^1.0.0-rc.8",
       "jsr:@std/assert@^1.0.14",
       "npm:@apidevtools/json-schema-ref-parser@^11.9.3",
+      "npm:@apidevtools/swagger-parser@^12.1.0",
       "npm:@hapi/hoek@9.3.0",
       "npm:@hapi/topo@5.1.0",
       "npm:@sideway/address@4.1.5",
@@ -1270,6 +1331,7 @@
       "npm:json-schema-typed@^8.0.1",
       "npm:lodash@^4.17.21",
       "npm:openai@^4.104.0",
+      "npm:openapi-types@^12.1.3",
       "npm:pluralize@8"
     ]
   }

--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -72,7 +72,7 @@ function unexpandSchema(expanded: ExpandedSchemaSpec): SchemaSpec {
 function unexpandVariant(
   expanded: ExpandedSchemaVariantSpec,
 ): SchemaVariantSpec {
-  const { ...variant } = expanded;
+  const { superSchema: _, ...variant } = expanded;
   bfsPropTree(
     [
       variant.domain,

--- a/bin/clover/src/pipelines/aws/provider.ts
+++ b/bin/clover/src/pipelines/aws/provider.ts
@@ -1,9 +1,7 @@
 import { normalizeProperty } from "../../cfDb.ts";
 import { ExpandedPropSpecFor } from "../../spec/props.ts";
 import {
-  CfProperty,
   PipelineOptions,
-  PropertyNormalizationContext,
   PROVIDER_REGISTRY,
   ProviderConfig,
   ProviderFuncSpecs,
@@ -19,6 +17,7 @@ import {
 } from "./funcs.ts";
 import type { CfSchema } from "./schema.ts";
 import { generateAwsSpecs } from "./pipeline.ts";
+import { JSONSchema } from "../draft_07.ts";
 
 function cfCategory(schema: CfSchema): string {
   const [metaCategory, category] = schema.typeName.split("::");
@@ -49,10 +48,7 @@ function createDocLink(
   return docLink;
 }
 
-function awsNormalizeProperty(
-  prop: CfProperty,
-  _context: PropertyNormalizationContext,
-): CfProperty {
+function awsNormalizeProperty(prop: JSONSchema) {
   return normalizeProperty(prop);
 }
 

--- a/bin/clover/src/pipelines/azure/pipeline.ts
+++ b/bin/clover/src/pipelines/azure/pipeline.ts
@@ -56,7 +56,7 @@ async function getLatestAzureSpecs(options: PipelineOptions) {
       throw e;
     }
     processed++;
-    if (processed % 50 === 0) {
+    if (processed % 100 === 0) {
       console.log(`Processed ${processed} specs...`);
     }
   }

--- a/bin/clover/src/pipelines/azure/provider.ts
+++ b/bin/clover/src/pipelines/azure/provider.ts
@@ -1,8 +1,6 @@
 import {
-  CfProperty,
   FetchSchemaOptions,
   PipelineOptions,
-  PropertyNormalizationContext,
   PROVIDER_REGISTRY,
   ProviderConfig,
   SuperSchema,
@@ -17,6 +15,7 @@ import {
 import { normalizeAzureProperty } from "./spec.ts";
 import { generateAzureSpecs } from "./pipeline.ts";
 import { initAzureRestApiSpecsRepo } from "./schema.ts";
+import { JSONSchema } from "../draft_07.ts";
 
 async function azureFetchSchema(options: FetchSchemaOptions) {
   const specsRepo = initAzureRestApiSpecsRepo(options);
@@ -72,16 +71,8 @@ function azureIsChildRequired(
   return schema.requiredProperties.has(childName);
 }
 
-function azureNormalizeProperty(
-  prop: CfProperty,
-  _context: PropertyNormalizationContext,
-): CfProperty {
-  let propToNormalize = prop;
-  if ("properties" in prop && prop.properties && !prop.type) {
-    propToNormalize = { ...prop, type: "object" };
-  }
-
-  return normalizeAzureProperty(propToNormalize);
+function azureNormalizeProperty(prop: JSONSchema) {
+  return normalizeAzureProperty(prop);
 }
 
 async function azureLoadSchemas(options: PipelineOptions) {

--- a/bin/clover/src/pipelines/dummy/provider.ts
+++ b/bin/clover/src/pipelines/dummy/provider.ts
@@ -21,6 +21,7 @@ import { ExpandedPropSpecFor } from "../../spec/props.ts";
 import { generateDummySpecs } from "./pipeline.ts";
 import { DUMMY_PROP_OVERRIDES, DUMMY_SCHEMA_OVERRIDES } from "./overrides.ts";
 import { makeModule } from "../generic/index.ts";
+import { JSONSchema } from "../draft_07.ts";
 
 function createDocLink(
   _schema: SuperSchema,
@@ -35,13 +36,18 @@ function dummyCategory(schema: SuperSchema): string {
 }
 
 function dummyNormalizeProperty(
-  prop: CfProperty,
+  prop: JSONSchema,
   _context: PropertyNormalizationContext,
 ): CfProperty {
-  if ("properties" in prop && prop.properties && !prop.type) {
+  if (
+    typeof prop === "object" &&
+    "properties" in prop &&
+    prop.properties &&
+    !prop.type
+  ) {
     return { ...prop, type: "object" } as CfProperty;
   }
-  return prop;
+  return prop as CfProperty;
 }
 
 function dummyIsChildRequired(

--- a/bin/clover/src/pipelines/generic/index.ts
+++ b/bin/clover/src/pipelines/generic/index.ts
@@ -5,7 +5,10 @@ import {
 } from "../../spec/pkgs.ts";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import { CfProperty, ProviderConfig, SuperSchema } from "../types.ts";
-import { createDefaultPropFromCf, OnlyProperties } from "../../spec/props.ts";
+import {
+  createDefaultPropFromJsonSchema,
+  OnlyProperties,
+} from "../../spec/props.ts";
 import { SiPkgKind } from "../../bindings/SiPkgKind.ts";
 import { FuncSpec } from "../../bindings/FuncSpec.ts";
 import { generateDefaultActionFuncs } from "./generateDefaultActionFuncs.ts";
@@ -56,7 +59,7 @@ export function makeModule(
   const color = providerConfig.metadata?.color || "#FF9900"; // Default to AWS orange
 
   // Create prop specs using the provided properties
-  const domain = createDefaultPropFromCf(
+  const domain = createDefaultPropFromJsonSchema(
     "domain",
     domainProperties,
     schema,
@@ -65,7 +68,7 @@ export function makeModule(
     providerConfig,
   );
 
-  const resourceValue = createDefaultPropFromCf(
+  const resourceValue = createDefaultPropFromJsonSchema(
     "resource_value",
     resourceValueProperties,
     schema,
@@ -74,7 +77,7 @@ export function makeModule(
     providerConfig,
   );
 
-  const secrets = createDefaultPropFromCf(
+  const secrets = createDefaultPropFromJsonSchema(
     "secrets",
     {},
     schema,

--- a/bin/clover/src/pipelines/hetzner/pipeline-steps/createCredential.ts
+++ b/bin/clover/src/pipelines/hetzner/pipeline-steps/createCredential.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { FuncSpec } from "../../../bindings/FuncSpec.ts";
 import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
 import {
-  createDefaultPropFromCf,
+  createDefaultPropFromJsonSchema,
   OnlyProperties,
 } from "../../../spec/props.ts";
 import {
@@ -15,14 +15,12 @@ import { makeModule } from "../../generic/index.ts";
 import { HetznerSchema } from "../schema.ts";
 import { hetznerProviderConfig } from "./../provider.ts";
 
-export function generateCredentialModule(
-  specs: ExpandedPkgSpec[],
-) {
+export function generateCredentialModule(specs: ExpandedPkgSpec[]) {
   const credential: HetznerSchema = {
     typeName: "Hetzner::Credential::ApiToken",
     description: "A Hetzner cloud credential connection",
     properties: {
-      "HetznerApiToken": { type: "string" },
+      HetznerApiToken: { type: "string" },
     },
     requiredProperties: new Set([]),
     primaryIdentifier: [],
@@ -61,7 +59,7 @@ function createCredentialSpec(
   const authFuncs = schemaVariant.authFuncs;
 
   // Create the secret definition manually since it needs special handling
-  const secretDefinition = createDefaultPropFromCf(
+  const secretDefinition = createDefaultPropFromJsonSchema(
     "secret_definition",
     credential.properties,
     credential,
@@ -73,8 +71,8 @@ function createCredentialSpec(
   schemaVariant.secretDefinition = secretDefinition;
 
   if (schemaVariant.secretDefinition.kind === "object") {
-    const apiTokenProp = schemaVariant.secretDefinition.entries.find((p) =>
-      p.name === "HetznerApiToken"
+    const apiTokenProp = schemaVariant.secretDefinition.entries.find(
+      (p) => p.name === "HetznerApiToken",
     );
     if (apiTokenProp) {
       apiTokenProp.data.widgetKind = "Password";
@@ -90,18 +88,13 @@ function createCredentialSpec(
   for (const func of createQualificationFuncs(schemaVariant.domain.uniqueId!)) {
     funcs.push(func);
     leafFuncs.push(
-      createLeafFuncSpec("qualification", func.uniqueId, [
-        "domain",
-        "code",
-      ]),
+      createLeafFuncSpec("qualification", func.uniqueId, ["domain", "code"]),
     );
   }
 
   for (const func of createAuthenticationFuncs()) {
     funcs.push(func);
-    authFuncs.push(
-      createAuthenticationFuncSpec("authenticate", func.uniqueId),
-    );
+    authFuncs.push(createAuthenticationFuncSpec("authenticate", func.uniqueId));
   }
 
   return spec;
@@ -117,13 +110,13 @@ export function createQualificationFuncs(domain_id: string): FuncSpec[] {
         uniqueId: domain_id,
         deleted: false,
       },
-    ])
+    ]),
   );
 }
 
 export function createAuthenticationFuncs() {
   return Object.entries(AUTHENTICATION_FUNC_SPECS).map(([func, spec]) =>
-    createDefaultFuncSpec(func, spec, [])
+    createDefaultFuncSpec(func, spec, []),
   );
 }
 
@@ -135,21 +128,14 @@ export const AUTHENTICATION_FUNC_SPECS = {
     backendKind: "jsAuthentication",
     responseType: "void",
   },
-} as const satisfies Record<
-  string,
-  FuncSpecInfo
->;
+} as const satisfies Record<string, FuncSpecInfo>;
 
 export const QUALIFICATION_FUNC_SPECS = {
   "Hetzner Authentication Qualification": {
     id: "f594dc6ebe7597027203a39f2bef0307f2c09d97067c1a4e1a4fb9f7f3b9d379",
     displayName: "Qualify Credentials with Hetzner Cloud",
-    path:
-      "./src/pipelines/hetzner/funcs/qualifications/credentialQualification.ts",
+    path: "./src/pipelines/hetzner/funcs/qualifications/credentialQualification.ts",
     backendKind: "jsAttribute",
     responseType: "qualification",
   },
-} as const as Record<
-  string,
-  FuncSpecInfo
->;
+} as const as Record<string, FuncSpecInfo>;

--- a/bin/clover/src/pipelines/hetzner/provider.ts
+++ b/bin/clover/src/pipelines/hetzner/provider.ts
@@ -24,6 +24,7 @@ import {
 import { type JsonSchema, type OperationData } from "./schema.ts";
 import { mergeResourceOperations, normalizeHetznerProperty } from "./spec.ts";
 import { generateHetznerSpecs } from "./pipeline.ts";
+import { JSONSchema } from "../draft_07.ts";
 
 function createDocLink(
   { typeName }: SuperSchema,
@@ -64,11 +65,16 @@ function hetznerIsChildRequired(
 }
 
 function hetznerNormalizeProperty(
-  prop: CfProperty,
+  prop: JSONSchema,
   _context: PropertyNormalizationContext,
 ): CfProperty {
   let propToNormalize = prop;
-  if ("properties" in prop && prop.properties && !prop.type) {
+  if (
+    typeof prop === "object" &&
+    "properties" in prop &&
+    prop.properties &&
+    !prop.type
+  ) {
     propToNormalize = { ...prop, type: "object" } as CfProperty;
   }
 

--- a/bin/clover/src/pipelines/types.ts
+++ b/bin/clover/src/pipelines/types.ts
@@ -9,7 +9,7 @@ import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 import { ExpandedPropSpec, ExpandedPropSpecFor } from "../spec/props.ts";
 import { Provider } from "../types.ts";
 
-const CF_PROPERTY_TYPES = [
+export const CF_PROPERTY_TYPES = [
   "boolean",
   "string",
   "number",
@@ -19,6 +19,10 @@ const CF_PROPERTY_TYPES = [
   "json",
 ] as const;
 export type CfPropertyType = (typeof CF_PROPERTY_TYPES)[number];
+const CF_PROPERTY_TYPE_SET = new Set<string>(CF_PROPERTY_TYPES);
+export function isCfPropertyType(type: unknown): type is CfPropertyType {
+  return typeof type === "string" && CF_PROPERTY_TYPE_SET.has(type);
+}
 
 export type CfProperty =
   | Extend<CfBooleanProperty, { type: "boolean" }>
@@ -294,7 +298,7 @@ export interface ProviderConfig {
    * @returns Normalized CfProperty that can be processed by createPropFromCf
    */
   normalizeProperty: (
-    prop: CfProperty,
+    prop: JSONSchema,
     context: PropertyNormalizationContext,
   ) => CfProperty;
 

--- a/lib/jsr-systeminit/cf-db/draft_07.ts
+++ b/lib/jsr-systeminit/cf-db/draft_07.ts
@@ -46,691 +46,698 @@ type ValueOf<T> = T[keyof T];
  */
 export type JSONSchema<
   Value = any,
-  SchemaType = Value extends boolean ? "boolean"
-    : Value extends null ? "null"
-    : Value extends number ? "number" | "integer"
-    : Value extends string ? "string"
-    : Value extends unknown[] ? "array"
-    : Value extends Record<string | number, unknown> ? "object"
+  SchemaType = Value extends boolean
+    ? "boolean"
+    : Value extends null
+    ? "null"
+    : Value extends number
+    ? "number" | "integer"
+    : Value extends string
+    ? "string"
+    : Value extends unknown[]
+    ? "array"
+    : Value extends Record<string | number, unknown>
+    ? "object"
     : JSONSchema.TypeValue,
-> = boolean | {
-  /**
-   * This keyword is reserved for comments from schema authors to readers or
-   * maintainers of the schema. The value of this keyword MUST be a string.
-   * Implementations MUST NOT present this string to end users. Tools for
-   * editing schemas SHOULD support displaying and editing this keyword.
-   *
-   * The value of this keyword MAY be used in debug or error output which is
-   * intended for developers making use of schemas. Schema vocabularies
-   * SHOULD allow `comment` within any object containing vocabulary
-   * keywords.
-   *
-   * Implementations MAY assume `comment` is allowed unless the vocabulary
-   * specifically forbids it. Vocabularies MUST NOT specify any effect of
-   * `comment` beyond what is described in this specification. Tools that
-   * translate other media types or programming languages to and from
-   * `application/schema+json` MAY choose to convert that media type or
-   * programming language's native comments to or from `comment` values.
-   *
-   * The behavior of such translation when both native comments and
-   * `comment` properties are present is implementation-dependent.
-   * Implementations SHOULD treat `comment` identically to an unknown
-   * extension keyword.
-   *
-   * They MAY strip `comment` values at any point during processing. In
-   * particular, this allows for shortening schemas when the size of deployed
-   * schemas is a concern. Implementations MUST NOT take any other action
-   * based on the presence, absence, or contents of `comment` properties.
-   */
-  $comment?: string;
+> =
+  | boolean
+  | {
+      /**
+       * This keyword is reserved for comments from schema authors to readers or
+       * maintainers of the schema. The value of this keyword MUST be a string.
+       * Implementations MUST NOT present this string to end users. Tools for
+       * editing schemas SHOULD support displaying and editing this keyword.
+       *
+       * The value of this keyword MAY be used in debug or error output which is
+       * intended for developers making use of schemas. Schema vocabularies
+       * SHOULD allow `comment` within any object containing vocabulary
+       * keywords.
+       *
+       * Implementations MAY assume `comment` is allowed unless the vocabulary
+       * specifically forbids it. Vocabularies MUST NOT specify any effect of
+       * `comment` beyond what is described in this specification. Tools that
+       * translate other media types or programming languages to and from
+       * `application/schema+json` MAY choose to convert that media type or
+       * programming language's native comments to or from `comment` values.
+       *
+       * The behavior of such translation when both native comments and
+       * `comment` properties are present is implementation-dependent.
+       * Implementations SHOULD treat `comment` identically to an unknown
+       * extension keyword.
+       *
+       * They MAY strip `comment` values at any point during processing. In
+       * particular, this allows for shortening schemas when the size of deployed
+       * schemas is a concern. Implementations MUST NOT take any other action
+       * based on the presence, absence, or contents of `comment` properties.
+       */
+      $comment?: string;
 
-  /**
-   * The `$id` keyword defines a URI for the schema, and the base URI that
-   * other URI references within the schema are resolved against. A
-   * subschema's `$id` is resolved against the base URI of its parent
-   * schema. If no parent sets an explicit base with `$id`, the base URI is
-   * that of the entire document, as determined per
-   * [RFC 3986 section 5][RFC3986].
-   *
-   * If present, the value for this keyword MUST be a string, and MUST
-   * represent a valid [URI-reference][RFC3986]. This value SHOULD be
-   * normalized, and SHOULD NOT be an empty fragment `#` or an empty string.
-   *
-   * [RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986
-   *
-   * @format "uri-reference"
-   */
-  $id?: string;
+      /**
+       * The `$id` keyword defines a URI for the schema, and the base URI that
+       * other URI references within the schema are resolved against. A
+       * subschema's `$id` is resolved against the base URI of its parent
+       * schema. If no parent sets an explicit base with `$id`, the base URI is
+       * that of the entire document, as determined per
+       * [RFC 3986 section 5][RFC3986].
+       *
+       * If present, the value for this keyword MUST be a string, and MUST
+       * represent a valid [URI-reference][RFC3986]. This value SHOULD be
+       * normalized, and SHOULD NOT be an empty fragment `#` or an empty string.
+       *
+       * [RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986
+       *
+       * @format "uri-reference"
+       */
+      $id?: string;
 
-  /**
-   * The `$ref` keyword is used to reference a schema, and provides the
-   * ability to validate recursive structures through self-reference.
-   *
-   * An object schema with a `$ref` property MUST be interpreted as a
-   * `$ref` reference. The value of the `$ref` property MUST be a URI
-   * Reference. Resolved against the current URI base, it identifies the URI
-   * of a schema to use. All other properties in a `$ref` object MUST be
-   * ignored.
-   *
-   * The URI is not a network locator, only an identifier. A schema need not
-   * be downloadable from the address if it is a network-addressable URL, and
-   * implementations SHOULD NOT assume they should perform a network
-   * operation when they encounter a network-addressable URI.
-   *
-   * A schema MUST NOT be run into an infinite loop against a schema. For
-   * example, if two schemas `"#alice"` and `"#bob"` both have an
-   * `allOf` property that refers to the other, a naive validator might get
-   * stuck in an infinite recursive loop trying to validate the instance.
-   * Schemas SHOULD NOT make use of infinite recursive nesting like this; the
-   * behavior is undefined.
-   *
-   * @format "uri-reference"
-   */
-  $ref?: string;
+      /**
+       * The `$ref` keyword is used to reference a schema, and provides the
+       * ability to validate recursive structures through self-reference.
+       *
+       * An object schema with a `$ref` property MUST be interpreted as a
+       * `$ref` reference. The value of the `$ref` property MUST be a URI
+       * Reference. Resolved against the current URI base, it identifies the URI
+       * of a schema to use. All other properties in a `$ref` object MUST be
+       * ignored.
+       *
+       * The URI is not a network locator, only an identifier. A schema need not
+       * be downloadable from the address if it is a network-addressable URL, and
+       * implementations SHOULD NOT assume they should perform a network
+       * operation when they encounter a network-addressable URI.
+       *
+       * A schema MUST NOT be run into an infinite loop against a schema. For
+       * example, if two schemas `"#alice"` and `"#bob"` both have an
+       * `allOf` property that refers to the other, a naive validator might get
+       * stuck in an infinite recursive loop trying to validate the instance.
+       * Schemas SHOULD NOT make use of infinite recursive nesting like this; the
+       * behavior is undefined.
+       *
+       * @format "uri-reference"
+       */
+      $ref?: string;
 
-  /**
-   * The `$schema` keyword is both used as a JSON Schema version identifier
-   * and the location of a resource which is itself a JSON Schema, which
-   * describes any schema written for this particular version.
-   *
-   * The value of this keyword MUST be a [URI][RFC3986] (containing a scheme)
-   * and this URI MUST be normalized. The current schema MUST be valid
-   * against the meta-schema identified by this URI.
-   *
-   * If this URI identifies a retrievable resource, that resource SHOULD be
-   * of media type `application/schema+json`.
-   *
-   * The `$schema` keyword SHOULD be used in a root schema. It MUST NOT
-   * appear in subschemas.
-   *
-   * Values for this property are defined in other documents and by other
-   * parties. JSON Schema implementations SHOULD implement support for
-   * current and previous published drafts of JSON Schema vocabularies as
-   * deemed reasonable.
-   *
-   * [RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986
-   *
-   * @format "uri"
-   */
-  $schema?: string;
+      /**
+       * The `$schema` keyword is both used as a JSON Schema version identifier
+       * and the location of a resource which is itself a JSON Schema, which
+       * describes any schema written for this particular version.
+       *
+       * The value of this keyword MUST be a [URI][RFC3986] (containing a scheme)
+       * and this URI MUST be normalized. The current schema MUST be valid
+       * against the meta-schema identified by this URI.
+       *
+       * If this URI identifies a retrievable resource, that resource SHOULD be
+       * of media type `application/schema+json`.
+       *
+       * The `$schema` keyword SHOULD be used in a root schema. It MUST NOT
+       * appear in subschemas.
+       *
+       * Values for this property are defined in other documents and by other
+       * parties. JSON Schema implementations SHOULD implement support for
+       * current and previous published drafts of JSON Schema vocabularies as
+       * deemed reasonable.
+       *
+       * [RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986
+       *
+       * @format "uri"
+       */
+      $schema?: string;
 
-  /**
-   * The value of `additionalItems` MUST be a valid JSON Schema.
-   *
-   * This keyword determines how child instances validate for arrays, and
-   * does not directly validate the immediate instance itself.
-   *
-   * If `items` is an array of schemas, validation succeeds if every
-   * instance element at a position greater than the size of `items`
-   * validates against `additionalItems`.
-   *
-   * Otherwise, `additionalItems` MUST be ignored, as the `items` schema
-   * (possibly the default value of an empty schema) is applied to all
-   * elements.
-   *
-   * Omitting this keyword has the same behavior as an empty schema.
-   */
-  additionalItems?: JSONSchema;
+      /**
+       * The value of `additionalItems` MUST be a valid JSON Schema.
+       *
+       * This keyword determines how child instances validate for arrays, and
+       * does not directly validate the immediate instance itself.
+       *
+       * If `items` is an array of schemas, validation succeeds if every
+       * instance element at a position greater than the size of `items`
+       * validates against `additionalItems`.
+       *
+       * Otherwise, `additionalItems` MUST be ignored, as the `items` schema
+       * (possibly the default value of an empty schema) is applied to all
+       * elements.
+       *
+       * Omitting this keyword has the same behavior as an empty schema.
+       */
+      additionalItems?: JSONSchema;
 
-  /**
-   * The value of `additionalProperties` MUST be a valid JSON Schema.
-   *
-   * This keyword determines how child instances validate for objects, and
-   * does not directly validate the immediate instance itself.
-   *
-   * Validation with `additionalProperties` applies only to the child
-   * values of instance names that do not match any names in `properties`,
-   * and do not match any regular expression in `patternProperties`.
-   *
-   * For all such properties, validation succeeds if the child instance
-   * validates against the `additionalProperties` schema.
-   *
-   * Omitting this keyword has the same behavior as an empty schema.
-   */
-  additionalProperties?: JSONSchema;
+      /**
+       * The value of `additionalProperties` MUST be a valid JSON Schema.
+       *
+       * This keyword determines how child instances validate for objects, and
+       * does not directly validate the immediate instance itself.
+       *
+       * Validation with `additionalProperties` applies only to the child
+       * values of instance names that do not match any names in `properties`,
+       * and do not match any regular expression in `patternProperties`.
+       *
+       * For all such properties, validation succeeds if the child instance
+       * validates against the `additionalProperties` schema.
+       *
+       * Omitting this keyword has the same behavior as an empty schema.
+       */
+      additionalProperties?: JSONSchema;
 
-  /**
-   * This keyword's value MUST be a non-empty array. Each item of the array
-   * MUST be a valid JSON Schema.
-   *
-   * An instance validates successfully against this keyword if it validates
-   * successfully against all schemas defined by this keyword's value.
-   */
-  allOf?: MaybeReadonlyArray<JSONSchema<Value, SchemaType>>;
+      /**
+       * This keyword's value MUST be a non-empty array. Each item of the array
+       * MUST be a valid JSON Schema.
+       *
+       * An instance validates successfully against this keyword if it validates
+       * successfully against all schemas defined by this keyword's value.
+       */
+      allOf?: MaybeReadonlyArray<JSONSchema<Value, SchemaType>>;
 
-  /**
-   * This keyword's value MUST be a non-empty array. Each item of the array
-   * MUST be a valid JSON Schema.
-   *
-   * An instance validates successfully against this keyword if it validates
-   * successfully against at least one schema defined by this keyword's
-   * value.
-   */
-  anyOf?: MaybeReadonlyArray<JSONSchema<Value, SchemaType>>;
+      /**
+       * This keyword's value MUST be a non-empty array. Each item of the array
+       * MUST be a valid JSON Schema.
+       *
+       * An instance validates successfully against this keyword if it validates
+       * successfully against at least one schema defined by this keyword's
+       * value.
+       */
+      anyOf?: MaybeReadonlyArray<JSONSchema<Value, SchemaType>>;
 
-  /**
-   * An instance validates successfully against this keyword if its value is
-   * equal to the value of the keyword.
-   *
-   * Use of this keyword is functionally equivalent to the `enum` keyword
-   * with a single value.
-   */
-  const?: Value;
+      /**
+       * An instance validates successfully against this keyword if its value is
+       * equal to the value of the keyword.
+       *
+       * Use of this keyword is functionally equivalent to the `enum` keyword
+       * with a single value.
+       */
+      const?: Value;
 
-  /**
-   * The value of this keyword MUST be a valid JSON Schema.
-   *
-   * An array instance is valid against `contains` if at least one of its
-   * elements is valid against the given schema.
-   */
-  contains?: JSONSchema<Value, SchemaType>;
+      /**
+       * The value of this keyword MUST be a valid JSON Schema.
+       *
+       * An array instance is valid against `contains` if at least one of its
+       * elements is valid against the given schema.
+       */
+      contains?: JSONSchema<Value, SchemaType>;
 
-  /**
-   * If the instance value is a string, this property defines that the
-   * string SHOULD be interpreted as binary data and decoded using the
-   * encoding named by this property. [RFC 2045, Sec 6.1][RFC2045] lists the
-   * possible values for this property.
-   *
-   * The value of this property SHOULD be ignored if the instance described
-   * is not a string.
-   *
-   * [RFC2045]: https://datatracker.ietf.org/doc/html/rfc2045#section-6.1
-   */
-  contentEncoding?:
-    | "7bit"
-    | "8bit"
-    | "base64"
-    | "binary"
-    | "ietf-token"
-    | "quoted-printable"
-    | "x-token";
+      /**
+       * If the instance value is a string, this property defines that the
+       * string SHOULD be interpreted as binary data and decoded using the
+       * encoding named by this property. [RFC 2045, Sec 6.1][RFC2045] lists the
+       * possible values for this property.
+       *
+       * The value of this property SHOULD be ignored if the instance described
+       * is not a string.
+       *
+       * [RFC2045]: https://datatracker.ietf.org/doc/html/rfc2045#section-6.1
+       */
+      contentEncoding?:
+        | "7bit"
+        | "8bit"
+        | "base64"
+        | "binary"
+        | "ietf-token"
+        | "quoted-printable"
+        | "x-token";
 
-  /**
-   * The value of this property must be a media type, as defined by
-   * [RFC 2046][RFC2046]. This property defines the media type of instances
-   * which this schema defines.
-   *
-   * The value of this property SHOULD be ignored if the instance described
-   * is not a string.
-   *
-   * If the `contentEncoding` property is not present, but the instance
-   * value is a string, then the value of this property SHOULD specify a text
-   * document type, and the character set SHOULD be the character set into
-   * which the JSON string value was decoded (for which the default is
-   * Unicode).
-   *
-   * [RFC2046]: https://datatracker.ietf.org/doc/html/rfc2046
-   */
-  contentMediaType?: string;
+      /**
+       * The value of this property must be a media type, as defined by
+       * [RFC 2046][RFC2046]. This property defines the media type of instances
+       * which this schema defines.
+       *
+       * The value of this property SHOULD be ignored if the instance described
+       * is not a string.
+       *
+       * If the `contentEncoding` property is not present, but the instance
+       * value is a string, then the value of this property SHOULD specify a text
+       * document type, and the character set SHOULD be the character set into
+       * which the JSON string value was decoded (for which the default is
+       * Unicode).
+       *
+       * [RFC2046]: https://datatracker.ietf.org/doc/html/rfc2046
+       */
+      contentMediaType?: string;
 
-  /**
-   * This keyword can be used to supply a default JSON value associated with
-   * a particular schema. It is RECOMMENDED that a `default` value be valid
-   * against the associated schema.
-   */
-  default?: Value;
+      /**
+       * This keyword can be used to supply a default JSON value associated with
+       * a particular schema. It is RECOMMENDED that a `default` value be valid
+       * against the associated schema.
+       */
+      default?: Value;
 
-  /**
-   * The `definitions` keywords provides a standardized location for schema
-   * authors to inline re-usable JSON Schemas into a more general schema. The
-   * keyword does not directly affect the validation result.
-   *
-   * This keyword's value MUST be an object. Each member value of this object
-   * MUST be a valid JSON Schema.
-   */
-  definitions?: Record<string, JSONSchema>;
+      /**
+       * The `definitions` keywords provides a standardized location for schema
+       * authors to inline re-usable JSON Schemas into a more general schema. The
+       * keyword does not directly affect the validation result.
+       *
+       * This keyword's value MUST be an object. Each member value of this object
+       * MUST be a valid JSON Schema.
+       */
+      definitions?: Record<string, JSONSchema>;
 
-  /**
-   * This keyword specifies rules that are evaluated if the instance is an
-   * object and contains a certain property.
-   *
-   * This keyword's value MUST be an object. Each property specifies a
-   * dependency. Each dependency value MUST be an array or a valid JSON
-   * Schema.
-   *
-   * If the dependency value is a subschema, and the dependency key is a
-   * property in the instance, the entire instance must validate against the
-   * dependency value.
-   *
-   * If the dependency value is an array, each element in the array, if any,
-   * MUST be a string, and MUST be unique. If the dependency key is a
-   * property in the instance, each of the items in the dependency value must
-   * be a property that exists in the instance.
-   *
-   * Omitting this keyword has the same behavior as an empty object.
-   */
-  dependencies?: Record<string, MaybeReadonlyArray<string> | JSONSchema>;
+      /**
+       * This keyword specifies rules that are evaluated if the instance is an
+       * object and contains a certain property.
+       *
+       * This keyword's value MUST be an object. Each property specifies a
+       * dependency. Each dependency value MUST be an array or a valid JSON
+       * Schema.
+       *
+       * If the dependency value is a subschema, and the dependency key is a
+       * property in the instance, the entire instance must validate against the
+       * dependency value.
+       *
+       * If the dependency value is an array, each element in the array, if any,
+       * MUST be a string, and MUST be unique. If the dependency key is a
+       * property in the instance, each of the items in the dependency value must
+       * be a property that exists in the instance.
+       *
+       * Omitting this keyword has the same behavior as an empty object.
+       */
+      dependencies?: Record<string, MaybeReadonlyArray<string> | JSONSchema>;
 
-  /**
-   * Can be used to decorate a user interface with explanation or information
-   * about the data produced.
-   */
-  description?: string;
+      /**
+       * Can be used to decorate a user interface with explanation or information
+       * about the data produced.
+       */
+      description?: string;
 
-  /**
-   * This keyword's value MUST be a valid JSON Schema.
-   *
-   * When `if` is present, and the instance fails to validate against its
-   * subschema, then validation succeeds against this keyword if the instance
-   * successfully validates against this keyword's subschema.
-   *
-   * This keyword has no effect when `if` is absent, or when the instance
-   * successfully validates against its subschema. Implementations MUST NOT
-   * evaluate the instance against this keyword, for either validation or
-   * annotation collection purposes, in such cases.
-   */
-  else?: JSONSchema<Value, SchemaType>;
+      /**
+       * This keyword's value MUST be a valid JSON Schema.
+       *
+       * When `if` is present, and the instance fails to validate against its
+       * subschema, then validation succeeds against this keyword if the instance
+       * successfully validates against this keyword's subschema.
+       *
+       * This keyword has no effect when `if` is absent, or when the instance
+       * successfully validates against its subschema. Implementations MUST NOT
+       * evaluate the instance against this keyword, for either validation or
+       * annotation collection purposes, in such cases.
+       */
+      else?: JSONSchema<Value, SchemaType>;
 
-  /**
-   * The value of this keyword MUST be an array. This array SHOULD have at
-   * least one element. Elements in the array SHOULD be unique.
-   *
-   * An instance validates successfully against this keyword if its value is
-   * equal to one of the elements in this keyword's array value.
-   *
-   * Elements in the array might be of any type, including `null`.
-   */
-  enum?: MaybeReadonlyArray<Value>;
+      /**
+       * The value of this keyword MUST be an array. This array SHOULD have at
+       * least one element. Elements in the array SHOULD be unique.
+       *
+       * An instance validates successfully against this keyword if its value is
+       * equal to one of the elements in this keyword's array value.
+       *
+       * Elements in the array might be of any type, including `null`.
+       */
+      enum?: MaybeReadonlyArray<Value>;
 
-  /**
-   * The value of this keyword MUST be an array. When multiple occurrences of
-   * this keyword are applicable to a single sub-instance, implementations
-   * MUST provide a flat array of all values rather than an array of arrays.
-   *
-   * This keyword can be used to provide sample JSON values associated with a
-   * particular schema, for the purpose of illustrating usage. It is
-   * RECOMMENDED that these values be valid against the associated schema.
-   *
-   * Implementations MAY use the value(s) of `default`, if present, as an
-   * additional example. If `examples` is absent, `default` MAY still be
-   * used in this manner.
-   */
-  examples?: MaybeReadonlyArray<Value>;
+      /**
+       * The value of this keyword MUST be an array. When multiple occurrences of
+       * this keyword are applicable to a single sub-instance, implementations
+       * MUST provide a flat array of all values rather than an array of arrays.
+       *
+       * This keyword can be used to provide sample JSON values associated with a
+       * particular schema, for the purpose of illustrating usage. It is
+       * RECOMMENDED that these values be valid against the associated schema.
+       *
+       * Implementations MAY use the value(s) of `default`, if present, as an
+       * additional example. If `examples` is absent, `default` MAY still be
+       * used in this manner.
+       */
+      examples?: MaybeReadonlyArray<Value>;
 
-  /**
-   * The value of `exclusiveMaximum` MUST be a number, representing an
-   * exclusive upper limit for a numeric instance.
-   *
-   * If the instance is a number, then the instance is valid only if it has a
-   * value strictly less than (not equal to) `exclusiveMaximum`.
-   */
-  exclusiveMaximum?: number;
+      /**
+       * The value of `exclusiveMaximum` MUST be a number, representing an
+       * exclusive upper limit for a numeric instance.
+       *
+       * If the instance is a number, then the instance is valid only if it has a
+       * value strictly less than (not equal to) `exclusiveMaximum`.
+       */
+      exclusiveMaximum?: number;
 
-  /**
-   * The value of `exclusiveMinimum` MUST be a number, representing an
-   * exclusive lower limit for a numeric instance.
-   *
-   * If the instance is a number, then the instance is valid only if it has a
-   * value strictly greater than (not equal to) `exclusiveMinimum`.
-   */
-  exclusiveMinimum?: number;
+      /**
+       * The value of `exclusiveMinimum` MUST be a number, representing an
+       * exclusive lower limit for a numeric instance.
+       *
+       * If the instance is a number, then the instance is valid only if it has a
+       * value strictly greater than (not equal to) `exclusiveMinimum`.
+       */
+      exclusiveMinimum?: number;
 
-  /**
-   * The `format` keyword functions as both an [annotation][annotation] and
-   * as an [assertion][assertion]. While no special effort is required to
-   * implement it as an annotation conveying semantic meaning, implementing
-   * validation is non-trivial.
-   *
-   * Implementations MAY support the `format` keyword as a validation
-   * assertion.
-   *
-   * Implementations MAY add custom `format` attributes. Save for agreement
-   * between parties, schema authors SHALL NOT expect a peer implementation
-   * to support this keyword and/or custom `format` attributes.
-   *
-   * [annotation]: https://json-schema.org/draft-07/json-schema-validation.html#annotations
-   * [assertion]: https://json-schema.org/draft-07/json-schema-validation.html#assertions
-   */
-  format?: string;
+      /**
+       * The `format` keyword functions as both an [annotation][annotation] and
+       * as an [assertion][assertion]. While no special effort is required to
+       * implement it as an annotation conveying semantic meaning, implementing
+       * validation is non-trivial.
+       *
+       * Implementations MAY support the `format` keyword as a validation
+       * assertion.
+       *
+       * Implementations MAY add custom `format` attributes. Save for agreement
+       * between parties, schema authors SHALL NOT expect a peer implementation
+       * to support this keyword and/or custom `format` attributes.
+       *
+       * [annotation]: https://json-schema.org/draft-07/json-schema-validation.html#annotations
+       * [assertion]: https://json-schema.org/draft-07/json-schema-validation.html#assertions
+       */
+      format?: string;
 
-  /**
-   * This keyword's value MUST be a valid JSON Schema.
-   *
-   * This validation outcome of this keyword's subschema has no direct effect
-   * on the overall validation result. Rather, it controls which of the
-   * `then` or `else` keywords are evaluated.
-   *
-   * Instances that successfully validate against this keyword's subschema
-   * MUST also be valid against the subschema value of the `then` keyword,
-   * if present.
-   *
-   * Instances that fail to validate against this keyword's subschema MUST
-   * also be valid against the subschema value of the `else` keyword, if
-   * present.
-   *
-   * If [annotations][annotations] are being collected, they are collected
-   * from this keyword's subschema in the usual way, including when the
-   * keyword is present without either `then` or `else`.
-   *
-   * [annotations]: https://json-schema.org/draft-07/json-schema-validation.html#annotations
-   */
-  if?: JSONSchema<Value, SchemaType>;
+      /**
+       * This keyword's value MUST be a valid JSON Schema.
+       *
+       * This validation outcome of this keyword's subschema has no direct effect
+       * on the overall validation result. Rather, it controls which of the
+       * `then` or `else` keywords are evaluated.
+       *
+       * Instances that successfully validate against this keyword's subschema
+       * MUST also be valid against the subschema value of the `then` keyword,
+       * if present.
+       *
+       * Instances that fail to validate against this keyword's subschema MUST
+       * also be valid against the subschema value of the `else` keyword, if
+       * present.
+       *
+       * If [annotations][annotations] are being collected, they are collected
+       * from this keyword's subschema in the usual way, including when the
+       * keyword is present without either `then` or `else`.
+       *
+       * [annotations]: https://json-schema.org/draft-07/json-schema-validation.html#annotations
+       */
+      if?: JSONSchema<Value, SchemaType>;
 
-  /**
-   * The value of `items` MUST be either a valid JSON Schema or an array of
-   * valid JSON Schemas.
-   *
-   * This keyword determines how child instances validate for arrays, and
-   * does not directly validate the immediate instance itself.
-   *
-   * If `items` is a schema, validation succeeds if all elements in the
-   * array successfully validate against that schema.
-   *
-   * If `items` is an array of schemas, validation succeeds if each element
-   * of the instance validates against the schema at the same position, if
-   * any.
-   *
-   * Omitting this keyword has the same behavior as an empty schema.
-   */
-  items?: MaybeReadonlyArray<JSONSchema> | JSONSchema;
+      /**
+       * The value of `items` MUST be either a valid JSON Schema or an array of
+       * valid JSON Schemas.
+       *
+       * This keyword determines how child instances validate for arrays, and
+       * does not directly validate the immediate instance itself.
+       *
+       * If `items` is a schema, validation succeeds if all elements in the
+       * array successfully validate against that schema.
+       *
+       * If `items` is an array of schemas, validation succeeds if each element
+       * of the instance validates against the schema at the same position, if
+       * any.
+       *
+       * Omitting this keyword has the same behavior as an empty schema.
+       */
+      items?: MaybeReadonlyArray<JSONSchema> | JSONSchema;
 
-  /**
-   * The value of `maximum` MUST be a number, representing an inclusive
-   * upper limit for a numeric instance.
-   *
-   * If the instance is a number, then this keyword validates only if the
-   * instance is less than or exactly equal to `maximum`.
-   */
-  maximum?: number;
+      /**
+       * The value of `maximum` MUST be a number, representing an inclusive
+       * upper limit for a numeric instance.
+       *
+       * If the instance is a number, then this keyword validates only if the
+       * instance is less than or exactly equal to `maximum`.
+       */
+      maximum?: number;
 
-  /**
-   * The value of this keyword MUST be a non-negative integer.
-   *
-   * An array instance is valid against `maxItems` if its size is less
-   * than, or equal to, the value of this keyword.
-   *
-   * @minimum 0
-   */
-  maxItems?: number;
+      /**
+       * The value of this keyword MUST be a non-negative integer.
+       *
+       * An array instance is valid against `maxItems` if its size is less
+       * than, or equal to, the value of this keyword.
+       *
+       * @minimum 0
+       */
+      maxItems?: number;
 
-  /**
-   * The value of this keyword MUST be a non-negative integer.
-   *
-   * A string instance is valid against this keyword if its length is less
-   * than, or equal to, the value of this keyword.
-   *
-   * The length of a string instance is defined as the number of its
-   * characters as defined by [RFC 7159][RFC7159].
-   *
-   * [RFC7159]: https://datatracker.ietf.org/doc/html/rfc7159
-   *
-   * @minimum 0
-   */
-  maxLength?: number;
+      /**
+       * The value of this keyword MUST be a non-negative integer.
+       *
+       * A string instance is valid against this keyword if its length is less
+       * than, or equal to, the value of this keyword.
+       *
+       * The length of a string instance is defined as the number of its
+       * characters as defined by [RFC 7159][RFC7159].
+       *
+       * [RFC7159]: https://datatracker.ietf.org/doc/html/rfc7159
+       *
+       * @minimum 0
+       */
+      maxLength?: number;
 
-  /**
-   * The value of this keyword MUST be a non-negative integer.
-   *
-   * An object instance is valid against `maxProperties` if its number of
-   * `properties` is less than, or equal to, the value of this keyword.
-   *
-   * @minimum 0
-   */
-  maxProperties?: number;
+      /**
+       * The value of this keyword MUST be a non-negative integer.
+       *
+       * An object instance is valid against `maxProperties` if its number of
+       * `properties` is less than, or equal to, the value of this keyword.
+       *
+       * @minimum 0
+       */
+      maxProperties?: number;
 
-  /**
-   * The value of `minimum` MUST be a number, representing an inclusive
-   * lower limit for a numeric instance.
-   *
-   * If the instance is a number, then this keyword validates only if the
-   * instance is greater than or exactly equal to `minimum`.
-   */
-  minimum?: number;
+      /**
+       * The value of `minimum` MUST be a number, representing an inclusive
+       * lower limit for a numeric instance.
+       *
+       * If the instance is a number, then this keyword validates only if the
+       * instance is greater than or exactly equal to `minimum`.
+       */
+      minimum?: number;
 
-  /**
-   * The value of this keyword MUST be a non-negative integer.
-   *
-   * An array instance is valid against `minItems` if its size is greater
-   * than, or equal to, the value of this keyword.
-   *
-   * Omitting this keyword has the same behavior as a value of `0`.
-   *
-   * @default 0
-   * @minimum 0
-   */
-  minItems?: number;
+      /**
+       * The value of this keyword MUST be a non-negative integer.
+       *
+       * An array instance is valid against `minItems` if its size is greater
+       * than, or equal to, the value of this keyword.
+       *
+       * Omitting this keyword has the same behavior as a value of `0`.
+       *
+       * @default 0
+       * @minimum 0
+       */
+      minItems?: number;
 
-  /**
-   * The value of this keyword MUST be a non-negative integer.
-   *
-   * A string instance is valid against this keyword if its length is greater
-   * than, or equal to, the value of this keyword.
-   *
-   * The length of a string instance is defined as the number of its
-   * characters as defined by [RFC 7159][RFC7159].
-   *
-   * Omitting this keyword has the same behavior as a value of `0`.
-   *
-   * [RFC7159]: https://datatracker.ietf.org/doc/html/rfc7159
-   *
-   * @default 0
-   * @minimum 0
-   */
-  minLength?: number;
+      /**
+       * The value of this keyword MUST be a non-negative integer.
+       *
+       * A string instance is valid against this keyword if its length is greater
+       * than, or equal to, the value of this keyword.
+       *
+       * The length of a string instance is defined as the number of its
+       * characters as defined by [RFC 7159][RFC7159].
+       *
+       * Omitting this keyword has the same behavior as a value of `0`.
+       *
+       * [RFC7159]: https://datatracker.ietf.org/doc/html/rfc7159
+       *
+       * @default 0
+       * @minimum 0
+       */
+      minLength?: number;
 
-  /**
-   * The value of this keyword MUST be a non-negative integer.
-   *
-   * An object instance is valid against `minProperties` if its number of
-   * `properties` is greater than, or equal to, the value of this keyword.
-   *
-   * Omitting this keyword has the same behavior as a value of `0`.
-   *
-   * @default 0
-   * @minimum 0
-   */
-  minProperties?: number;
+      /**
+       * The value of this keyword MUST be a non-negative integer.
+       *
+       * An object instance is valid against `minProperties` if its number of
+       * `properties` is greater than, or equal to, the value of this keyword.
+       *
+       * Omitting this keyword has the same behavior as a value of `0`.
+       *
+       * @default 0
+       * @minimum 0
+       */
+      minProperties?: number;
 
-  /**
-   * The value of `multipleOf` MUST be a number, strictly greater than
-   * `0`.
-   *
-   * A numeric instance is valid only if division by this keyword's value
-   * results in an integer.
-   *
-   * @exclusiveMinimum 0
-   */
-  multipleOf?: number;
+      /**
+       * The value of `multipleOf` MUST be a number, strictly greater than
+       * `0`.
+       *
+       * A numeric instance is valid only if division by this keyword's value
+       * results in an integer.
+       *
+       * @exclusiveMinimum 0
+       */
+      multipleOf?: number;
 
-  /**
-   * This keyword's value MUST be a valid JSON Schema.
-   *
-   * An instance is valid against this keyword if it fails to validate
-   * successfully against the schema defined by this keyword.
-   */
-  not?: JSONSchema<Value, SchemaType>;
+      /**
+       * This keyword's value MUST be a valid JSON Schema.
+       *
+       * An instance is valid against this keyword if it fails to validate
+       * successfully against the schema defined by this keyword.
+       */
+      not?: JSONSchema<Value, SchemaType>;
 
-  /**
-   * This keyword's value MUST be a non-empty array. Each item of the array
-   * MUST be a valid JSON Schema.
-   *
-   * An instance validates successfully against this keyword if it validates
-   * successfully against exactly one schema defined by this keyword's value.
-   */
-  oneOf?: MaybeReadonlyArray<JSONSchema<Value, SchemaType>>;
+      /**
+       * This keyword's value MUST be a non-empty array. Each item of the array
+       * MUST be a valid JSON Schema.
+       *
+       * An instance validates successfully against this keyword if it validates
+       * successfully against exactly one schema defined by this keyword's value.
+       */
+      oneOf?: MaybeReadonlyArray<JSONSchema<Value, SchemaType>>;
 
-  /**
-   * The value of this keyword MUST be a string. This string SHOULD be a
-   * valid regular expression, according to the [ECMA-262][ecma262] regular
-   * expression dialect.
-   *
-   * A string instance is considered valid if the regular expression matches
-   * the instance successfully. Recall: regular expressions are not
-   * implicitly anchored.
-   *
-   * [ecma262]: https://www.ecma-international.org/publications-and-standards/standards/ecma-262/
-   *
-   * @format "regex"
-   */
-  pattern?: string;
+      /**
+       * The value of this keyword MUST be a string. This string SHOULD be a
+       * valid regular expression, according to the [ECMA-262][ecma262] regular
+       * expression dialect.
+       *
+       * A string instance is considered valid if the regular expression matches
+       * the instance successfully. Recall: regular expressions are not
+       * implicitly anchored.
+       *
+       * [ecma262]: https://www.ecma-international.org/publications-and-standards/standards/ecma-262/
+       *
+       * @format "regex"
+       */
+      pattern?: string;
 
-  /**
-   * The value of `patternProperties` MUST be an object. Each property name
-   * of this object SHOULD be a valid regular expression, according to the
-   * [ECMA-262][ecma262] regular expression dialect. Each property value of
-   * this object MUST be a valid JSON Schema.
-   *
-   * This keyword determines how child instances validate for objects, and
-   * does not directly validate the immediate instance itself. Validation of
-   * the primitive instance type against this keyword always succeeds.
-   *
-   * Validation succeeds if, for each instance name that matches any regular
-   * expressions that appear as a property name in this keyword's value, the
-   * child instance for that name successfully validates against each schema
-   * that corresponds to a matching regular expression.
-   *
-   * Omitting this keyword has the same behavior as an empty object.
-   *
-   * [ecma262]: https://www.ecma-international.org/publications-and-standards/standards/ecma-262/
-   */
-  patternProperties?: Record<string, JSONSchema>;
+      /**
+       * The value of `patternProperties` MUST be an object. Each property name
+       * of this object SHOULD be a valid regular expression, according to the
+       * [ECMA-262][ecma262] regular expression dialect. Each property value of
+       * this object MUST be a valid JSON Schema.
+       *
+       * This keyword determines how child instances validate for objects, and
+       * does not directly validate the immediate instance itself. Validation of
+       * the primitive instance type against this keyword always succeeds.
+       *
+       * Validation succeeds if, for each instance name that matches any regular
+       * expressions that appear as a property name in this keyword's value, the
+       * child instance for that name successfully validates against each schema
+       * that corresponds to a matching regular expression.
+       *
+       * Omitting this keyword has the same behavior as an empty object.
+       *
+       * [ecma262]: https://www.ecma-international.org/publications-and-standards/standards/ecma-262/
+       */
+      patternProperties?: Record<string, JSONSchema>;
 
-  /**
-   * The value of `properties` MUST be an object. Each value of this object
-   * MUST be a valid JSON Schema.
-   *
-   * This keyword determines how child instances validate for objects, and
-   * does not directly validate the immediate instance itself.
-   *
-   * Validation succeeds if, for each name that appears in both the instance
-   * and as a name within this keyword's value, the child instance for that
-   * name successfully validates against the corresponding schema.
-   *
-   * Omitting this keyword has the same behavior as an empty object.
-   */
-  properties?: Record<string, JSONSchema>;
+      /**
+       * The value of `properties` MUST be an object. Each value of this object
+       * MUST be a valid JSON Schema.
+       *
+       * This keyword determines how child instances validate for objects, and
+       * does not directly validate the immediate instance itself.
+       *
+       * Validation succeeds if, for each name that appears in both the instance
+       * and as a name within this keyword's value, the child instance for that
+       * name successfully validates against the corresponding schema.
+       *
+       * Omitting this keyword has the same behavior as an empty object.
+       */
+      properties?: Record<string, JSONSchema>;
 
-  /**
-   * The value of `propertyNames` MUST be a valid JSON Schema.
-   *
-   * If the instance is an object, this keyword validates if every property
-   * name in the instance validates against the provided schema. Note the
-   * property name that the schema is testing will always be a string.
-   *
-   * Omitting this keyword has the same behavior as an empty schema.
-   */
-  propertyNames?: JSONSchema;
+      /**
+       * The value of `propertyNames` MUST be a valid JSON Schema.
+       *
+       * If the instance is an object, this keyword validates if every property
+       * name in the instance validates against the provided schema. Note the
+       * property name that the schema is testing will always be a string.
+       *
+       * Omitting this keyword has the same behavior as an empty schema.
+       */
+      propertyNames?: JSONSchema;
 
-  /**
-   * The value of this keyword MUST be a boolean. When multiple occurrences
-   * of this keyword are applicable to a single sub-instance, the resulting
-   * value MUST be `true` if any occurrence specifies a `true` value, and
-   * MUST be `false` otherwise.
-   *
-   * If `readOnly` has a value of boolean `true`, it indicates that the
-   * value of the instance is managed exclusively by the owning authority,
-   * and attempts by an application to modify the value of this property are
-   * expected to be ignored or rejected by that owning authority.
-   *
-   * An instance document that is marked as `readOnly` for the entire
-   * document MAY be ignored if sent to the owning authority, or MAY result
-   * in an error, at the authority's discretion.
-   *
-   * For example, `readOnly` would be used to mark a database-generated
-   * serial number as read-only.
-   *
-   * This keyword can be used to assist in user interface instance
-   * generation.
-   *
-   * @default false
-   */
-  readOnly?: boolean;
+      /**
+       * The value of this keyword MUST be a boolean. When multiple occurrences
+       * of this keyword are applicable to a single sub-instance, the resulting
+       * value MUST be `true` if any occurrence specifies a `true` value, and
+       * MUST be `false` otherwise.
+       *
+       * If `readOnly` has a value of boolean `true`, it indicates that the
+       * value of the instance is managed exclusively by the owning authority,
+       * and attempts by an application to modify the value of this property are
+       * expected to be ignored or rejected by that owning authority.
+       *
+       * An instance document that is marked as `readOnly` for the entire
+       * document MAY be ignored if sent to the owning authority, or MAY result
+       * in an error, at the authority's discretion.
+       *
+       * For example, `readOnly` would be used to mark a database-generated
+       * serial number as read-only.
+       *
+       * This keyword can be used to assist in user interface instance
+       * generation.
+       *
+       * @default false
+       */
+      readOnly?: boolean;
 
-  /**
-   * The value of this keyword MUST be an array. Elements of this array, if
-   * any, MUST be strings, and MUST be unique.
-   *
-   * An object instance is valid against this keyword if every item in the
-   * array is the name of a property in the instance.
-   *
-   * Omitting this keyword has the same behavior as an empty array.
-   */
-  required?: MaybeReadonlyArray<string>;
+      /**
+       * The value of this keyword MUST be an array. Elements of this array, if
+       * any, MUST be strings, and MUST be unique.
+       *
+       * An object instance is valid against this keyword if every item in the
+       * array is the name of a property in the instance.
+       *
+       * Omitting this keyword has the same behavior as an empty array.
+       */
+      required?: MaybeReadonlyArray<string>;
 
-  /**
-   * This keyword's value MUST be a valid JSON Schema.
-   *
-   * When `if` is present, and the instance successfully validates against
-   * its subschema, then validation succeeds against this keyword if the
-   * instance also successfully validates against this keyword's subschema.
-   *
-   * This keyword has no effect when `if` is absent, or when the instance
-   * fails to validate against its subschema. Implementations MUST NOT
-   * evaluate the instance against this keyword, for either validation or
-   * annotation collection purposes, in such cases.
-   */
-  then?: JSONSchema<Value, SchemaType>;
+      /**
+       * This keyword's value MUST be a valid JSON Schema.
+       *
+       * When `if` is present, and the instance successfully validates against
+       * its subschema, then validation succeeds against this keyword if the
+       * instance also successfully validates against this keyword's subschema.
+       *
+       * This keyword has no effect when `if` is absent, or when the instance
+       * fails to validate against its subschema. Implementations MUST NOT
+       * evaluate the instance against this keyword, for either validation or
+       * annotation collection purposes, in such cases.
+       */
+      then?: JSONSchema<Value, SchemaType>;
 
-  /**
-   * Can be used to decorate a user interface with a short label about the
-   * data produced.
-   */
-  title?: string;
+      /**
+       * Can be used to decorate a user interface with a short label about the
+       * data produced.
+       */
+      title?: string;
 
-  /**
-   * The value of this keyword MUST be either a string or an array. If it is
-   * an array, elements of the array MUST be strings and MUST be unique.
-   *
-   * String values MUST be one of the six primitive types (`"null"`,
-   * `"boolean"`, `"object"`, `"array"`, `"number"`, or
-   * `"string"`), or `"integer"` which matches any number with a zero
-   * fractional part.
-   *
-   * An instance validates if and only if the instance is in any of the sets
-   * listed for this keyword.
-   */
-  type?: SchemaType;
+      /**
+       * The value of this keyword MUST be either a string or an array. If it is
+       * an array, elements of the array MUST be strings and MUST be unique.
+       *
+       * String values MUST be one of the six primitive types (`"null"`,
+       * `"boolean"`, `"object"`, `"array"`, `"number"`, or
+       * `"string"`), or `"integer"` which matches any number with a zero
+       * fractional part.
+       *
+       * An instance validates if and only if the instance is in any of the sets
+       * listed for this keyword.
+       */
+      type?: SchemaType;
 
-  /**
-   * The value of this keyword MUST be a boolean.
-   *
-   * If this keyword has boolean value `false`, the instance validates
-   * successfully. If it has boolean value `true`, the instance validates
-   * successfully if all of its elements are unique.
-   *
-   * Omitting this keyword has the same behavior as a value of `false`.
-   *
-   * @default false
-   */
-  uniqueItems?: boolean;
+      /**
+       * The value of this keyword MUST be a boolean.
+       *
+       * If this keyword has boolean value `false`, the instance validates
+       * successfully. If it has boolean value `true`, the instance validates
+       * successfully if all of its elements are unique.
+       *
+       * Omitting this keyword has the same behavior as a value of `false`.
+       *
+       * @default false
+       */
+      uniqueItems?: boolean;
 
-  /**
-   * The value of this keyword MUST be a boolean. When multiple occurrences
-   * of this keyword is applicable to a single sub-instance, the resulting
-   * value MUST be `true` if any occurrence specifies a `true` value, and
-   * MUST be `false` otherwise.
-   *
-   * If `writeOnly` has a value of boolean `true`, it indicates that the
-   * value is never present when the instance is retrieved from the owning
-   * authority. It can be present when sent to the owning authority to update
-   * or create the document (or the resource it represents), but it will not
-   * be included in any updated or newly created version of the instance.
-   *
-   * An instance document that is marked as `writeOnly` for the entire
-   * document MAY be returned as a blank document of some sort, or MAY
-   * produce an error upon retrieval, or have the retrieval request ignored,
-   * at the authority's discretion.
-   *
-   * For example, `writeOnly` would be used to mark a password input field.
-   *
-   * These keywords can be used to assist in user interface instance
-   * generation. In particular, an application MAY choose to use a widget
-   * that hides input values as they are typed for write-only fields.
-   *
-   * @default false
-   */
-  writeOnly?: boolean;
-};
+      /**
+       * The value of this keyword MUST be a boolean. When multiple occurrences
+       * of this keyword is applicable to a single sub-instance, the resulting
+       * value MUST be `true` if any occurrence specifies a `true` value, and
+       * MUST be `false` otherwise.
+       *
+       * If `writeOnly` has a value of boolean `true`, it indicates that the
+       * value is never present when the instance is retrieved from the owning
+       * authority. It can be present when sent to the owning authority to update
+       * or create the document (or the resource it represents), but it will not
+       * be included in any updated or newly created version of the instance.
+       *
+       * An instance document that is marked as `writeOnly` for the entire
+       * document MAY be returned as a blank document of some sort, or MAY
+       * produce an error upon retrieval, or have the retrieval request ignored,
+       * at the authority's discretion.
+       *
+       * For example, `writeOnly` would be used to mark a password input field.
+       *
+       * These keywords can be used to assist in user interface instance
+       * generation. In particular, an application MAY choose to use a widget
+       * that hides input values as they are typed for write-only fields.
+       *
+       * @default false
+       */
+      writeOnly?: boolean;
+    };
 
 // -----------------------------------------------------------------------------
 
 export namespace JSONSchema {
-  export type TypeValue = (
+  export type TypeValue =
     | ValueOf<TypeName>
     | TypeName
     | Array<ValueOf<TypeName> | TypeName>
-    | ReadonlyArray<ValueOf<TypeName> | TypeName>
-  );
+    | ReadonlyArray<ValueOf<TypeName> | TypeName>;
 
   /**
    * JSON Schema interface
@@ -738,20 +745,14 @@ export namespace JSONSchema {
   export type Interface<
     Value = any,
     SchemaType extends TypeValue = TypeValue,
-  > = Exclude<
-    JSONSchema<Value, SchemaType>,
-    boolean
-  >;
+  > = Exclude<JSONSchema<Value, SchemaType>, boolean>;
 
   export type Array<T = any> = Pick<
     Interface<T, "array">,
     KeywordByType.Any | KeywordByType.Array
   >;
 
-  export type Boolean = Pick<
-    Interface<boolean, "boolean">,
-    KeywordByType.Any
-  >;
+  export type Boolean = Pick<Interface<boolean, "boolean">, KeywordByType.Any>;
 
   export type Integer = Pick<
     Interface<number, "integer">,
@@ -763,10 +764,7 @@ export namespace JSONSchema {
     KeywordByType.Any | KeywordByType.Number
   >;
 
-  export type Null = Pick<
-    Interface<null, "null">,
-    KeywordByType.Any
-  >;
+  export type Null = Pick<Interface<null, "null">, KeywordByType.Any>;
 
   export type Object<T = any> = Pick<
     Interface<T, "object">,

--- a/lib/jsr-systeminit/cf-db/isArrayFix.ts
+++ b/lib/jsr-systeminit/cf-db/isArrayFix.ts
@@ -1,0 +1,8 @@
+// Fix typescript issue where Array.isArray doesn't work for readonly arrays
+// https://github.com/microsoft/TypeScript/issues/17002#issuecomment-2781717755
+declare global {
+  interface ArrayConstructor {
+    // deno-lint-ignore no-explicit-any
+    isArray(arg: ReadonlyArray<any> | any): arg is ReadonlyArray<any>;
+  }
+}


### PR DESCRIPTION
We're not generating the loadBalancers schema for Azure right now, among several other critical network ones, due to some issues with circular types.

This PR generates many more valid Azure schemas, and removes some non-valid ones, by changing some rules:

* Process circular schemas (network schemas in particular have a lot of this, including loadBalancers)
* Heavily restrict the endpoints we process to avoid bringing in non-resources (e.g. `".../providers/Microsoft.Network/loadBalancers/{loadBalancerName}"`)
* Don't use "list" endpoints as a source for "read" (they almost always have arrays, not objects)
* Don't process readonly schemas (if it only has GET it's probably a query, search or list)

This PR also brings in real OpenAPI types, so we can stop maintaining them. It does *not* fix up Hetzner or AWS's use of these types.

DRAFT: this could affect Hetzner and AWS and I want to make sure it doesn't change any schemas before checking in

#### Out of Scope:

* loadBalancers are now generating, but are still too big (>4MB). That's next.
* `x-ms-client-flatten` support isn't in, so we are generating a ton of unnecessary indirect properties named `properties`. This is OK, as `properties` is in fact part of the schema, but we may want to support this as users will not be expecting to see it (no other generated Azure clients force you to pass a properties object). 

## How was it tested?

- [X] Saw more Azure resources!!!

## In short: [:link:](https://giphy.com/)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb3BjY3d3Znd5MTFrcnZjMW5rdjgydG85cmd5emhxNXk1enN3djY1aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/grLNXt0wmCaIVdx5lf/giphy.gif"/>
