### PR TITLE
adding search functionality to the views dropdown

### DIFF
--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -36,8 +36,10 @@
       <template v-else>
         <div class="flex-none flex flex-row items-start gap-xs">
           <DropdownMenuButton
+            ref="viewsDropdownRef"
             class="rounded min-w-[128px] h-[2.5rem]"
-            :options="viewListOptions"
+            :options="filteredViewListOptions"
+            :search="viewListOptions.length > DEFAULT_DROPDOWN_SEARCH_THRESHOLD"
             :modelValue="selectedViewId"
             minWidthToAnchor
             placeholder="All Views"
@@ -567,6 +569,7 @@ import {
   themeClasses,
   TruncateWithTooltip,
   VormInput,
+  DEFAULT_DROPDOWN_SEARCH_THRESHOLD,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useQuery } from "@tanstack/vue-query";
@@ -837,6 +840,20 @@ const viewListOptions = computed(() => {
   return list
     .map((l) => ({ value: l.id, label: l.name }))
     .sort((a, b) => a.label.localeCompare(b.label));
+});
+const viewsDropdownRef = ref<InstanceType<typeof DropdownMenuButton>>();
+const filteredViewListOptions = computed(() => {
+  const searchString = viewsDropdownRef.value?.searchString;
+
+  if (!searchString || searchString === "") {
+    return viewListOptions.value;
+  }
+
+  return viewListOptions.value.filter(
+    (option) =>
+      option.label.toLocaleLowerCase().includes(searchString) ||
+      option.value.toLocaleLowerCase().includes(searchString),
+  );
 });
 
 const defaultView = computed(() =>


### PR DESCRIPTION
## How does this PR change the system?

Just like the workspaces and change sets dropdowns, the views dropdown now has a search available when more than the number of views exceeds the `DEFAULT_DROPDOWN_SEARCH_THRESHOLD` (which is 10)

#### Screenshots:

<img width="225" height="394" alt="Screenshot 2025-10-21 at 5 39 45 PM" src="https://github.com/user-attachments/assets/a1aa15e6-1fef-4132-a6cc-254df23a5cf9" />

#### Out of Scope:

There may be other dropdowns in the UI we want to also add search to! I just did this one very quickly because it was bothering me and was only a few minutes of work to add 😅

## How was it tested?

Double checked the search functionality with a variety of cases after making sure the flow is identical to the working flow in the change sets dropdown.

## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlajAzM3FubjFtc3N5bnc2YnV5c285dmJyZXF2NGp2bmsxN3Z4anB6aSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o6nURs60NHTOfXd72/giphy.gif"/>
