### PR TITLE
better error handling for AttributePanel, fixed truncation bug

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
+++ b/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
@@ -30,7 +30,7 @@
     >
       <Icon
         :name="open ? 'chevron--down' : 'chevron--right'"
-        class="group-hover/header:scale-125"
+        class="group-hover/header:scale-125 flex-none"
       />
       <slot name="header" />
     </dt>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -244,7 +244,9 @@
         <span v-if="props.validation?.message">
           {{ props.validation.message }}
         </span>
-        <span v-else-if="hasError"> `{{ errorValue }}` failed to save </span>
+        <span v-else-if="hasError">
+          {{ errorValue }}
+        </span>
       </div>
 
       <!-- socket connections incompatibility message -->
@@ -367,7 +369,7 @@
               )
             "
           >
-            `{{ errorValue }}` failed to save
+            {{ errorValue }}
           </div>
 
           <!-- raw value selection area -->
@@ -895,10 +897,10 @@ const attrData = computed<AttrData>(() => {
 const errorContext = inject<ComputedRef<AttributeErrors>>("ATTRIBUTE_ERRORS");
 assertIsDefined<ComputedRef<AttributeErrors>>(errorContext);
 
-const errorValue = computed(() => {
-  const key = `${props.component.id}-${props.path}`;
-  return errorContext.value.saveErrors.value[key];
-});
+const errorKey = computed(() => `${props.component.id}-${props.path}`);
+const errorValue = computed(
+  () => errorContext.value.saveErrors.value[errorKey.value],
+);
 const hasError = computed(() => {
   return !!errorValue.value;
 });
@@ -1255,6 +1257,9 @@ const resetEverything = () => {
   inputTouched.value = false;
   showAllPossibleConnections.value = false;
   cancelTabBehavior.value = false;
+  if (errorValue.value) {
+    delete errorContext.value.saveErrors.value[errorKey.value];
+  }
 };
 
 const openInput = () => {

--- a/lib/vue-lib/src/design-system/general/TruncateWithTooltip.vue
+++ b/lib/vue-lib/src/design-system/general/TruncateWithTooltip.vue
@@ -55,9 +55,12 @@ const expanded = ref(false);
 const divRef = ref<HTMLElement>();
 const innerText = ref("");
 const mObserver = ref();
-
 const neededTooltipOnLoad = ref(false);
 const forceRecompute = ref(0);
+
+const windowResizeHandler = () => {
+  forceRecompute.value++;
+};
 
 onMounted(() => {
   if (divRef.value) {
@@ -74,12 +77,15 @@ onMounted(() => {
     subtree: true,
     characterData: true,
   });
+
+  window.addEventListener("resize", windowResizeHandler);
 });
 
 onBeforeUnmount(() => {
   if (mObserver.value) {
     mObserver.value.disconnect();
   }
+  window.removeEventListener("resize", windowResizeHandler);
 });
 
 const tooltipActive = computed(() => {


### PR DESCRIPTION
## How does this PR change the system?

This PR improves the error handling in the `AttributePanel` in the following two ways -

- When a subscription fails due to incompatible types (for example, trying to subscribe an Array prop to a String value) the attributes endpoint now returns a 400 and the frontend displays a user-friendly message.
- When an error occurs in the `AttributePanel` the error is now cleared out when the user reselects that AV input.

Also included in this PR is a fix to a truncation bug in the headers of the `AttributePanel` found while working  on it. Part of that bug fix is an improvement to TruncateWithTooltip which makes it reactive to the browser window changing size.

#### Screenshots:

<img width="452" height="210" alt="Screenshot 2025-10-22 at 8 01 57 PM" src="https://github.com/user-attachments/assets/098d20e5-7e9a-4295-928f-105d280ddb03" />

Truncation bug before being fixed -

https://github.com/user-attachments/assets/32596d85-9a08-49cf-8619-9b0735340fd8

#### Out of Scope:

All other errors in the `AttributePanel` besides a `SubscriptionTypeMismatch` still display the same. We may want to have more detailed error handling in the future.

We may want to revisit the styling of the error display or adjust the copy of the user-friendly error message for the 400.

## How was it tested?

For the changes to error handling, I exercised a variety of scenarios which both triggered the 400 error and ones that should not to ensure it behaved as expected.

For the truncation bug I tested every possible combination of elements in the header at a variety of window widths to ensure it displays as expected in all scenarios.
