### PR TITLE
Use the auth portal go endpoint to auth to a workspace i dont have a token for

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -646,6 +646,14 @@ onBeforeMount(async () => {
   if (!workspaceAuthToken) {
     tokenFail.value = true;
     tokenFailStatus.value = 500;
+    // we don't have a token for this workspace, this is a dead end
+    // push the user to the auth flow for this workspace.
+    const url = `${
+      import.meta.env.VITE_AUTH_API_URL
+    }/workspaces/${thisWorkspacePk}/go?redirect=${encodeURIComponent(
+      window.location.pathname,
+    )}`;
+    window.location.href = url;
     return;
   }
 

--- a/lib/vue-lib/src/pinia/pinia_api_tools.ts
+++ b/lib/vue-lib/src/pinia/pinia_api_tools.ts
@@ -489,6 +489,9 @@ export const initPiniaApiToolkitPlugin = (config: { api: AxiosInstance }) => {
             // TODO maybe use Axios.isAxiosError instead, but don't want to change behavior right now
             if (err.response) {
               apiRequestStatus.error = (err as AxiosError).response;
+              span.setAttributes({
+                "http.status_code": apiRequestStatus.error?.status,
+              });
             } else {
               // if error was not http error or had no response body
               // we still want some kind of fallback message to show
@@ -507,7 +510,6 @@ export const initPiniaApiToolkitPlugin = (config: { api: AxiosInstance }) => {
           completed.resolve({
             error: err,
           });
-          span.setAttributes({ "http.status_code": err.response.status });
           span.end();
           return await completed.promise;
         }


### PR DESCRIPTION
## How does this PR change the system?

When a user doesn't have an auth token for a workspace we leave them to figure it out for themselves.

#### Out of Scope:

Next up, the auth portal redirect to the workspace you asked for in the URL not the default

## How was it tested?

1. Go to a workspace that is not your default work space
2. Copy the URL
3. Log out from that workspace (this removes tokens)
4. Paste the URL into your browser
5. Get redirected to auth portal `/go`
6. Which selected your default work space (this is the out of scope bit)
7. Paste the URL into your browser
8. Get redirected to the correct workspace

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZXY2MTlvdjQ1MWhjcGpsaWg3cnFyejRoeWNjcHJmbGtyNnVud2pkeSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o6gb3kkXfLvdKEZs4/giphy.gif"/>