### PR TITLE
feat(conduit): Allow push to update assets and funcs

### DIFF
--- a/bin/si-conduit/README.md
+++ b/bin/si-conduit/README.md
@@ -326,7 +326,7 @@ Enable verbose logging to debug issues:
 
 ```bash
 # Maximum verbosity (trace level)
-si-conduit -vvvv schema scaffold generate MySchema
+si-conduit -v4 schema scaffold generate MySchema
 
 # Or specify a numeric level (0-4)
 si-conduit --verbose 4 schema scaffold generate MySchema
@@ -343,8 +343,8 @@ si-conduit --verbose 4 schema scaffold generate MySchema
 - [x] Push code generators
 - [x] Add PostHog analytics events
 - [x] Write comprehensive README
-- [ ] Handle existing function bindings for asset updates
-- [ ] Handle existing function names for new and updating assets
+- [x] Handle existing function bindings for asset updates
+- [x] Handle existing function names for new and updating assets
 
 ### Code Style
 
@@ -356,5 +356,5 @@ si-conduit --verbose 4 schema scaffold generate MySchema
 
 ## License
 
-See the main System Initiative repository for license information.
+See the root of the System Initiative repository for license information.
 

--- a/bin/si-conduit/deno.json
+++ b/bin/si-conduit/deno.json
@@ -1,7 +1,7 @@
 {
   "workspace": [],
   "tasks": {
-    "dev": "deno run --allow-net --allow-env --allow-read --allow-write main.ts",
+    "dev": "deno run --allow-net --allow-env --allow-read --env-file=.env.local --allow-write main.ts",
     "build": "deno compile --allow-net --allow-env --allow-read --allow-write main.ts",
     "lint": "deno lint",
     "test": "deno test"
@@ -15,7 +15,7 @@
     "@logtape/pretty": "jsr:@logtape/pretty@^1.1.0",
     "@logtape/redaction": "jsr:@logtape/redaction@^1.1.1",
     "@std/path": "https://deno.land/std@0.224.0/path/mod.ts",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.3.3",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.5.0",
     "axios": "npm:axios@1.11.0",
     "posthog-node": "npm:posthog-node@^4.2.1"
   },

--- a/bin/si-conduit/deno.lock
+++ b/bin/si-conduit/deno.lock
@@ -21,10 +21,11 @@
     "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/path@~1.0.6": "1.0.9",
     "jsr:@std/text@~1.0.7": "1.0.16",
-    "jsr:@systeminit/api-client@^1.3.3": "1.3.3",
+    "jsr:@systeminit/api-client@^1.5.0": "1.5.0",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:axios@1.11.0": "1.11.0",
     "npm:axios@^1.6.1": "1.11.0",
+    "npm:path-to-regexp@8.2.0": "8.2.0",
     "npm:posthog-node@^4.2.1": "4.18.0"
   },
   "jsr": {
@@ -123,8 +124,8 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
-    "@systeminit/api-client@1.3.3": {
-      "integrity": "c9e8b650fc1726e664e933b31960f988fce5f4bc78baf239b052c4f3fe489a7d",
+    "@systeminit/api-client@1.5.0": {
+      "integrity": "336300a86ec236978c0d18957d25c5d51f7630ac655c9c98ca00b7a9ba715dc0",
       "dependencies": [
         "npm:axios@^1.6.1"
       ]
@@ -261,6 +262,9 @@
         "mime-db"
       ]
     },
+    "path-to-regexp@8.2.0": {
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
+    },
     "posthog-node@4.18.0": {
       "integrity": "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==",
       "dependencies": [
@@ -361,12 +365,12 @@
   "workspace": {
     "dependencies": [
       "jsr:@cliffy/command@^1.0.0-rc.7",
+      "npm:axios@1.11.0",
       "jsr:@cliffy/prompt@^1.0.0-rc.7",
       "jsr:@logtape/logtape@0.12",
       "jsr:@logtape/pretty@^1.1.0",
       "jsr:@logtape/redaction@^1.1.1",
-      "jsr:@systeminit/api-client@^1.3.3",
-      "npm:axios@1.11.0",
+      "jsr:@systeminit/api-client@^1.5.0",
       "npm:posthog-node@^4.2.1"
     ]
   }

--- a/bin/si-conduit/src/cli.ts
+++ b/bin/si-conduit/src/cli.ts
@@ -209,13 +209,14 @@ function buildRemoteCommand() {
         .description(
           "Pushes schemas to your remote System Initiative workspace",
         )
-        .action(async ({ root }) => {
+        .option("-s, --skip-confirmation", "Skip confirmation prompt")
+        .action(async ({ root, skipConfirmation }) => {
           const project = createProject(root);
 
           const ctx = Context.instance();
           const cliContext = await initializeCliContextWithAuth({ ctx });
 
-          await pushAssets(cliContext, project);
+          await pushAssets(cliContext, project, skipConfirmation);
         }),
     );
 }

--- a/bin/si-conduit/src/cli/push-assets.ts
+++ b/bin/si-conduit/src/cli/push-assets.ts
@@ -1,4 +1,4 @@
-import { ChangeSetsApi, SchemasApi } from "@systeminit/api-client";
+import { ChangeSetsApi, SchemasApi, FuncsApi } from "@systeminit/api-client";
 import { AuthenticatedCliContext } from "./helpers.ts";
 import { AxiosError } from "axios";
 import { Context } from "../context.ts";
@@ -122,6 +122,7 @@ async function parseActions(
 }
 
 type ActionArray = Awaited<ReturnType<typeof parseActions>>;
+type Action = ActionArray[number];
 
 async function parseSimpleFuncDirectory(
   ctx: Context,
@@ -213,6 +214,7 @@ async function parseSimpleFuncDirectory(
 }
 
 type SimpleFuncArray = Awaited<ReturnType<typeof parseSimpleFuncDirectory>>;
+type SimpleFunc = SimpleFuncArray[number];
 
 interface Schema {
   name: string;
@@ -224,6 +226,23 @@ interface Schema {
   qualifications: SimpleFuncArray;
   codeGenerators: SimpleFuncArray;
   managementFuncs: SimpleFuncArray;
+  authFuncs: SimpleFuncArray;
+}
+
+function allSchemaFuncsWithKind(schema: Schema) {
+  const addKind = (kind: string, funcs: (Action | SimpleFunc)[]) =>
+    funcs.map((func) => ({
+      kind,
+      funcData: func,
+    }))
+
+  return [
+    ...addKind("Qualification", schema.qualifications),
+    ...addKind("Action", schema.actions),
+    ...addKind("CodeGeneration", schema.codeGenerators),
+    ...addKind("Management", schema.managementFuncs),
+    ...addKind("Authentication", schema.authFuncs),
+  ];
 }
 
 export async function pushAssets(
@@ -252,9 +271,9 @@ export async function pushAssets(
 
       readSchemas += 1;
 
-      const schemaName = entry.name;
+      const schemaDirName = entry.name;
 
-      const versionFilePath = project.schemaFormatVersionPath(schemaName);
+      const versionFilePath = project.schemaFormatVersionPath(schemaDirName);
 
       let thisFormatVersion: number;
       try {
@@ -262,7 +281,7 @@ export async function pushAssets(
         thisFormatVersion = parseInt(formatContent);
       } catch (error) {
         const msg = error instanceof Deno.errors.NotFound
-          ? `.format-version file not found on the ${schemaName} directory`
+          ? `.format-version file not found on the ${schemaDirName} directory`
           : unknownValueToErrorMessage(error);
         logger.error(msg);
         continue;
@@ -273,7 +292,7 @@ export async function pushAssets(
         thisFormatVersion !== SCHEMA_FILE_FORMAT_VERSION
       ) {
         const msg =
-          `Unsupported format version ${thisFormatVersion} on the asset ${schemaName}. ` +
+          `Unsupported format version ${thisFormatVersion} on the asset ${schemaDirName}. ` +
           `Supported version is ${SCHEMA_FILE_FORMAT_VERSION}. ` +
           `You can run a new scaffold command and port your schema over to push it with this executable`;
 
@@ -281,23 +300,23 @@ export async function pushAssets(
         continue;
       }
 
-      const schemaCodePath = project.schemaFuncCodePath(schemaName);
+      const schemaCodePath = project.schemaFuncCodePath(schemaDirName);
       try {
         const code = await schemaCodePath.readTextFile();
 
-        let name: string;
+        let schemaName: string;
         let category: string;
         let description: string;
         let link: string;
 
-        const schemaMetadataPath = project.schemaMetadataPath(schemaName);
+        const schemaMetadataPath = project.schemaMetadataPath(schemaDirName);
         try {
           const metadataContent = await schemaMetadataPath.readTextFile();
           const metadata = JSON.parse(metadataContent);
 
-          name = metadata.name;
+          schemaName = metadata.name;
 
-          if (!name || name.trim() === "") {
+          if (!schemaName || schemaName.trim() === "") {
             throw new Error("Missing required 'name' field in metadata.json");
           }
 
@@ -306,7 +325,7 @@ export async function pushAssets(
           link = metadata.link;
         } catch (error) {
           const msg = error instanceof Deno.errors.NotFound
-            ? `metadata.json file not found on the ${schemaName} directory`
+            ? `metadata.json file not found on the ${schemaDirName} directory`
             : unknownValueToErrorMessage(error);
           logger.error(msg);
           continue;
@@ -344,8 +363,14 @@ export async function pushAssets(
           project.managementBasePath(schemaName),
         );
 
-        schemas.push({
-          name,
+        const authFuncs = await parseSimpleFuncDirectory(
+          ctx,
+          schemaName,
+          project.authBasePath(schemaName),
+        );
+
+        const schema = {
+          name: schemaName,
           code,
           category,
           description,
@@ -354,11 +379,26 @@ export async function pushAssets(
           actions,
           codeGenerators,
           managementFuncs,
-        });
+          authFuncs,
+        };
+
+        const existingNames = {} as Record<string, string>;
+        allSchemaFuncsWithKind(schema).forEach((func) => {
+          const { name: funcName } = func.funcData;
+          const { kind } = func;
+          if (existingNames[funcName]) {
+            throw new Error(
+              `Duplicate function name "${funcName}" found in asset "${schemaName}": ${existingNames[funcName]} and ${kind}`,
+            );
+          }
+          existingNames[funcName] = kind;
+        })
+
+        schemas.push(schema);
       } catch (error) {
         if (error instanceof Deno.errors.NotFound) {
           logger.error(
-            `No index.ts file found for asset "${schemaName}", skipping...\n`,
+            `No index.ts file found for asset "${schemaDirName}", skipping...\n`,
           );
           continue;
         }
@@ -412,6 +452,7 @@ export async function pushAssets(
     }
   }
 
+  // TODO We should read the schema from head and see what we need to do before creating the changeset, so we can avoid changesets with no real diffs
   // Create schemas on the server
   const changeSetsApi = new ChangeSetsApi(apiConfiguration);
 
@@ -423,19 +464,16 @@ export async function pushAssets(
   });
 
   const changeSetId = createChangeSetResponse.data.changeSet.id;
-  if (!changeSetId) {
-    throw new Error("Error creating changeset");
-  }
 
   let pushedSchemas = 0;
   try {
     const siSchemasApi = new SchemasApi(apiConfiguration);
+    const siFuncsApi = new FuncsApi(apiConfiguration);
 
     for (const schema of schemas) {
       const { code, name, category, description } = schema;
 
       let existingSchemaId = undefined;
-      let existingSchemaIsInstalled = undefined;
       try {
         const response = await siSchemasApi.findSchema({
           workspaceId,
@@ -444,16 +482,38 @@ export async function pushAssets(
         });
 
         existingSchemaId = response.data.schemaId;
-        existingSchemaIsInstalled = response.data.installed;
       } catch (error) {
         // Swallow error if it's a schema not found error, as we will create the schema
-        if (!(error instanceof AxiosError) || error.status !== 404) {
+        if (!(error instanceof AxiosError)) {
+          throw error;
+        }
+
+        // TypeScript does not believe the typecheck above
+        const axiosError = error as AxiosError;
+
+        if (axiosError.status !== 404) {
           throw error;
         }
       }
 
       let schemaId;
-      let variantId;
+      let schemaVariantId;
+
+      // These two records will only be filled out if the schema already exists
+      // But we create it here to create a single code path when dealing with funcs
+      const funcsToUnbindById = {} as Record<string, {
+        kind: string,
+        name: string,
+      }>;
+      const existingFuncDataByName = {} as Record<string, {
+        id: string,
+        name: string,
+        displayName?: string | null,
+        description?: string | null,
+        code: string,
+        funcKind: string,
+      }>;
+
       if (existingSchemaId) {
         logger.info(
           `existing schema ${name} (${existingSchemaId}), unlocking and updating...`,
@@ -465,10 +525,11 @@ export async function pushAssets(
           schemaId: existingSchemaId,
         });
 
-        const schemaVariantId = unlockSchemaResponse.data.unlockedVariantId;
+        schemaId = existingSchemaId;
+        schemaVariantId = unlockSchemaResponse.data.unlockedVariantId;
 
         // TODO add optional fields (link)
-        await siSchemasApi.updateSchemaVariant({
+        const unlockedVariantData = (await siSchemasApi.updateSchemaVariant({
           workspaceId,
           changeSetId,
           schemaId: existingSchemaId,
@@ -479,10 +540,33 @@ export async function pushAssets(
             category,
             description,
           },
-        });
+        })).data;
 
-        schemaId = existingSchemaId;
-        variantId = schemaVariantId;
+        // Gather all the funcs that are currently bound to this schema
+        logger.debug(`gathering funcs...`);
+        for (const existingFunc of unlockedVariantData.variantFuncs) {
+          const funcRequest = await siFuncsApi.getFunc({
+            workspaceId,
+            changeSetId,
+            funcId: existingFunc.id,
+          });
+
+          const loadedFuncData = funcRequest.data;
+          funcsToUnbindById[existingFunc.id] = {
+            kind: loadedFuncData.kind,
+            name: loadedFuncData.name,
+          };
+
+          existingFuncDataByName[loadedFuncData.name] = {
+            id: existingFunc.id,
+            name: loadedFuncData.name,
+            displayName: loadedFuncData.displayName,
+            description: loadedFuncData.description,
+            code: loadedFuncData.code,
+            funcKind: existingFunc.funcKind.kind,
+          };
+        }
+
       } else {
         logger.info(`creating schema ${name}...`);
 
@@ -499,50 +583,139 @@ export async function pushAssets(
         });
 
         schemaId = createSchemaResponse.data.schemaId;
-        variantId = createSchemaResponse.data.defaultVariantId;
+        schemaVariantId = createSchemaResponse.data.defaultVariantId;
       }
+
+      const baseVariantPayload = {
+        workspaceId,
+        changeSetId,
+        schemaId,
+        schemaVariantId,
+      };
+
+
+      let createdFuncs = 0;
+      let modifiedFuncs = 0;
+      let skippedFuncs = 0;
+
+      for (const filesystemFuncAndKind of allSchemaFuncsWithKind(schema)) {
+        const filesystemFunc = filesystemFuncAndKind.funcData;
+        const filesystemFuncKind = filesystemFuncAndKind.kind;
+
+        const existingFunc = existingFuncDataByName[filesystemFunc.name];
+        if (existingFunc) {
+          logger.debug(`found ${filesystemFuncKind} ${filesystemFunc.name}...`);
+          delete funcsToUnbindById[existingFunc.id];
+
+          if (funcContentsMatch(existingFunc, filesystemFunc)) {
+            logger.debug(`${existingFunc.name} is unchanged. Skipping...`);
+            skippedFuncs += 1;
+          } else {
+            logger.debug(`${existingFunc.name} is changed. Unlocking and updating...`);
+            modifiedFuncs += 1;
+
+            const unlockFuncResult = await siFuncsApi.unlockFunc({
+              workspaceId,
+              changeSetId,
+              funcId: existingFunc.id,
+              unlockFuncV1Request: {
+                schemaVariantId
+              }
+            })
+
+            const unlockedFuncId = unlockFuncResult.data.unlockedFuncId;
+
+            await siFuncsApi.updateFunc({
+              workspaceId,
+              changeSetId,
+              funcId: unlockedFuncId,
+              updateFuncV1Request: filesystemFunc,
+            });
+          }
+        } else {
+          logger.debug(`${filesystemFunc.name} is new. Creating...`);
+          createdFuncs += 1;
+
+          switch (filesystemFuncKind) {
+            case "Action":
+              if (!("kind" in filesystemFunc)) {
+                logger.error(`Action must have a 'kind' field, ${filesystemFunc.name} is missing it`);
+                break;
+              }
+
+              await siSchemasApi.createVariantAction({
+                ...baseVariantPayload,
+                createVariantActionFuncV1Request: filesystemFunc,
+              });
+              break;
+            case "Qualification":
+              await siSchemasApi.createVariantQualification({
+                ...baseVariantPayload,
+                createVariantQualificationFuncV1Request: filesystemFunc,
+              });
+              break;
+            case "CodeGeneration":
+              await siSchemasApi.createVariantCodegen({
+                ...baseVariantPayload,
+                createVariantCodegenFuncV1Request: filesystemFunc,
+              });
+              break;
+            case "Management":
+              await siSchemasApi.createVariantManagement({
+                ...baseVariantPayload,
+                createVariantManagementFuncV1Request: filesystemFunc,
+              });
+              break;
+            case "Authentication":
+              await siSchemasApi.createVariantAuthentication({
+                ...baseVariantPayload,
+                createVariantAuthenticationFuncV1Request: filesystemFunc,
+              });
+              break;
+            default:
+              logger.error(`Unknown func kind for func "${filesystemFunc.name}": ${filesystemFuncKind}`);
+          }
+        }
+      }
+
+      let detachedFuncs = 0;
+
+      // TODO unbinding should happen before creating and updating any funcs, so we don't get conflicts with existing actions
+      // loop over funcIdsToUnbind, using both the keys and the values
+      for (const [funcId, { kind, name }] of Object.entries(funcsToUnbindById)) {
+        logger.debug(`${name} was removed. Detaching...`);
+        detachedFuncs += 1;
+
+        const detachPayload = {
+          ...baseVariantPayload,
+          funcId,
+        }
+
+        switch (kind) {
+          case "Action":
+            await siSchemasApi.detachActionFuncBinding(detachPayload);
+            break;
+          case "Qualification":
+            await siSchemasApi.detachQualificationFuncBinding(detachPayload);
+            break;
+          case "CodeGeneration":
+            await siSchemasApi.detachCodegenFuncBinding(detachPayload);
+            break;
+          case "Management":
+            await siSchemasApi.detachManagementFuncBinding(detachPayload);
+            break;
+          case "Authentication":
+            await siSchemasApi.detachAuthenticationFuncBinding(detachPayload);
+            break;
+          default:
+            console.error(`Unknown unknown func kind for func ${funcId}: ${kind}`);
+        }
+      }
+
+      logger.info(`func summary: ${createdFuncs} created, ${modifiedFuncs} modified, ${detachedFuncs} detached, ${skippedFuncs} unchanged`);
+
       pushedSchemas += 1;
 
-      // Create qualifications
-      for (let qualification of schema.qualifications) {
-        await siSchemasApi.createVariantQualification({
-          workspaceId,
-          changeSetId,
-          schemaId,
-          schemaVariantId: variantId,
-          createVariantQualificationFuncV1Request: qualification,
-        });
-      }
-
-      for (const action of schema.actions) {
-        await siSchemasApi.createVariantAction({
-          workspaceId,
-          changeSetId,
-          schemaId,
-          schemaVariantId: variantId,
-          createVariantActionFuncV1Request: action,
-        });
-      }
-
-      for (const func of schema.codeGenerators) {
-        await siSchemasApi.createVariantCodegen({
-          workspaceId,
-          changeSetId,
-          schemaId,
-          schemaVariantId: variantId,
-          createVariantCodegenFuncV1Request: func,
-        });
-      }
-
-      for (const func of schema.managementFuncs) {
-        await siSchemasApi.createVariantManagement({
-          workspaceId,
-          changeSetId,
-          schemaId,
-          schemaVariantId: variantId,
-          createVariantManagementFuncV1Request: func,
-        });
-      }
     }
 
     const changeSetUrl =
@@ -577,3 +750,15 @@ export async function pushAssets(
     });
   }
 }
+
+interface FuncData {
+  name: string;
+  displayName?: string | null;
+  code: string;
+  description?: string | null;
+}
+const funcContentsMatch = (funcA: FuncData, funcB: FuncData) =>
+  funcA.name === funcB.name &&
+  funcA.displayName === funcB.displayName &&
+  funcA.code === funcB.code &&
+  funcA.description === funcB.description;

--- a/bin/si-conduit/src/helpers.ts
+++ b/bin/si-conduit/src/helpers.ts
@@ -17,3 +17,16 @@ export function unknownValueToErrorMessage(value: unknown): string {
 export function makeStringSafeForFilename(str: string): string {
   return str.replace(/[\\/:*?"<>|]/g, "_");
 }
+
+// I kept deleting this and bringing it back when debugging API client usage, so let's keep it here
+export function logAllFunctions(obj: unknown) {
+  if (typeof obj !== 'object' || obj === null) {
+    console.log('Not an object:', obj);
+    return;
+  }
+
+  const objWithIndex = obj as Record<string, unknown>;
+  const allPrototypeProps = Object.getOwnPropertyNames(Object.getPrototypeOf(objWithIndex));
+  const prototypeFunctions = allPrototypeProps.filter(name => typeof objWithIndex[name] === 'function');
+  console.log(prototypeFunctions);
+}

--- a/bin/si-conduit/src/project.ts
+++ b/bin/si-conduit/src/project.ts
@@ -103,6 +103,9 @@ const CODEGENS_DIR = "codeGenerators" as const;
 /** Directory name for management functions within a schema. */
 const MANAGEMENTS_DIR = "management" as const;
 
+/** Directory name for authentication functions within a schema. */
+const AUTH_DIR = "authentication" as const;
+
 /** Directory name for qualifications within a schema. */
 const QUALIFICATIONS_DIR = "qualifications" as const;
 
@@ -538,6 +541,18 @@ export class Project {
   }
 
   /**
+   * Returns the relative path to a schema's management functions directory.
+   *
+   * @param schemaName - The name of the schema
+   * @returns A RelativeDirectoryPath to the authentication directory
+   */
+  authBaseRelativePath(schemaName: string): RelativeDirectoryPath {
+    return new RelativeDirectoryPath(
+      join(this.schemaBaseRelativePath(schemaName), AUTH_DIR),
+    );
+  }
+
+  /**
    * Returns the absolute path to a schema's management functions directory.
    *
    * @param schemaName - The name of the schema
@@ -546,6 +561,18 @@ export class Project {
   managementBasePath(schemaName: string): AbsoluteDirectoryPath {
     return new AbsoluteDirectoryPath(
       join(this.rootPath, this.managementBaseRelativePath(schemaName)),
+    );
+  }
+
+  /**
+   * Returns the absolute path to a schema's auth functions directory.
+   *
+   * @param schemaName - The name of the schema
+   * @returns An AbsoluteDirectoryPath to the authentication directory
+   */
+  authBasePath(schemaName: string): AbsoluteDirectoryPath {
+    return new AbsoluteDirectoryPath(
+      join(this.rootPath, this.authBaseRelativePath(schemaName)),
     );
   }
 


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Allow for `si-conduit push` to detect existing schemas (same name), unlock them and modify them, along with unlocking and updating, deleting or adding any functions on the filesystem schema. 

Also adds auth func support to conduit 

#### Out of Scope:

Even if there are no changes to the schema or functions, schemas described on the filesystem will be unlocked on the changeset. This will be fixed in a further PR. Funcs that are exactly the same get skipped.

## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Regression test: Validate the we can still push net new assets and funcs
- [X] Manual test: Create an asset will all the scaffold funcs. Deleted an action, added a credential, updated codegen then ran push and all of it worked 
- [X] Manual test: Create a component from a schema, then update it and merge. Than, update it again to make sure that it unlocks the default schema, not the old one.  

## In short: [:link:](https://giphy.com/)

![](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3MDE1dGx1YmxhYWdnY2hkMGMxNXQ5Ynp2aW13bDFqcTV5anBrbGU3MyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xUNd9L2VQyFALRuJdC/giphy.gif)
