### PR TITLE
modal loading state fixes

### DIFF
--- a/app/web/src/newhotness/CreateTemplateModal.vue
+++ b/app/web/src/newhotness/CreateTemplateModal.vue
@@ -3,6 +3,8 @@
     ref="modalRef"
     title="Create template"
     confirmLabel="Create"
+    loadingText="Creating..."
+    :requestStatus="createTemplateApi.requestStatuses.value"
     @confirm="confirm"
     @keydown.enter="confirm"
   >

--- a/app/web/src/newhotness/DuplicateComponentsModal.vue
+++ b/app/web/src/newhotness/DuplicateComponentsModal.vue
@@ -4,6 +4,8 @@
     title="Duplicate"
     confirmLabel="Duplicate"
     size="xl"
+    :loading="isConfirming"
+    loadingText="Duplicating..."
     @confirm="emit('confirm', prefixName)"
   >
     <ErrorMessage v-if="requestError">{{ requestError }}</ErrorMessage>

--- a/app/web/src/newhotness/EraseModal.vue
+++ b/app/web/src/newhotness/EraseModal.vue
@@ -5,7 +5,9 @@
     irreversible
     confirmIcon="trash"
     confirmTone="destructive"
-    @confirm="emit('confirm')"
+    :loading="confirming"
+    loadingText="Erasing..."
+    @confirm="confirm"
   >
     <div>
       You are about to erase
@@ -61,8 +63,11 @@ const components = ref<ComponentInList[]>([]);
 
 const modalRef = ref<InstanceType<typeof ConfirmModal>>();
 
+const confirming = ref(false);
+
 function open(selectedComponents: ComponentInList[]) {
   components.value = selectedComponents;
+  confirming.value = false;
   modalRef.value?.open();
 }
 function close() {
@@ -73,6 +78,11 @@ function close() {
 const emit = defineEmits<{
   (e: "confirm"): void;
 }>();
+
+const confirm = () => {
+  confirming.value = true;
+  emit("confirm");
+};
 
 defineExpose({ open, close });
 </script>

--- a/app/web/src/newhotness/layout_components/ConfirmModal.vue
+++ b/app/web/src/newhotness/layout_components/ConfirmModal.vue
@@ -21,6 +21,10 @@
           :icon="confirmIcon"
           :tone="confirmTone"
           :disabled="!irreversibleConfirmed"
+          :loading="loading"
+          :loadingText="loadingText"
+          :loadingIcon="loadingIcon"
+          :requestStatus="requestStatus"
           @click="emit('confirm')"
         >
           {{ confirmLabel }}
@@ -39,6 +43,7 @@ import {
   useModal,
   VormInput,
 } from "@si/vue-lib/design-system";
+import { ApiRequestStatus } from "@si/vue-lib/pinia";
 import { nextTick, PropType, ref } from "vue";
 
 const props = defineProps({
@@ -52,6 +57,12 @@ const props = defineProps({
       "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "4wxl" | "6xl" | "7xl" | "max"
     >,
     default: "lg",
+  },
+  loading: { type: Boolean },
+  loadingText: { type: String },
+  loadingIcon: { type: String as PropType<IconNames>, default: "loader" },
+  requestStatus: {
+    type: [Boolean, Object] as PropType<false | ApiRequestStatus>, // can be false if passing 'someCondition && status'
   },
 });
 


### PR DESCRIPTION
## How does this PR change the system?

Fixes a few modals which did not properly disable and show a loading state when the user clicked the action button.

Fixes [BUG-1093](https://linear.app/system-initiative/issue/BUG-1093/create-template-modal-is-unresponsive)

#### Screenshots:

<img width="538" height="483" alt="Screenshot 2025-10-20 at 4 10 34 PM" src="https://github.com/user-attachments/assets/f8531e31-4595-4304-b668-08dee244de5e" />

#### Out of Scope:

There is probably a pass to be made in the future to unify the styles and underlying structure of all the modals in the new UI.

## How was it tested?

Checked each modal thoroughly with the vite delay enabled to see that everything works properly.
