### PR TITLE
[feat] Azure: bring in publicIPAddress.id, other type fixes

### DIFF
--- a/bin/clover/deno.json
+++ b/bin/clover/deno.json
@@ -2,7 +2,7 @@
   "workspace": [],
   "tasks": {
     "updateSchema": "../../lib/jsr-systeminit/cf-db/update-schema.sh",
-    "run": "deno run --allow-all main.ts",
+    "run": "deno run --allow-all main.ts"
   },
   "imports": {
     "@apidevtools/json-schema-ref-parser": "npm:@apidevtools/json-schema-ref-parser@^11.9.3",
@@ -24,5 +24,9 @@
     "@sideway/address": "npm:@sideway/address@4.1.5",
     "@sideway/pinpoint": "npm:@sideway/pinpoint@2.0.0",
     "@hapi/hoek": "npm:@hapi/hoek@9.3.0"
-  }
+  },
+  "exclude": [
+    "si-specs",
+    "src/provider-schemas"
+  ]
 }

--- a/bin/clover/src/commands/generateSiSpecs.ts
+++ b/bin/clover/src/commands/generateSiSpecs.ts
@@ -18,6 +18,7 @@ import "../pipelines/dummy/spec.ts";
 
 const logger = _logger.ns("siSpecs").seal();
 const SI_SPEC_DIR = "si-specs";
