### PR TITLE
feat(metrics): expanded macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "forklift-server",
  "innit-client",
  "si-service",
+ "telemetry-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "decompression-deflate", "decompression-gzip", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1.41" }
 tracing-appender = "0.2.3"
-tracing-opentelemetry = "0.27.0"
+tracing-opentelemetry = { version = "0.27.0", features = ["metrics_gauge_unstable"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json", "std"] }
 tracing-tunnel = "0.1.0"
 trybuild = { version = "1.0.101", features = ["diff"] }

--- a/lib/telemetry-utils-rs/src/lib.rs
+++ b/lib/telemetry-utils-rs/src/lib.rs
@@ -1,3 +1,79 @@
+/// This macro wraps tracing events with `metrics = true` to route them through the MetricsLayer.
+/// The MetricsLayer recognizes four metric type prefixes based on the OpenTelemetry specification.
+///
+/// # Metric Types
+///
+/// ## `counter.` - Up/Down Counter
+/// Values that can both increase and decrease. Use for tracking values that fluctuate in both directions.
+///
+/// **Use cases**: Active connections, queue depth, items in progress
+///
+/// **Example**:
+/// ```rust
+/// # use telemetry_utils::metric;
+/// metric!(counter.connections.active = 1);   // Connection opened
+/// metric!(counter.connections.active = -1);  // Connection closed
+/// ```
+///
+/// ## `monotonic_counter.` - Monotonic Counter
+/// Non-negative values that only increase over time. Use for cumulative totals.
+///
+/// **Use cases**: Total requests, bytes sent, errors occurred, events processed
+///
+/// **Example**:
+/// ```rust
+/// # use telemetry_utils::metric;
+/// metric!(monotonic_counter.requests.total = 1);
+/// metric!(monotonic_counter.bytes.sent = 1024);
+/// ```
+///
+/// ## `histogram.` - Histogram
+/// Distribution of values for statistical analysis. Records the distribution of measurements.
+///
+/// **Use cases**: Request duration, response size, query latency, processing time
+///
+/// **Example**:
+/// ```rust
+/// # use telemetry_utils::metric;
+/// metric!(histogram.request.duration_ms = 125.5);
+/// metric!(histogram.response.size_bytes = 4096);
+/// ```
+///
+/// ## `gauge.` - Gauge
+/// Instantaneous measurements that can arbitrarily go up or down. Represents a point-in-time value.
+///
+/// **Use cases**: Memory usage, CPU percentage, temperature, current queue size
+///
+/// **Example**:
+/// ```rust
+/// # use telemetry_utils::metric;
+/// metric!(gauge.memory.usage_bytes = 1073741824);
+/// metric!(gauge.cpu.percent = 75.5);
+/// ```
+///
+/// # Adding Labels (Attributes)
+///
+/// Metrics support additional key-value labels for dimensionality:
+///
+/// ```rust
+/// # use telemetry_utils::metric;
+/// // Single label
+/// metric!(counter.requests = 1, method = "GET");
+///
+/// // Multiple labels
+/// metric!(histogram.api.latency_ms = 42.5, method = "POST", endpoint = "/users", status = 200);
+///
+/// // Dynamic labels
+/// let service_name = "poop"
+/// metric!(histogram.api.latency_ms = 42.5, method = "POST", service = service_name);
+/// ```
+///
+/// # Important Constraints
+///
+/// - **Do NOT mix** floating-point and integer numbers for the same metric name
+/// - Integers (i64/u64) can be mixed and will be handled automatically
+///
+/// ```
 #[macro_export]
 macro_rules! metric {
     ($key:ident = $value:expr_2021, *) => {
@@ -9,7 +85,99 @@ macro_rules! metric {
     ($($key:ident).+ = $value:expr_2021) => {
         info!(metrics = true, $($key).+ = $value);
     };
-    ($($key:ident).+ = $value:expr_2021, $label:ident = $label_value:expr_2021) => {
-        info!(metrics = true, $($key).+ = $value, $label = $label_value);
+    ($($key:ident).+ = $value:expr_2021, $($label:ident = $label_value:expr_2021),+ $(,)?) => {
+        info!(metrics = true, $($key).+ = $value, $($label = $label_value),+);
+    };
+}
+
+/// Emit a counter metric (can increase or decrease).
+///
+/// Counters track changes in a value that can go both up and down. Use this for tracking
+/// active connections, items in progress, or queue depth.
+///
+/// # Examples
+///
+/// ```rust
+/// # use telemetry_utils::counter;
+/// // Increment
+/// counter!(connections.active = 1);
+///
+/// // Decrement
+/// counter!(connections.active = -1);
+///
+/// // With labels
+/// counter!(tasks.running = 1, worker_id = 42);
+/// counter!(queue.depth = -1, queue_name = "events", priority = "high");
+/// ```
+#[macro_export]
+macro_rules! counter {
+    ($($key:ident).+ = $value:expr_2021 $(, $label:ident = $label_value:expr_2021)* $(,)?) => {
+        $crate::metric!(counter.$($key).+ = $value $(, $label = $label_value)*);
+    };
+}
+
+/// Emit a monotonic counter metric (only increases).
+///
+/// Monotonic counters track cumulative totals that only ever increase. Use this for
+/// counting total requests, bytes sent, errors occurred, or events processed.
+///
+/// # Examples
+///
+/// ```rust
+/// # use telemetry_utils::monotonic;
+/// monotonic!(requests.total = 1);
+/// monotonic!(bytes.sent = 1024);
+/// monotonic!(errors.occurred = 1, error_type = "timeout");
+/// ```
+#[macro_export]
+macro_rules! monotonic {
+    ($($key:ident).+ = $value:expr_2021 $(, $label:ident = $label_value:expr_2021)* $(,)?) => {
+        $crate::metric!(monotonic_counter.$($key).+ = $value $(, $label = $label_value)*);
+    };
+}
+
+/// Emit a histogram metric (distribution of values).
+///
+/// Histograms record the statistical distribution of measurements. Use this for tracking
+/// request durations, response sizes, query latencies, or any value where you want to
+/// analyze percentiles, averages, or distributions.
+///
+/// # Examples
+///
+/// ```rust
+/// # use telemetry_utils::histogram;
+/// histogram!(request.duration_ms = 125.5);
+/// histogram!(response.size_bytes = 4096);
+/// histogram!(query.latency_ms = 23.4, query_type = "select", table = "users");
+/// ```
+#[macro_export]
+macro_rules! histogram {
+    ($($key:ident).+ = $value:expr_2021 $(, $label:ident = $label_value:expr_2021)* $(,)?) => {
+        $crate::metric!(histogram.$($key).+ = $value $(, $label = $label_value)*);
+    };
+}
+
+/// Emit a gauge metric (instantaneous measurement).
+///
+/// Gauges represent point-in-time measurements that can arbitrarily go up or down.
+/// Use this for reporting current memory usage, CPU percentage, temperature, or
+/// instantaneous queue sizes.
+///
+/// Note: Gauges differ from counters in that they represent absolute values rather than
+/// changes. Set a gauge to the current value, don't increment/decrement it.
+///
+/// # Examples
+///
+/// ```rust
+/// # use telemetry_utils::gauge;
+/// gauge!(memory.heap_bytes = 1073741824);
+/// gauge!(cpu.percent = 75.5);
+/// gauge!(temperature.celsius = 42.8, sensor_id = "cpu-1");
+/// gauge!(queue.current_size = 150, queue_name = "events");
+/// ```
+#[macro_export]
+macro_rules! gauge {
+    ($($key:ident).+ = $value:expr_2021 $(, $label:ident = $label_value:expr_2021)* $(,)?) => {
+        $crate::metric!(gauge.$($key).+ = $value $(, $label = $label_value)*);
     };
 }

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -1848,7 +1848,7 @@ cargo.rust_library(
         ":hyper-util-0.1.16",
         ":pin-project-lite-0.2.16",
         ":rustls-0.23.29",
-        ":rustls-native-certs-0.8.1",
+        ":rustls-native-certs-0.8.2",
         ":rustls-pki-types-1.12.0",
         ":tokio-1.46.1",
         ":tower-0.5.2",
@@ -8390,7 +8390,7 @@ cargo.rust_library(
         ":hyper-1.6.0",
         ":hyper-util-0.1.16",
         ":rustls-0.23.29",
-        ":rustls-native-certs-0.8.1",
+        ":rustls-native-certs-0.8.2",
         ":tokio-1.46.1",
         ":tokio-rustls-0.26.2",
         ":tower-service-0.3.3",
@@ -11875,6 +11875,7 @@ cargo.rust_library(
         "default",
         "logs",
         "metrics",
+        "otel_unstable",
         "pin-project-lite",
         "trace",
     ],
@@ -15875,23 +15876,23 @@ cargo.rust_library(
 
 alias(
     name = "rustls-native-certs",
-    actual = ":rustls-native-certs-0.8.1",
+    actual = ":rustls-native-certs-0.8.2",
     visibility = ["PUBLIC"],
 )
 
 http_archive(
-    name = "rustls-native-certs-0.8.1.crate",
-    sha256 = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3",
-    strip_prefix = "rustls-native-certs-0.8.1",
-    urls = ["https://static.crates.io/crates/rustls-native-certs/0.8.1/download"],
+    name = "rustls-native-certs-0.8.2.crate",
+    sha256 = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923",
+    strip_prefix = "rustls-native-certs-0.8.2",
+    urls = ["https://static.crates.io/crates/rustls-native-certs/0.8.2/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "rustls-native-certs-0.8.1",
-    srcs = [":rustls-native-certs-0.8.1.crate"],
+    name = "rustls-native-certs-0.8.2",
+    srcs = [":rustls-native-certs-0.8.2.crate"],
     crate = "rustls_native_certs",
-    crate_root = "rustls-native-certs-0.8.1.crate/src/lib.rs",
+    crate_root = "rustls-native-certs-0.8.2.crate/src/lib.rs",
     edition = "2021",
     named_deps = {
         "pki_types": ":rustls-pki-types-1.12.0",
@@ -19913,6 +19914,7 @@ cargo.rust_library(
     features = [
         "default",
         "metrics",
+        "metrics_gauge_unstable",
         "smallvec",
         "tracing-log",
     ],

--- a/third-party/rust/Cargo.lock
+++ b/third-party/rust/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.29",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs 0.8.2",
  "rustls-pki-types",
  "tokio",
  "tower 0.5.2",
@@ -3445,7 +3445,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.29",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs 0.8.2",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -5946,9 +5946,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -7167,7 +7167,7 @@ dependencies = [
  "ringmap",
  "rust-s3",
  "rustls 0.23.29",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs 0.8.2",
  "rustls-pemfile 2.2.0",
  "sea-orm",
  "serde",

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -171,7 +171,7 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["compression-br", "compression-deflate", "compression-gzip", "cors", "decompression-deflate", "decompression-gzip", "trace"] } # todo: pinning back to 0.4.4, upgrade this alongside hyper/http/axum/tokio-tungstenite
 tracing = { version = "0.1.41" }
 tracing-appender = "0.2.3"
-tracing-opentelemetry = "0.27.0"
+tracing-opentelemetry = { version = "0.27.0", features = ["metrics_gauge_unstable"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json", "std"] }
 tracing-tunnel = "0.1.0"
 trybuild = { version = "1.0.101", features = ["diff"] }


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

* extends the `metric!` macro to allow for multiple labels
* adds the feature flag for `gauge` metrics
* adds helper macros to make usage a bit easier
  * `counter!`
  * `monotonic!`
  * `histogram!`
  * `gauge!`
  
#### Screenshots:

```rust
counter!(test.connections = 1);
counter!(test.connections = -1, connection_type = "websocket");
counter!(
    test.connected = 1,
    connection_type = "websocket",
    mulitple_labels = true
);
let test = "test";
counter!(test.variables = 1, var = test);

monotonic!(test.requests_total = 1);
monotonic!(test.bytes_sent = 1024, protocol = "http");

histogram!(test.startup_duration_ms = 42.5);
histogram!(test.request_size_bytes = 4096, endpoint = "/api/health");

gauge!(test.memory_usage_mb = 256);
gauge!(test.cpu_percent = 15.5, core = 0);
```

<img width="1744" height="858" alt="image" src="https://github.com/user-attachments/assets/fc2e1159-6369-4683-8a88-a1e673381437" />


## How was it tested?

Builds locally and I still see all of the existing metrics.

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI

## In short: [:link:](https://giphy.com/)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlY2FubnF4azQxaDRtdnNkc3lqY21odzU2bWU4YXp3c29wM3Y4cThvMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3osxYc2axjCJNsCXyE/giphy.gif"/>