### PR TITLE
chore: commit Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,7 +3267,6 @@ dependencies = [
  "forklift-server",
  "innit-client",
  "si-service",
- "telemetry-utils",
 ]
 
 [[package]]


### PR DESCRIPTION
The dependencies for forklift on main for some reason includes telemetry-utils. But that is not `bin/forklift/Cargo.toml`. `cargo` is automatically removing it every time it runs, so let's commit it.