### PR TITLE
Skip variants that are neither default nor editing

### DIFF
--- a/app/web/src/newhotness/AddComponentModal.vue
+++ b/app/web/src/newhotness/AddComponentModal.vue
@@ -544,6 +544,14 @@ const categories = computed(() => {
   const installedSchemas: Set<string> = new Set();
   if (installedVariants.data.value) {
     installedVariants.data.value.forEach((variant) => {
+      // Only show installed variants that are either the default or are editing.
+      const members = ctx.schemaMembers?.value[variant.schemaId];
+      if (
+        members?.defaultVariantId !== variant.id &&
+        members?.editingVariantId !== variant.id
+      )
+        return;
+
       let category = categories[variant.category];
       if (!category) {
         category = {


### PR DESCRIPTION
## Description

This change ensures that we skip schema variants that are neither the default nor the editing variant for a given schema. We can show both the editing variant and the default variant, but all other variants will be filtered out in the AddComponentModal.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbWF6bGZkNTg3ejRyODNya2VxNzlsaXgzeXdsYWU4eXZ1aTNzd2k4MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/rYeCiuSACNqiWHacXN/giphy.gif"/>

## Testing

1. Create a change set
2. Create an `AWS ARN` component
3. Apply to HEAD
4. Create another change set
5. Create an unlocked `AWS ARN` variant, add a prop to it and regenerate
6. Observe two options in the AddComponentModal (one is a working copy)
7. Apply to HEAD
8. Create a third change set
9. Observe that only one variant is available in the AddComponentModal
10. Create another `AWS ARN` component
11. Observe that it is the component with the new prop
12. Create another unlocked variant, add another prop and regenerate
13. Observe that both variants are available in the AddComponentModal
14. Repeat the earlier steps to test that new components get both new props