### PR TITLE
[feat] Azure: remove readOnly props from domain

### DIFF
--- a/bin/clover/src/assertUnreachable.ts
+++ b/bin/clover/src/assertUnreachable.ts
@@ -1,0 +1,4 @@
+import util from "node:util";
+export function assertUnreachable(value: never): never {
+  throw new Error(`Didn't expect to get here: ${util.inspect(value)}`);
+}

--- a/bin/clover/src/pipelines/aws/provider.ts
+++ b/bin/clover/src/pipelines/aws/provider.ts
@@ -15,11 +15,10 @@ import {
   MANAGEMENT_FUNCS,
   QUALIFICATION_FUNC_SPECS,
 } from "./funcs.ts";
-import type { CfSchema } from "./schema.ts";
 import { generateAwsSpecs } from "./pipeline.ts";
 import { JSONSchema } from "../draft_07.ts";
 
-function cfCategory(schema: CfSchema): string {
+function cfCategory(schema: SuperSchema): string {
   const [metaCategory, category] = schema.typeName.split("::");
   return `${metaCategory}::${category}`;
 }

--- a/bin/clover/src/pipelines/aws/schema.ts
+++ b/bin/clover/src/pipelines/aws/schema.ts
@@ -1,14 +1,13 @@
 import type { JSONSchema } from "../draft_07.ts";
-import type { CfProperty, CfHandler, CfHandlerKind } from "../types.ts";
+import type {
+  CfProperty,
+  CfHandler,
+  CfHandlerKind,
+  SuperSchema,
+  JSONPointer,
+} from "../types.ts";
 
-type JSONPointer = string;
-
-export type CfSchema = {
-  typeName: string;
-  description: string;
-  primaryIdentifier: JSONPointer[];
-  sourceUrl?: string;
-  documentationUrl?: string;
+export interface CfSchema extends SuperSchema {
   replacementStrategy?: "create_then_delete" | "delete_then_create";
   taggable?: boolean;
   tagging?: {
@@ -24,6 +23,7 @@ export type CfSchema = {
   properties: Record<string, CfProperty>;
   readOnlyProperties?: JSONPointer[];
   writeOnlyProperties?: JSONPointer[];
+  primaryIdentifier: JSONPointer[];
   conditionalCreateOnlyProperties?: JSONPointer[];
   nonPublicProperties?: JSONPointer[];
   nonPublicDefinitions?: JSONPointer[];
@@ -36,6 +36,6 @@ export type CfSchema = {
     mappings: Record<string, JSONPointer>;
   };
   propertyTransform?: Record<string, string>;
-};
+}
 
 export type CfDb = Record<string, CfSchema>;

--- a/bin/clover/src/pipelines/azure/provider.ts
+++ b/bin/clover/src/pipelines/azure/provider.ts
@@ -14,7 +14,7 @@ import {
 } from "./funcs.ts";
 import { normalizeAzureProperty } from "./spec.ts";
 import { generateAzureSpecs } from "./pipeline.ts";
-import { initAzureRestApiSpecsRepo } from "./schema.ts";
+import { AzureSchema, initAzureRestApiSpecsRepo } from "./schema.ts";
 import { JSONSchema } from "../draft_07.ts";
 
 async function azureFetchSchema(options: FetchSchemaOptions) {
@@ -61,7 +61,7 @@ function azureCategory(schema: SuperSchema): string {
 }
 
 function azureIsChildRequired(
-  schema: SuperSchema,
+  schema: SuperSchema | AzureSchema,
   _parentProp: ExpandedPropSpecFor["object" | "array" | "map"] | undefined,
   childName: string,
 ): boolean {

--- a/bin/clover/src/pipelines/azure/schema.ts
+++ b/bin/clover/src/pipelines/azure/schema.ts
@@ -1,10 +1,9 @@
 import type {
   CfArrayProperty,
-  CfHandler,
-  CfHandlerKind,
   CfObjectProperty,
   CfProperty,
   CommonCommandOptions,
+  SuperSchema,
 } from "../types.ts";
 import { JSONSchema } from "../draft_07.ts";
 import assert from "node:assert";
@@ -38,8 +37,6 @@ type DereferenceChildren<T> = {
   [K in keyof T]: Dereference<T[K]>;
 };
 
-type JSONPointer = string;
-
 export type PropertySet = Set<string>;
 
 export interface AzureOperationData {
@@ -49,15 +46,8 @@ export interface AzureOperationData {
   apiVersion?: string;
 }
 
-export interface AzureSchema {
-  typeName: string;
-  description: string;
-  sourceUrl?: string;
-  documentationUrl?: string;
-  properties: Record<string, CfProperty>;
+export interface AzureSchema extends SuperSchema {
   requiredProperties: Set<string>;
-  primaryIdentifier: JSONPointer[];
-  handlers?: { [key in CfHandlerKind]?: CfHandler };
   apiVersion?: string;
 }
 
@@ -71,9 +61,14 @@ export const AZURE_HTTP_METHODS = [
 ] as const;
 export type AzureHttpMethod = (typeof AZURE_HTTP_METHODS)[number];
 
-export type AzureProperty = CfProperty;
-export type AzureObjectProperty = CfObjectProperty;
-export type AzureArrayProperty = CfArrayProperty;
+export type AzureProperty = CfProperty & AzurePropExtensions;
+export type AzureObjectProperty = CfObjectProperty & AzurePropExtensions;
+export type AzureArrayProperty = CfArrayProperty & AzurePropExtensions;
+interface AzurePropExtensions {
+  readOnly?: boolean;
+  items?: AzureProperty;
+  properties?: Record<string, AzureProperty>;
+}
 
 export function isAzureObjectProperty(o: unknown): o is AzureObjectProperty {
   if (!(typeof o === "object" && o !== null)) return false;

--- a/bin/clover/src/pipelines/dummy/provider.ts
+++ b/bin/clover/src/pipelines/dummy/provider.ts
@@ -16,7 +16,7 @@ import {
   MANAGEMENT_FUNCS,
   QUALIFICATION_FUNC_SPECS,
 } from "./funcs.ts";
-import { databaseSchema, serverSchema } from "./schema.ts";
+import { databaseSchema, DummySchema, serverSchema } from "./schema.ts";
 import { ExpandedPropSpecFor } from "../../spec/props.ts";
 import { generateDummySpecs } from "./pipeline.ts";
 import { DUMMY_PROP_OVERRIDES, DUMMY_SCHEMA_OVERRIDES } from "./overrides.ts";
@@ -51,7 +51,7 @@ function dummyNormalizeProperty(
 }
 
 function dummyIsChildRequired(
-  schema: SuperSchema,
+  schema: SuperSchema | DummySchema,
   _parentProp: ExpandedPropSpecFor["object" | "array" | "map"] | undefined,
   childName: string,
 ): boolean {

--- a/bin/clover/src/pipelines/dummy/schema.ts
+++ b/bin/clover/src/pipelines/dummy/schema.ts
@@ -1,6 +1,11 @@
-import { SuperSchema } from "../types.ts";
+import { CfProperty, SuperSchema } from "../types.ts";
 
-export const serverSchema: SuperSchema = {
+export interface DummySchema extends SuperSchema {
+  properties: Record<string, CfProperty>;
+  requiredProperties: Set<string>;
+}
+
+export const serverSchema: DummySchema = {
   typeName: "Dummy::Server",
   description: "A dummy server resource for testing",
   properties: {
@@ -32,7 +37,6 @@ export const serverSchema: SuperSchema = {
     },
   },
   requiredProperties: new Set(["name", "size", "region"]),
-  primaryIdentifier: ["id"],
   handlers: {
     create: { permissions: [], timeoutInMinutes: 60 },
     read: { permissions: [], timeoutInMinutes: 60 },
@@ -42,7 +46,7 @@ export const serverSchema: SuperSchema = {
   },
 };
 
-export const databaseSchema: SuperSchema = {
+export const databaseSchema: DummySchema = {
   typeName: "Dummy::Database",
   description: "A dummy database resource for testing",
   properties: {
@@ -78,7 +82,6 @@ export const databaseSchema: SuperSchema = {
     },
   },
   requiredProperties: new Set(["name", "engine"]),
-  primaryIdentifier: ["id"],
   handlers: {
     create: { permissions: [], timeoutInMinutes: 60 },
     read: { permissions: [], timeoutInMinutes: 60 },

--- a/bin/clover/src/pipelines/dummy/spec.ts
+++ b/bin/clover/src/pipelines/dummy/spec.ts
@@ -3,15 +3,16 @@ import { OnlyProperties } from "../../spec/props.ts";
 import { makeModule } from "../generic/index.ts";
 import { CfProperty, SuperSchema } from "../types.ts";
 import { DUMMY_PROVIDER_CONFIG } from "./provider.ts";
-import { databaseSchema, serverSchema } from "./schema.ts";
+import { databaseSchema, DummySchema, serverSchema } from "./schema.ts";
 
 function splitDummyProperties(
-  schema: SuperSchema,
+  schema: SuperSchema | DummySchema,
   onlyProperties: OnlyProperties,
 ): {
   domainProperties: Record<string, CfProperty>;
   resourceValueProperties: Record<string, CfProperty>;
 } {
+  if (!("properties" in schema)) throw new Error("Not DummySchema");
   const readOnlySet = new Set(onlyProperties.readOnly);
   const domainProperties: Record<string, CfProperty> = {};
   const resourceValueProperties: Record<string, CfProperty> = {};

--- a/bin/clover/src/pipelines/hetzner/pipeline-steps/createCredential.ts
+++ b/bin/clover/src/pipelines/hetzner/pipeline-steps/createCredential.ts
@@ -14,18 +14,17 @@ import {
 import { makeModule } from "../../generic/index.ts";
 import { HetznerSchema } from "../schema.ts";
 import { hetznerProviderConfig } from "./../provider.ts";
+import { CfProperty } from "../../types.ts";
 
 export function generateCredentialModule(specs: ExpandedPkgSpec[]) {
   const credential: HetznerSchema = {
     typeName: "Hetzner::Credential::ApiToken",
     description: "A Hetzner cloud credential connection",
-    properties: {
-      HetznerApiToken: { type: "string" },
-    },
     requiredProperties: new Set([]),
-    primaryIdentifier: [],
   };
-
+  const properties: Record<string, CfProperty> = {
+    HetznerApiToken: { type: "string" },
+  };
   const onlyProperties: OnlyProperties = {
     createOnly: [],
     readOnly: [],
@@ -33,7 +32,11 @@ export function generateCredentialModule(specs: ExpandedPkgSpec[]) {
     primaryIdentifier: [],
   };
 
-  const credentialSpec = createCredentialSpec(credential, onlyProperties);
+  const credentialSpec = createCredentialSpec(
+    credential,
+    properties,
+    onlyProperties,
+  );
   specs.push(credentialSpec);
 
   return specs;
@@ -41,6 +44,7 @@ export function generateCredentialModule(specs: ExpandedPkgSpec[]) {
 
 function createCredentialSpec(
   credential: HetznerSchema,
+  properties: Record<string, CfProperty>,
   onlyProperties: OnlyProperties,
 ): ExpandedPkgSpec {
   const spec = makeModule(
@@ -48,7 +52,7 @@ function createCredentialSpec(
     credential.description,
     onlyProperties,
     hetznerProviderConfig,
-    credential.properties,
+    properties,
     {},
   );
 
@@ -61,7 +65,7 @@ function createCredentialSpec(
   // Create the secret definition manually since it needs special handling
   const secretDefinition = createDefaultPropFromJsonSchema(
     "secret_definition",
-    credential.properties,
+    properties,
     credential,
     onlyProperties,
     hetznerProviderConfig.functions.createDocLink,

--- a/bin/clover/src/pipelines/hetzner/provider.ts
+++ b/bin/clover/src/pipelines/hetzner/provider.ts
@@ -21,7 +21,11 @@ import {
   MANAGEMENT_FUNCS,
   QUALIFICATION_FUNC_SPECS,
 } from "./funcs.ts";
-import { type JsonSchema, type OperationData } from "./schema.ts";
+import {
+  HetznerSchema,
+  type JsonSchema,
+  type OperationData,
+} from "./schema.ts";
 import { mergeResourceOperations, normalizeHetznerProperty } from "./spec.ts";
 import { generateHetznerSpecs } from "./pipeline.ts";
 import { JSONSchema } from "../draft_07.ts";
@@ -54,7 +58,7 @@ function hCategory(schema: SuperSchema): string {
 }
 
 function hetznerIsChildRequired(
-  schema: SuperSchema,
+  schema: SuperSchema | HetznerSchema,
   _parentProp: ExpandedPropSpecFor["object" | "array" | "map"] | undefined,
   childName: string,
 ): boolean {

--- a/bin/clover/src/pipelines/hetzner/schema.ts
+++ b/bin/clover/src/pipelines/hetzner/schema.ts
@@ -1,19 +1,9 @@
-import type { CfProperty } from "../types.ts";
-import { CfHandler, CfHandlerKind } from "../types.ts";
+import type { SuperSchema } from "../types.ts";
 
-type JSONPointer = string;
-
-export type HetznerSchema = {
-  typeName: string;
-  description: string;
-  sourceUrl?: string;
-  documentationUrl?: string;
-  properties: Record<string, CfProperty>;
+export interface HetznerSchema extends SuperSchema {
   requiredProperties: Set<string>;
-  primaryIdentifier: JSONPointer[];
-  handlers?: Record<CfHandlerKind, CfHandler>;
   endpoint?: string;
-};
+}
 
 export type JsonSchema = Record<string, unknown>;
 

--- a/bin/clover/src/pipelines/types.ts
+++ b/bin/clover/src/pipelines/types.ts
@@ -1,10 +1,7 @@
 import type { JSONSchema } from "./draft_07.ts";
-import type { HetznerSchema } from "./hetzner/schema.ts";
-import type { AzureSchema } from "./azure/schema.ts";
 import type { Extend } from "../extend.ts";
 import { ActionFuncSpecKind } from "../bindings/ActionFuncSpecKind.ts";
 import { FuncSpecInfo } from "../spec/funcs.ts";
-import type { CfSchema } from "./aws/schema.ts";
 import { ExpandedPkgSpec } from "../spec/pkgs.ts";
 import { ExpandedPropSpec, ExpandedPropSpecFor } from "../spec/props.ts";
 import { Provider } from "../types.ts";
@@ -98,7 +95,15 @@ export type CfHandler = {
 
 export type { CfDb, CfSchema } from "./aws/schema.ts";
 
-export type SuperSchema = HetznerSchema | CfSchema | AzureSchema;
+export type JSONPointer = string;
+
+export interface SuperSchema {
+  typeName: string;
+  description: string;
+  sourceUrl?: string;
+  documentationUrl?: string;
+  handlers?: { [key in CfHandlerKind]?: CfHandler };
+}
 
 export type CategoryFn = ({ typeName }: SuperSchema) => string;
 


### PR DESCRIPTION
This uses the GET response for the resourceValue, and the PUT request for the domain for Azure, to make sure the API shapes match the actual requests we do. It also goes through the PUT request and removes any `readOnly` parameters, since you can't specify those!

I did some type work to separate out OnlyProperties and schema properties that were not shared, as well.

#### Out of Scope:

* There may be a discovery/import turn to set readOnly and writeOnly on the appropriate props by comparing the domain against the resourceValue. But we may also want to handle that more generally, y
* createOnly appears to be only specified in the description. We may end up having to go to the original autorest specs to see if the data we need is there; otherwise, createOnly may be a job for AI!

## How was it tested?

- [X] Microsoft.Compute/virtualMachines has provisioningState in resourceValue, but not in domain

## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdldTN5OGpzcTl5eWRleG04Zm9jc3p3OTZrMmI0anJkd2FxYnNtNm41dSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1iu8uG2cjYFZS6wTxv/giphy-downsized-medium.gif"/>
