### PR TITLE
Bust deployment atoms, refactor to common pattern

### DIFF
--- a/app/web/src/store/realtime/heimdall.ts
+++ b/app/web/src/store/realtime/heimdall.ts
@@ -31,9 +31,9 @@ import {
   ConnStatusFn,
 } from "@/workers/types/dbinterface";
 import {
-  CachedDefaultVariant,
   Connection,
   EntityKind,
+  GLOBAL_IDENTIFIER,
   GlobalEntity,
   SchemaMembers,
 } from "@/workers/types/entity_kind_types";
@@ -43,7 +43,6 @@ import { DefaultMap } from "@/utils/defaultmap";
 import * as rainbow from "@/newhotness/logic_composables/rainbow_counter";
 import { sdfApiInstance as sdf } from "@/store/apis.web";
 import { WorkspaceMetadata, WorkspacePk } from "@/api/sdf/dal/workspace";
-import { SchemaId } from "@/api/sdf/dal/schema";
 import {
   cachedAppEmitter,
   SHOW_CACHED_APP_NOTIFICATION_EVENT,
@@ -237,8 +236,13 @@ const bustTanStackCache: BustCacheFn = (
   id: string,
   noBroadcast?: boolean,
 ) => {
-  const queryKey = [workspaceId, changeSetId, kind, id];
-  queryClient?.invalidateQueries({ queryKey });
+  if (workspaceId === GLOBAL_IDENTIFIER && changeSetId === GLOBAL_IDENTIFIER) {
+    const queryKey = ["global", kind, id];
+    queryClient?.invalidateQueries({ queryKey });
+  } else {
+    const queryKey = [workspaceId, changeSetId, kind, id];
+    queryClient?.invalidateQueries({ queryKey });
+  }
   if (!noBroadcast) {
     db.broadcastMessage({
       messageKind: "cacheBust",
@@ -514,7 +518,7 @@ export const bifrostList = async <T>(args: {
 export const getKind = async <T>(args: {
   workspaceId: WorkspacePk;
   changeSetId: ChangeSetId;
-  kind: Exclude<EntityKind, GlobalEntity>;
+  kind: EntityKind;
 }): Promise<T[]> => {
   if (!initCompleted.value) throw new Error("You must wait for initialization");
 
@@ -528,23 +532,6 @@ export const getKind = async <T>(args: {
   // eslint-disable-next-line no-console
   console.log("🌈 bifrost getKind", end - start, "ms");
   return records.map((r) => JSON.parse(r));
-};
-
-export const getDefaultSchemaVariants = async (): Promise<
-  Record<SchemaId, CachedDefaultVariant>
-> => {
-  if (!initCompleted.value) throw new Error("You must wait for initialization");
-
-  const start = performance.now();
-  const records = await db.getDefaultSchemaVariants();
-  const end = performance.now();
-  // eslint-disable-next-line no-console
-  console.log("🌈 bifrost getDefaultSchemaVariants", end - start, "ms");
-  const parsed: Record<SchemaId, CachedDefaultVariant> = {};
-  Object.entries(records).forEach(([k, v]) => {
-    parsed[k] = JSON.parse(v);
-  });
-  return parsed;
 };
 
 /**

--- a/app/web/src/store/realtime/heimdall_inner.ts
+++ b/app/web/src/store/realtime/heimdall_inner.ts
@@ -1,6 +1,11 @@
 // This is where re-usable code for use in actual test execution goes.
 import { computed, ComputedRef, MaybeRefOrGetter, toValue } from "vue";
-import { EntityKind } from "@/workers/types/entity_kind_types";
+import {
+  EntityKind,
+  GLOBAL_ENTITIES,
+  GLOBAL_IDENTIFIER,
+  GlobalEntity,
+} from "@/workers/types/entity_kind_types";
 import { Gettable } from "@/workers/types/dbinterface";
 import { Context } from "@/newhotness/types";
 
@@ -13,26 +18,42 @@ export const innerUseMakeKey = (ctx: Context) => {
     computed<
       | [string, string, ComputedRef<K> | K, string, string]
       | [string, string, ComputedRef<K> | K, string]
-    >(() =>
-      extension
-        ? [
-            ctx.workspacePk.value,
-            ctx.changeSetId.value,
-            toValue(kind),
-            toValue(id ?? ctx.workspacePk.value),
-            toValue(extension),
-          ]
-        : [
-            ctx.workspacePk.value,
-            ctx.changeSetId.value,
-            toValue(kind),
-            toValue(id ?? ctx.workspacePk),
-          ],
-    );
+      | [string, ComputedRef<K> | K, string]
+    >(() => {
+      if (GLOBAL_ENTITIES.includes(kind as GlobalEntity)) {
+        return [
+          GLOBAL_IDENTIFIER,
+          toValue(kind),
+          toValue(id) ?? GLOBAL_IDENTIFIER,
+        ];
+      } else
+        return extension
+          ? [
+              ctx.workspacePk.value,
+              ctx.changeSetId.value,
+              toValue(kind),
+              toValue(id ?? ctx.workspacePk.value),
+              toValue(extension),
+            ]
+          : [
+              ctx.workspacePk.value,
+              ctx.changeSetId.value,
+              toValue(kind),
+              toValue(id ?? ctx.workspacePk),
+            ];
+    });
 };
 
 export const innerUseMakeArgs = (ctx: Context) => {
-  return <K = Gettable>(kind: EntityKind, id?: string) => {
+  return <K = Gettable | GlobalEntity>(kind: EntityKind, id?: string) => {
+    if (GLOBAL_ENTITIES.includes(kind as GlobalEntity)) {
+      return {
+        workspaceId: "-",
+        changeSetId: "-",
+        kind: kind as K,
+        id: id ?? "-",
+      };
+    }
     return {
       workspaceId: ctx.workspacePk.value,
       changeSetId: ctx.changeSetId.value,

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -345,12 +345,6 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
-  async getDefaultSchemaVariants() {
-    return await withLeader(
-      async (remote) => await remote.getDefaultSchemaVariants(),
-    );
-  },
-
   async queryAttributes(
     workspaceId: WorkspacePk,
     changeSetId: ChangeSetId,

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -221,9 +221,8 @@ export interface SharedDBInterface {
   getKind(
     workspaceId: string,
     changeSetId: ChangeSetId,
-    kind: Exclude<EntityKind, GlobalEntity>,
+    kind: EntityKind,
   ): Promise<string[]>;
-  getDefaultSchemaVariants(): Promise<Record<string, string>>;
   /**
    * Query AttributeTree MVs in a changeset, looking for components that match the given terms.
    *
@@ -339,11 +338,10 @@ export interface TabDBInterface {
     kind: Gettable,
     id: Id,
   ): boolean;
-  getDefaultSchemaVariants(): Record<string, string>;
   getKind(
     workspaceId: string,
     changeSetId: ChangeSetId,
-    kind: Exclude<EntityKind, GlobalEntity>,
+    kind: EntityKind,
   ): string[];
   getList(
     workspaceId: string,

--- a/app/web/src/workers/types/entity_kind_types.ts
+++ b/app/web/src/workers/types/entity_kind_types.ts
@@ -60,7 +60,6 @@ export enum EntityKind {
   CachedSchema = "CachedSchema",
   CachedSchemaVariant = "CachedSchemaVariant",
   CachedDefaultVariant = "CachedDefaultVariant",
-  DefaultSchemaIdAndVariant = "DefaultSchemaIdAndVariant",
 }
 
 export const GLOBAL_ENTITIES = [
@@ -68,6 +67,8 @@ export const GLOBAL_ENTITIES = [
   EntityKind.CachedDefaultVariant,
 ] as const;
 export type GlobalEntity = (typeof GLOBAL_ENTITIES)[number];
+
+export const GLOBAL_IDENTIFIER = "-";
 
 /**
  * NOTE, if you want to narrow the type of a variable


### PR DESCRIPTION
## How does this PR change the system?

1. Deployment atoms weren't getting cache busts sent to tanstack (b/c nothing was reading them in the last PR!)
2. Handle global atoms with `getKind`

## How was it tested?

Same as the last PR 🤪 (add component modal)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbXN0Y3c4dmliMHpxN2FsMHpmMzJqM3p6YTBjeWpyNmRlZmtjMHhybiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jRN27EUBzMiIdPVPZp/giphy.gif"/>