### PR TITLE
Graceful failure for changeset mvIndex

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -127,6 +127,23 @@
         />
         <Onboarding v-else @completed="onboardingCompleted = true" />
       </template>
+      <main
+        v-else-if="indexFailedToLoad"
+        :class="
+          clsx(
+            'grow min-h-0 m-sm border flex flex-row items-center justify-center',
+            themeClasses('border-neutral-400', 'border-neutral-600'),
+          )
+        "
+      >
+        <EmptyState
+          icon="logo-si"
+          text="Unable to Load Change Set Data"
+          secondaryText="We failed to load the data associated with this change set. This is our problem, and we have been alerted. You may select another change set."
+          finalLinkText="Click here to see your other workspaces"
+          @final="bumpToWorkspaces"
+        />
+      </main>
       <!-- grow the main body to fit all the space in between the nav and the bottom of the browser window
            min-h-0 prevents the main container from being *larger* than the max it can grow, no matter its contents -->
       <main v-else class="grow min-h-0">
@@ -645,6 +662,13 @@ watch(
     }
   },
 );
+
+const indexFailedToLoad = computed(() => {
+  // NOTE: this represents a 5XX error that was retried 5 times
+  // if we get here its likely because the index could not be retrieved, or even built
+  // don't trap people into the lobby, but give them an error page for only one index!
+  return heimdall.indexFailures.has(props.changeSetId);
+});
 
 const hiddenAt = ref<Date | undefined>(undefined);
 

--- a/app/web/src/workers/shared_webworker.ts
+++ b/app/web/src/workers/shared_webworker.ts
@@ -426,7 +426,10 @@ const dbInterface: SharedDBInterface = {
     );
   },
 
-  async niflheim(workspaceId: string, changeSetId: string): Promise<boolean> {
+  async niflheim(
+    workspaceId: string,
+    changeSetId: string,
+  ): Promise<-1 | 0 | 1> {
     return await withLeader(
       async (remote) => await remote.niflheim(workspaceId, changeSetId),
     );

--- a/app/web/src/workers/types/dbinterface.ts
+++ b/app/web/src/workers/types/dbinterface.ts
@@ -249,7 +249,7 @@ export interface SharedDBInterface {
     workspaceId: string,
     changeSetId: ChangeSetId,
   ): Promise<boolean>;
-  niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<boolean>;
+  niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<-1 | 0 | 1>;
   vanaheim(workspaceId: string): Promise<boolean>;
   exec(
     opts: ExecBaseOptions &
@@ -384,7 +384,7 @@ export interface TabDBInterface {
   addAtomUpdated(fn: UpdateFn): void;
   addConnStatusFn(fn: ConnStatusFn): void;
   changeSetExists(workspaceId: string, changeSetId: ChangeSetId): boolean;
-  niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<boolean>;
+  niflheim(workspaceId: string, changeSetId: ChangeSetId): Promise<-1 | 0 | 1>;
   vanaheim(workspaceId: string): Promise<boolean>;
   pruneAtomsForClosedChangeSet(
     workspaceId: WorkspacePk,


### PR DESCRIPTION
## How does this PR change the system?

If an `MvIndex` fails to build, the endpoint to retrieve them will throw a 500. This will not let a user out of the lobby.

We ought to let people out of the lobby. With these changes, we mark 500s separately, and display an error for that change set after the user exits the lobby.

NOTE: we didn't need the retry logic in the main browser thread anymore.

## How was it tested?

First, lets test a 500. I put this code into the `get_change_set_index` route in SDF:
```
    if change_set_id.to_string() == "01K81JTR58GKFG0MKTEZY3MZT7" {
        let e = Error::missing_field("foo")
        return Err(IndexError::DeserializingMvIndexData(e));
    }
```
When you load that change set:
1. you're in the lobby
2. you see 5 attempts in the network panel which all 500
3. after that you come out of the lobby and you see this: 
<img width="1293" height="425" alt="image" src="https://github.com/user-attachments/assets/9ce01e19-dd91-49ca-a6f5-d21f9d791798" />
You can move change sets to `HEAD`, and make new ones no problem

Second, lets test a 404 that ought to indicate "index is rebuilding" to make sure I didn't break anything. Replace my `get_change_set_index` changes with this:
```
    if change_set_id.to_string() == "01K81JTR58GKFG0MKTEZY3MZT7" {
        return Err(IndexError::IndexNotFound(workspace_pk, change_set_id));
    }
```

The user _will_ be stuck in the lobby based on my artificial test case. In the real world, the system would fire an `IndexUpdate` message, which we re-fire the cold start that would succeed and the user would leave the lobby.

Third;
1. put my initial status code 500 changes back
2. load the page, get past the lobby
3. remove my SDF changes entirely
5. DO NOT REFRESH THE PAGE
6. select the head change set
7. select the change set i was special casing
8. it will coldstart, and succeed, and the user will see the change set.\

Fourth;
1. nuke my frigg
2. cold start
3. watch the index re-build and get out of the lobby
4. make a new change set, see that it works / no errors

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlamNjZGpsc3p5MDB1bmc4dTRuc3FscjFkNGR2MTA2c25jaHZ6enlqNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/wo6sWAJ4o3W8xKL00B/giphy.gif"/>