+const MAX_SPEC_SIZE_MB = 20;
 
 export async function generateSiSpecs(options: PipelineOptions) {
   const specs: ExpandedPkgSpec[] = [];
@@ -35,18 +36,15 @@ export async function generateSiSpecs(options: PipelineOptions) {
     const specJson = JSON.stringify(unexpandPackageSpec(spec), null, 2);
     const name = spec.name;
 
-    try {
-      logger.debug(`Writing ${name}.json`);
-      const blob = new Blob([specJson]);
-      if (blob.size > 4 * 1024 * 1024) {
-        logger.warn(`${spec.name} is bigger than 4MBs. Skipping.`);
-        continue;
-      }
-      await Deno.writeFile(`${SI_SPEC_DIR}/${name}.json`, blob.stream());
-    } catch (e) {
-      console.log(`Error writing to file: ${name}: ${e}`);
-      continue;
+    logger.debug(`Writing ${name}.json`);
+    const blob = new Blob([specJson]);
+    if (blob.size > MAX_SPEC_SIZE_MB * 1024 * 1024) {
+      // TODO throw an error, once we've got Azure specs under control
+      console.warn(
+        `${spec.name} is bigger than ${MAX_SPEC_SIZE_MB}MBs. Skipping.`,
+      );
     }
+    await Deno.writeFile(`${SI_SPEC_DIR}/${name}.json`, blob.stream());
 
     imported += 1;
   }

--- a/bin/clover/src/pipelines/azure/provider.ts
+++ b/bin/clover/src/pipelines/azure/provider.ts
@@ -1,6 +1,5 @@
 import {
   FetchSchemaOptions,
-  PipelineOptions,
   PROVIDER_REGISTRY,
   ProviderConfig,
   SuperSchema,
@@ -12,9 +11,12 @@ import {
   MANAGEMENT_FUNCS,
   QUALIFICATION_FUNC_SPECS,
 } from "./funcs.ts";
-import { normalizeAzureProperty } from "./spec.ts";
 import { generateAzureSpecs } from "./pipeline.ts";
-import { AzureSchema, initAzureRestApiSpecsRepo } from "./schema.ts";
+import {
+  AzureProperty,
+  AzureSchema,
+  initAzureRestApiSpecsRepo,
+} from "./schema.ts";
 import { JSONSchema } from "../draft_07.ts";
 
 async function azureFetchSchema(options: FetchSchemaOptions) {
@@ -71,14 +73,6 @@ function azureIsChildRequired(
   return schema.requiredProperties.has(childName);
 }
 
-function azureNormalizeProperty(prop: JSONSchema) {
-  return normalizeAzureProperty(prop);
-}
-
-async function azureLoadSchemas(options: PipelineOptions) {
-  return await generateAzureSpecs(options);
-}
-
 export const AZURE_PROVIDER_CONFIG: ProviderConfig = {
   name: "azure",
   isStable: false,
@@ -93,8 +87,9 @@ export const AZURE_PROVIDER_CONFIG: ProviderConfig = {
     management: MANAGEMENT_FUNCS,
     qualification: QUALIFICATION_FUNC_SPECS,
   },
-  loadSchemas: azureLoadSchemas,
-  normalizeProperty: azureNormalizeProperty,
+  loadSchemas: generateAzureSpecs,
+  // These are normalized earlier in the process
+  normalizeProperty: (prop: JSONSchema) => prop as AzureProperty,
   isChildRequired: azureIsChildRequired,
   overrides: {
     propOverrides: {},

--- a/bin/clover/src/spec/props.ts
+++ b/bin/clover/src/spec/props.ts
@@ -1,3 +1,4 @@
+import util from "node:util";
 import { ulid } from "https://deno.land/x/ulid@v0.3.0/mod.ts";
 import { PropSpecWidgetKind } from "../bindings/PropSpecWidgetKind.ts";
 import { PropSpecData } from "../bindings/PropSpecData.ts";
@@ -135,7 +136,7 @@ export function createDefaultPropFromJsonSchema(
   // Recursively create prop and all its children
   const rootProp = createPropFromJsonSchema(
     ["root", name],
-    { ...schema, properties },
+    { ...schema, type: "object", properties },
     undefined,
   );
 
@@ -471,10 +472,20 @@ export function createDefaultPropFromJsonSchema(
       }
 
       if (!cfProp.type && cfProp.description == "") {
+        logger.warn(
+          `No type + empty description for top level prop at ${propPath.join(
+            "/",
+          )}: ${util.inspect(cfProp)}`,
+        );
         return undefined;
       }
 
       if (!cfProp.type && cfProp.title) {
+        logger.warn(
+          `No type for top level prop at ${propPath.join("/")}: ${util.inspect(
+            cfProp,
+          )}`,
+        );
         return undefined;
       }
 
@@ -483,6 +494,11 @@ export function createDefaultPropFromJsonSchema(
       throw new Error(
         `no matching kind in prop with path: ${propPath.join("/")}`,
       );
+    } catch (e) {
+      console.error(
+        `Error creating prop for ${schema.typeName} at ${propPath.join("/")}`,
+      );
+      throw e;
     } finally {
       propsBeingCreated.pop();
     }


### PR DESCRIPTION
Right now you can't add a publicIPAddress to a networkInterface in Azure, because we aren't generating the ID. This fixes that, and also brings in the 13 schemas we couldn't bring in because of boolean schema types.

## How does this PR change the system?

Because Azure reuses a *lot* of common definitions with allOf and $ref, 

* Deeper allOf handling:
  * treats `allOf` as `extend`, allowing { allOf: { ... }, properties { ... } } in the same. Recursively merges properties
  * Makes allOf, oneOf and anyOf merging strict
  * Merges `required` and `enum` fields
  * Brings in more child values with `allOf`, bringing in descriptions, readOnly information and merging properties
  * Delays normalization of type/format/etc. until after all allOf/oneOf/etc. alternatives have been processed
* Handles `true` (any) and `false` (never) JSON schemas consistently and more correctly
* Fixes situation where empty `properties` property in Azure was considered string instead of object

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI
- [X] Manual test: (regression check) creating a component still works

## In short: [:link:](https://giphy.com/)

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb3Z2NzQ0OHZvMXo0aG1lcGY3MTRxeWhjY3oxOWVjdTU4dm5ocnYwaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/hQcVssmQOWObFAvoPV/giphy-downsized-medium.gif"/>
