### PR TITLE
chore(sdf): increase manual module upload size limit

### DIFF
--- a/lib/sdf-server/src/service/v2/module.rs
+++ b/lib/sdf-server/src/service/v2/module.rs
@@ -1,6 +1,9 @@
 use axum::{
     Router,
-    extract::multipart::MultipartError,
+    extract::{
+        DefaultBodyLimit,
+        multipart::MultipartError,
+    },
     http::StatusCode,
     response::{
         IntoResponse,
@@ -33,6 +36,9 @@ mod list;
 mod module_by_hash;
 mod module_by_id;
 mod sync;
+
+// 20MB upload limit for module files
+const MAX_UPLOAD_BYTES: usize = 1024 * 1024 * 20;
 
 pub type ModuleAPIResult<T> = Result<T, ModulesAPIError>;
 
@@ -112,4 +118,5 @@ pub fn v2_routes() -> Router<AppState> {
             "/install_from_file",
             post(install_from_file::install_module_from_file),
         )
+        .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
 }


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Adjusts the default upload file size limit (2mb) to 20mb. This is only for the manual spec uploads done via the UI so we can test the larger Azure assets.


## How was it tested?

Manually was able to upload 15mb specs. Took a while, but it worked.

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI


## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMjVqNGlvdWYxMjYxZjJrMDE0c2IzZzB3eHFncTB1ZDN6ZzRibHB6aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT1R9Kqhm3PBnlpqpy/giphy.gif"/>