### PR TITLE
Adding more instrumentation to mv_build_error

### DIFF
--- a/lib/edda-server/src/materialized_view/deployment.rs
+++ b/lib/edda-server/src/materialized_view/deployment.rs
@@ -29,7 +29,7 @@ use crate::{
     materialized_view::{
         BuildMvInnerReturn,
         BuildMvOp,
-        BuildMvTaskResult,
+        DeploymentBuildMvTaskResult,
         MaterializedViewError,
         MvBuilderResult,
         build_mv,
@@ -478,7 +478,7 @@ async fn build_deployment_mv_inner(
 
 /// Spawns a build task for a specific deployment MV.
 async fn spawn_deployment_mv_task(
-    build_tasks: &mut JoinSet<BuildMvTaskResult>,
+    build_tasks: &mut JoinSet<DeploymentBuildMvTaskResult>,
     ctx: &DalContext,
     frigg: &FriggStore,
     mv_kind: ReferenceKind,
@@ -568,7 +568,7 @@ async fn build_mv_for_deployment_task<F, T, E>(
     mv_kind: ReferenceKind,
     build_mv_future: F,
     maybe_deployment_mv_index: Arc<Option<FrontendObject>>,
-) -> BuildMvTaskResult
+) -> DeploymentBuildMvTaskResult
 where
     F: std::future::Future<Output = Result<T, E>> + Send + 'static,
     T: serde::Serialize


### PR DESCRIPTION
## How was it tested?

Locally, I hit "rebuild index" I actually got an error
```
edda_server::materialized_view: name="mv_build_error" si.error.message="materialized views error: schema variant error: secret defining schema variant (01K6BNPVVK336M6V2QFEQZ6ZJ6) has no output sockets and needs one for the secret corresponding to its secret definition"
kind=SchemaVariant
id=01K6BNPVVK336M6V2QFEQZ6ZJ6
entity_id=01K6BNPVVK336M6V2QFEQZ6ZJ6
entity_kind=SchemaVariant
change_set_id=01JYPTEC5JM3T1Y4ECEPT9560J
workspace_id=01HRFEV0S23R1G23RP75QQDCA7
```

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlamJpOHdhdHF2ZDMxamxiYW5zaTlxMW1wd2Z2YjY5M2hndHRpenZ6MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2L3CDIUD1h9StO4xQg/giphy.gif"/>