### PR TITLE
fix(web): Fix an issue wjth Workspace integrations

### DIFF
--- a/app/web/src/components/WorkspaceIntegrationsModal.vue
+++ b/app/web/src/components/WorkspaceIntegrationsModal.vue
@@ -39,9 +39,8 @@ function open() {
 const webhookUrl = ref("");
 
 const updateIntegrations = () => {
-  if (!webhookUrl.value || webhookUrl.value === "" || !integration.value?.pk)
-    return;
-  workspacesStore.UPDATE_INTEGRATION(integration.value?.pk, webhookUrl.value);
+  if (!webhookUrl.value || webhookUrl.value === "") return;
+  workspacesStore.UPDATE_INTEGRATION(webhookUrl.value);
 
   modalRef.value?.close();
   webhookUrl.value = "";

--- a/app/web/src/newhotness/nav/WorkspaceIntegrationsModal.vue
+++ b/app/web/src/newhotness/nav/WorkspaceIntegrationsModal.vue
@@ -44,9 +44,8 @@ function open() {
 const webhookUrl = ref("");
 
 const updateIntegrations = () => {
-  if (!webhookUrl.value || webhookUrl.value === "" || !integration.value?.pk)
-    return;
-  workspacesStore.UPDATE_INTEGRATION(integration.value?.pk, webhookUrl.value);
+  if (!webhookUrl.value || webhookUrl.value === "") return;
+  workspacesStore.UPDATE_INTEGRATION(webhookUrl.value);
 
   modalRef.value?.close();
   webhookUrl.value = "";

--- a/app/web/src/store/workspaces.store.ts
+++ b/app/web/src/store/workspaces.store.ts
@@ -12,8 +12,6 @@ import { useRouterStore } from "./router.store";
 import handleStoreError from "./errors";
 import { AuthApiRequest } from ".";
 
-export type WorkspaceIntegrationId = string;
-
 type WorkspaceExportId = string;
 type WorkspaceExportSummary = {
   id: WorkspaceExportId;
@@ -43,7 +41,6 @@ export type WorkspaceImportSummary = {
 };
 
 export type WorkspaceIntegration = {
-  pk: WorkspaceIntegrationId;
   workspaceId: WorkspacePk;
   slackWebhookUrl?: string;
 };
@@ -187,17 +184,13 @@ export const useWorkspacesStore = () => {
             onSuccess: (response) => {
               if (response)
                 this.integrations = {
-                  pk: response.integration.pk,
-                  workspaceId: response.integration.workspace_pk,
-                  slackWebhookUrl: response.integration.slack_webhook_url,
+                  workspaceId: response.integration.workspacePk,
+                  slackWebhookUrl: response.integration.slackWebhookUrl,
                 };
             },
           });
         },
-        async UPDATE_INTEGRATION(
-          workspaceIntegrationId: WorkspaceIntegrationId,
-          webhookUrl: string,
-        ) {
+        async UPDATE_INTEGRATION(webhookUrl: string) {
           if (
             this.selectedWorkspacePk === null ||
             this.selectedWorkspacePk === ""
@@ -205,12 +198,17 @@ export const useWorkspacesStore = () => {
             return;
           return new ApiRequest({
             method: "post",
-            url: `v2/workspaces/${this.selectedWorkspacePk}/integrations/${workspaceIntegrationId}`,
+            url: `v2/workspaces/${this.selectedWorkspacePk}/integrations`,
             params: {
               slackWebhookUrl: webhookUrl,
             },
             onSuccess: (response) => {
-              this.integrations = response.integration;
+              if (response.integration) {
+                this.integrations = {
+                  workspaceId: response.integration.workspacePk,
+                  slackWebhookUrl: response.integration.slackWebhookUrl,
+                };
+              }
             },
           });
         },

--- a/lib/sdf-server/src/service/v2/integrations/get_integrations.rs
+++ b/lib/sdf-server/src/service/v2/integrations/get_integrations.rs
@@ -11,7 +11,10 @@ use serde::{
     Serialize,
 };
 
-use super::IntegrationsResult;
+use super::{
+    IntegrationResponse,
+    IntegrationsResult,
+};
 use crate::{
     extract::{
         HandlerContext,
@@ -22,8 +25,8 @@ use crate::{
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct GetIntegrationResponse {
-    pub integration: Option<WorkspaceIntegration>,
+pub struct WorkspaceIntegrationResponse {
+    pub integration: Option<IntegrationResponse>,
 }
 
 pub async fn get_integration(
@@ -32,10 +35,12 @@ pub async fn get_integration(
     PosthogClient(_posthog_client): PosthogClient,
     OriginalUri(_original_uri): OriginalUri,
     Host(_host_name): Host,
-) -> IntegrationsResult<Json<GetIntegrationResponse>> {
+) -> IntegrationsResult<Json<WorkspaceIntegrationResponse>> {
     let ctx = builder.build_head(access_builder).await?;
 
-    let integration = WorkspaceIntegration::get_integrations_for_workspace_pk(&ctx).await?;
+    let integration = WorkspaceIntegration::get_integrations_for_workspace_pk(&ctx)
+        .await?
+        .map(|i| i.into());
 
-    Ok(Json(GetIntegrationResponse { integration }))
+    Ok(Json(WorkspaceIntegrationResponse { integration }))
 }


### PR DESCRIPTION
The update endpoint accepted a user-controlled integration_id in the URL path and validated it AFTER lookup, allowing attackers to modify integrations in other workspaces by supplying a different integration ID.

Eliminated integration IDs from the API surface entirely:

1. Removed ID from URL - Changed POST /workspaces/{id}/integrations/{integration_id} to POST /workspaces/{id}/integrations
2. Server-side lookup - Integration is now looked up by workspace context from auth token, not by user-supplied ID
3. Sanitized responses - Created IntegrationResponse type that excludes the internal database ID from API responses

Why is this better?
-  Each workspace has exactly one integration row (enforced by UNIQUE INDEX on workspace_pk)
- No user-controllable identifiers means no opportunity for ID manipulation
- Defense in depth: ID never leaves the server, making attacks architecturally impossible