### PR TITLE
add dark reader exemption tag to auth portal

### DIFF
--- a/app/auth-portal/index.html
+++ b/app/auth-portal/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
+  <meta name="darkreader-lock">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SI Auth Portal</title>
 </head>


### PR DESCRIPTION
## How does this PR change the system?

We already have the head tag `<meta name="darkreader-lock">` in the SI web app to prevent the Dark Reader extension from breaking our dark mode styles. This PR adds the same tag to the SI auth portal.

#### Screenshots:

Dark mode broken by Dark Reader extension -
<img width="615" height="440" alt="Screenshot 2025-10-22 at 10 45 51 AM" src="https://github.com/user-attachments/assets/b67494df-5a99-40d3-aa76-c5065c5d7261" />

Proper dark mode with the extension disabled by the meta tag -
<img width="610" height="443" alt="Screenshot 2025-10-22 at 10 45 59 AM" src="https://github.com/user-attachments/assets/8d12de8b-dd64-4c16-aaa9-206e05f4a623" />