### PR TITLE
Prevent incomplete subscriptions

### DIFF
--- a/lib/dal-test/src/helpers/change_set.rs
+++ b/lib/dal-test/src/helpers/change_set.rs
@@ -8,6 +8,7 @@ use color_eyre::{
 };
 use dal::{
     ChangeSet,
+    ChangeSetId,
     ComponentId,
     DalContext,
     Func,
@@ -125,6 +126,16 @@ impl ChangeSetTestHelpers {
     pub async fn apply_change_set_to_base_approvals(ctx: &mut DalContext) -> Result<()> {
         ChangeSet::prepare_for_apply(ctx).await?;
         Self::apply_change_set_to_base_approvals_without_prepare_step(ctx).await?;
+        Ok(())
+    }
+
+    /// Switch to the [`ChangeSet`] corresponding to the provided ID.
+    pub async fn switch_to_change_set(
+        ctx: &mut DalContext,
+        change_set_id: ChangeSetId,
+    ) -> Result<()> {
+        ctx.update_visibility_and_snapshot_to_visibility(change_set_id)
+            .await?;
         Ok(())
     }
 

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,4 +1,5 @@
 mod action_prototype;
+mod attribute_prototype_argument;
 mod attribute_value;
 mod component;
 mod ordering;

--- a/lib/dal/tests/integration_test/node_weight/attribute_prototype_argument.rs
+++ b/lib/dal/tests/integration_test/node_weight/attribute_prototype_argument.rs
@@ -1,0 +1,94 @@
+use std::collections::HashSet;
+
+use dal::{
+    self,
+    Component,
+    ComponentId,
+    DalContext,
+    component::debug::ComponentDebugView,
+};
+use dal_test::{
+    Result,
+    helpers::{
+        ChangeSetTestHelpers,
+        attribute::value,
+        component,
+    },
+    test,
+};
+use pretty_assertions_sorted::assert_eq;
+
+#[test]
+async fn prevent_incomplete_subscriptions(ctx: &mut DalContext) -> Result<()> {
+    // Create two components with an inter-component subscription.
+    let erased_component_id = component::create(ctx, "Docker Image", "hammerfell").await?;
+    let subscriber_component_id = component::create(ctx, "Docker Image", "highrock").await?;
+    value::set(ctx, ("hammerfell", "/domain/image"), "neloth").await?;
+    value::subscribe(
+        ctx,
+        ("highrock", "/domain/image"),
+        ("hammerfell", "/domain/image"),
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        "neloth",                                              // expected
+        value::get(ctx, ("highrock", "/domain/image")).await?, // actual
+    );
+
+    // Apply to HEAD and check the subscription.
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    assert_eq!(
+        "neloth",                                              // expected
+        value::get(ctx, ("highrock", "/domain/image")).await?, // actual
+    );
+
+    // In a new change set, erase the component with the "source" value and commit.
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    let erase_change_set_id = ctx.change_set_id();
+    let head_components: HashSet<ComponentId> =
+        Component::exists_on_head_by_ids(ctx, &[erased_component_id]).await?;
+    let erased_component = Component::get_by_id(ctx, erased_component_id).await?;
+    dal::component::delete::delete_component(ctx, &erased_component, true, &head_components)
+        .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+
+    // In a second, new change set, override and then re-create the subscription. Commit in between each action.
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    value::set(ctx, ("highrock", "/domain/image"), "overriden").await?;
+    assert_eq!(
+        "neloth",                                                // expected
+        value::get(ctx, ("hammerfell", "/domain/image")).await?, // actual
+    );
+    assert_eq!(
+        "overriden",                                           // expected
+        value::get(ctx, ("highrock", "/domain/image")).await?, // actual
+    );
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    value::subscribe(
+        ctx,
+        ("highrock", "/domain/image"),
+        ("hammerfell", "/domain/image"),
+    )
+    .await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert_eq!(
+        "neloth",                                              // expected
+        value::get(ctx, ("highrock", "/domain/image")).await?, // actual
+    );
+
+    // Apply the second change set to HEAD and check the subscription.
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    assert_eq!(
+        "neloth",                                              // expected
+        value::get(ctx, ("highrock", "/domain/image")).await?, // actual
+    );
+
+    // Switch back to the first change set and check that we can create a debug view. If we can,
+    // then we know we have prevented an incomplete subscription from being made with our
+    // correct transform logic.
+    ChangeSetTestHelpers::switch_to_change_set(ctx, erase_change_set_id).await?;
+    ComponentDebugView::new(ctx, subscriber_component_id).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This change prevents incomplete subscriptions in edge case scenarios by removing new node updates for attribute prototype arguments conditionally. This condition is triggered when there is a set difference between the set of all destinations that no longer exist in the graph (i.e. the "incomplete" subscriptions) and the set of all new node updates.

This change fixes a bug where the erasure of a subscription component (not the subscriber) in one change set would result in subscriber components containing incomplete subscriptions when HEAD also contained changes to the subscription itself. This case is tested in an integration test.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMzl6ODdpeW00OTRnc3VsOG83bmJzdXAybm4xbWR2ejc1cHJ2emNwZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jekOuQv99wy7DJyJiW/giphy.gif"/>

## Test Steps in the UI

1. In a new change set, create an `AWS Credential` and an `AWS::EC2::Instance` component
2. Subscribe to the credential from the EC2 instance component
3. Apply the change set to HEAD (the create action does not need to pass)
4. Create a change set and erase the credential component (do not apply this change set)
5. Create another change set and remove the subscription to the credential
6. In that same change set, re-add the subscription and then apply the change set
7. Switch back to the erasure change set and observe that both the attributes panel and debug panel now work (without this PR, there would be an incomplete subscription)

## Integration Test Screenshots

Without the fix:

<img width="1970" height="1167" alt="Screenshot 2025-10-22 at 5 58 51 PM" src="https://github.com/user-attachments/assets/f0e2f593-5746-4354-a929-1f7725edbc2a" />

With the fix:

<img width="1970" height="1167" alt="Screenshot 2025-10-22 at 6 30 41 PM" src="https://github.com/user-attachments/assets/b93bd400-f2b1-44bf-9916-cce14cef0015" />