### PR TITLE
fix(clover): infer-ai needs provider

### DIFF
--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           cd bin/clover
           LOG_LEVEL=debug deno task run fetch-schema --provider=aws
-          LOG_LEVEL=debug deno task run infer-ai
+          LOG_LEVEL=debug deno task run infer-ai --provider=aws
           LOG_LEVEL=debug deno task run fetch-schema --provider=hetzner
 
       - name: Create Pull Request


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

`provider` was added as a global flag, so this broke places that weren't using is.

https://github.com/systeminit/si/actions/runs/18546105749/job/52864300695#step:4:235


## How was it tested?

locally. all good.


## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNjc4dTRqYXVwcXZ0N2I2aWlteWd3NDZpMWl1ZWRpeDFlbW10bmd1diZlcD12MV9naWZzX3NlYXJjaCZjdD1n/10VJ2YDMoNEBl6/giphy.gif"/>