### PR TITLE
Do not load mgmt func runs for invalid components

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -698,6 +698,7 @@ const showResourceInput = ref(false);
 const MGMT_RUN_KEY = "latestMgmtFuncRuns";
 
 const funcRunQuery = useQuery({
+  enabled: () => componentExists.value,
   queryKey: [ctx.changeSetId, MGMT_RUN_KEY],
   queryFn: async () =>
     api
@@ -712,11 +713,11 @@ const funcRuns = computed<FuncRun[]>(() => {
   return funcRunQuery.data.value.data;
 });
 
-// The latest funcrun for this each mgmt prototype of this component, keyed bu the prototypeId
+// The latest funcrun for this each mgmt prototype of this component, keyed by the prototypeId
 const latestFuncRuns = computed(() => {
   const runs = {} as Record<string, FuncRun>;
 
-  if (!componentId.value) return runs;
+  if (!componentId.value || !componentExists.value) return runs;
 
   for (const funcRun of funcRuns.value) {
     if (funcRun.functionKind !== "Management") continue;

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -217,6 +217,13 @@ impl crate::service::v1::common::ErrorIntoResponse for ComponentsError {
             ComponentsError::Attribute(
                 dal::attribute::attributes::AttributesError::CannotUpdateCreateOnlyProperty(_),
             ) => (StatusCode::PRECONDITION_FAILED, self.to_string()),
+            ComponentsError::Attribute(
+                dal::attribute::attributes::AttributesError::AttributeValue(
+                    dal::attribute::value::AttributeValueError::Prop(err),
+                ),
+            ) if matches!(**err, dal::prop::PropError::ChildPropNotFoundByName(_, _)) => {
+                (StatusCode::NOT_FOUND, self.to_string())
+            }
             ComponentsError::Component(dal::ComponentError::NotFound(_)) => {
                 (StatusCode::NOT_FOUND, self.to_string())
             }

--- a/lib/sdf-server/src/service/v2/management.rs
+++ b/lib/sdf-server/src/service/v2/management.rs
@@ -136,7 +136,8 @@ impl IntoResponse for ManagementApiError {
             ManagementApiError::ManagementPrototype(
                 dal::management::prototype::ManagementPrototypeError::FuncExecutionFailure(message),
             ) => (StatusCode::BAD_REQUEST, message),
-            ManagementApiError::Component(dal::ComponentError::NotFound(_)) => {
+            ManagementApiError::Component(dal::ComponentError::NotFound(_))
+            | ManagementApiError::Component(dal::ComponentError::SchemaVariantNotFound(_)) => {
                 (StatusCode::NOT_FOUND, self.to_string())
             }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),


### PR DESCRIPTION
## Description

If you put a component ID in the URL that does not exist on the current change set, you will see the "no component found" banner on the details page. However, the latest management func runs route will still be called. This changes blocks from it being called. This change also converts two error in sdf and luminork, respectively, from 500 to 404 based on user actions made as a result of the original bug.

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdla3czZjFhcW51emdtZ25wYXJnM2Vrc2pwNGswMGo3Z2VtNzN3bWpxZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/UHAYP0FxJOmFBuOiC2/giphy.gif"/>

## Testing

1. Create VPC template in a change set
2. Apply the change set
3. Go to the VPC template component details and copy the entire URL into your clipboard
4. Delete VPC template in another change set
6. Apply the change set
7. Create a new change set
8. Paste the URL into the status bar but replace the change set ID with the new change set
9. Observe that no error appears (the 404 is a failsafe but still should not be seen)

<img width="913" height="835" alt="Screenshot 2025-10-21 at 3 03 45 PM" src="https://github.com/user-attachments/assets/2379e11b-be08-414c-8269-7b751e0e2c1e" />
