### PR TITLE
feat(si-conduit): implement remote schema pull

### DIFF
--- a/bin/si-conduit/README.md
+++ b/bin/si-conduit/README.md
@@ -13,6 +13,7 @@ SI Conduit is a Deno-based CLI application that provides a structured workflow f
 - **Project Module** (`src/project.ts`): Project structure management and path utilities for working with schemas and their functions.
 - **Authentication** (`src/auth-api-client.ts`, `src/jwt.ts`): API authentication and JWT token handling for secure communication with System Initiative services.
 - **Generators** (`src/generators.ts`): Code generation utilities for scaffolding schemas and functions.
+- **Materialize Module** (`src/materialize.ts`): File system operations for creating and writing schema files, metadata, and function code to disk.
 
 ### Command Structure
 
@@ -27,7 +28,9 @@ si-conduit
 │   ├── qualification generate - Generate qualification functions
 │   └── scaffold generate    - Scaffold a complete schema structure
 ├── remote
-│   └── push                 - Push schemas to remote workspace
+│   └── schema
+│       ├── pull             - Pull schemas from remote workspace
+│       └── push             - Push schemas to remote workspace
 └── whoami                   - Display authenticated user information
 ```
 
@@ -273,12 +276,32 @@ si-conduit schema management generate MySchema reconcile
 si-conduit schema qualification generate MySchema validate
 ```
 
+### Pulling from Remote
+
+Pull schemas from your System Initiative workspace to your local project:
+
+```bash
+# Pull a specific schema
+si-conduit remote schema pull MySchema
+
+# Pull multiple schemas
+si-conduit remote schema pull Schema1 Schema2 Schema3
+```
+
+This command will:
+- Fetch the schema definition and metadata from your workspace
+- Download all associated functions (actions, code generators, management, qualifications)
+- Create the complete schema structure in your local project
+- Preserve the exact code and configuration from the remote workspace
+
+This command requires authentication via the `SI_API_TOKEN` environment variable.
+
 ### Pushing to Remote
 
 Push your schemas to your System Initiative workspace:
 
 ```bash
-si-conduit remote push
+si-conduit remote schema push
 ```
 
 This command requires authentication via the `SI_API_TOKEN` environment variable.

--- a/bin/si-conduit/src/api.ts
+++ b/bin/si-conduit/src/api.ts
@@ -1,0 +1,45 @@
+import { getLogger } from "@logtape/logtape";
+import { Configuration } from "@systeminit/api-client";
+import { AuthApiClient, WorkspaceDetails } from "./auth-api-client.ts";
+import * as jwt from "./jwt.ts";
+
+const logger = getLogger(["si-conduit", "api"]);
+
+export type ApiContext = {
+  config: Configuration;
+  workspace: WorkspaceDetails;
+  user: { id: string };
+};
+
+export async function apiContext(
+  apiBaseUrl: string,
+  apiToken: string,
+): Promise<ApiContext> {
+  const userData = jwt.tryGetUserDataFromToken(apiToken);
+
+  const config = new Configuration({
+    basePath: apiBaseUrl,
+    baseOptions: {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+      },
+    },
+  });
+
+  logger.debug("Getting workspace details from Auth API {apiBaseUrl}", {
+    apiBaseUrl,
+  });
+
+  const workspace = await new AuthApiClient(
+    apiToken,
+    userData.workspaceId,
+  ).getWorkspaceDetails();
+
+  logger.debug("Fetched workspace details {workspace}", {
+    workspace,
+  });
+
+  const user = { id: userData.userId };
+
+  return { config, workspace, user };
+}

--- a/bin/si-conduit/src/cli/prompt.ts
+++ b/bin/si-conduit/src/cli/prompt.ts
@@ -27,6 +27,8 @@
 import { Input } from "@cliffy/prompt";
 import type { InputOptions } from "@cliffy/prompt/input";
 import { Project } from "../project.ts";
+import { isInteractive } from "../logger.ts";
+import { ValidationError } from "@cliffy/command";
 
 /** Minimum length requirement for all prompt inputs. */
 const MIN_INPUT_LENGTH = 1 as const;
@@ -79,6 +81,10 @@ async function promptForName(
     return value;
   }
 
+  if (!isInteractive()) {
+    throw new ValidationError(`Missing required argument for ${promptMessage}`);
+  }
+
   const suggestions = await Promise.resolve(getSuggestions());
   return await Input.prompt(createPromptOptions(promptMessage, suggestions));
 }
@@ -111,7 +117,7 @@ async function promptForName(
  *
  * @see {@link Project.currentSchemaDirNames}
  */
-export async function schemaName(
+export async function schemaNameFromDirNames(
   schemaName: string | undefined,
   project: Project,
 ): Promise<string> {
@@ -120,6 +126,13 @@ export async function schemaName(
     "Schema Name",
     () => project.currentSchemaDirNames(),
   );
+}
+
+export async function schemaName(
+  schemaName: string | undefined,
+  _project: Project,
+): Promise<string> {
+  return await promptForName(schemaName, "Schema Name", () => []);
 }
 
 /**

--- a/bin/si-conduit/src/command/project/init.ts
+++ b/bin/si-conduit/src/command/project/init.ts
@@ -8,16 +8,17 @@
  */
 
 import { Context } from "../../context.ts";
+import { getLogger } from "../../logger.ts";
 import { AbsoluteDirectoryPath, Project } from "../../project.ts";
+
+const logger = getLogger();
 
 export async function callProjectInit(
   ctx: Context,
   rootPath: AbsoluteDirectoryPath,
 ) {
-  const logger = ctx.logger;
-
   logger.info("Initializing Conduit project");
-  logger.info("----------------------------");
+  logger.info("---");
   logger.info("");
 
   if (await rootPath.exists()) {
@@ -43,8 +44,10 @@ export async function callProjectInit(
     });
   }
 
+  ctx.analytics.trackEvent("project_init");
+
   logger.info("");
-  logger.info("Conduit project initialized");
-  logger.info("");
+  logger.info("---");
+  logger.info("Conduit project successfully initialized");
   logger.info(`   ${rootPath.toString()}`);
 }

--- a/bin/si-conduit/src/command/remote/schema/pull.ts
+++ b/bin/si-conduit/src/command/remote/schema/pull.ts
@@ -1,0 +1,395 @@
+import {
+  FuncsApi,
+  SchemasApi,
+  SchemaVariantFunc,
+} from "@systeminit/api-client";
+import { ApiContext } from "../../../api.ts";
+import { SCHEMA_FILE_FORMAT_VERSION } from "../../../config.ts";
+import { Context } from "../../../context.ts";
+import { FunctionMetadata, SchemaMetadata } from "../../../generators.ts";
+import * as materialize from "../../../materialize.ts";
+import { getLogger } from "../../../logger.ts";
+import { AbsoluteFilePath, Project } from "../../../project.ts";
+
+const logger = getLogger();
+
+export async function callRemoteSchemaPull(
+  ctx: Context,
+  project: Project,
+  apiCtx: ApiContext,
+  schemaNames: string[],
+): Promise<PullFullSchemaResult[]> {
+  logger.info("Pulling remote schemas to local system");
+  logger.info("---");
+  logger.info("");
+
+  const api = {
+    schemas: new SchemasApi(apiCtx.config),
+    funcs: new FuncsApi(apiCtx.config),
+  };
+
+  const changeSetCoord = {
+    workspaceId: apiCtx.workspace.id,
+    changeSetId: "HEAD",
+  };
+
+  const results = [];
+  const pulledSchemaNames = [];
+  const notFoundSchemaNames = [];
+  for (const schemaName of schemaNames) {
+    const result = await pullSchemaByName(
+      project,
+      api,
+      changeSetCoord,
+      schemaName,
+    );
+    if (result) {
+      results.push(result);
+      pulledSchemaNames.push(schemaName);
+    } else {
+      notFoundSchemaNames.push(schemaName);
+    }
+  }
+
+  ctx.analytics.trackEvent("remote_schema_pull", {
+    schemaNames: pulledSchemaNames,
+    notFoundSchemaNames,
+  });
+
+  // TODO(fnichol): If some schemas were not found, should we error out? At the
+  // moment we aren't
+
+  logger.info("");
+  logger.info("---");
+  logger.info("Successfully pulled schemas:");
+  for (const schemaName of pulledSchemaNames) {
+    logger.info(` - ${schemaName}`);
+  }
+
+  return results;
+}
+
+type Api = {
+  schemas: SchemasApi;
+  funcs: FuncsApi;
+};
+
+type SchemaAndVariantData = {
+  schema: {
+    id: string;
+    name: string;
+  };
+  variant: {
+    id: string;
+    displayName: string;
+    description?: string | null;
+    category: string;
+    link?: string | null;
+  };
+  func: {
+    schemaId: string;
+    actionIds: string[];
+    codegenIds: string[];
+    managementIds: string[];
+    qualificationIds: string[];
+  };
+};
+
+type ChangeSetCoordinate = {
+  workspaceId: string;
+  changeSetId: string;
+};
+
+type FuncCoord = ChangeSetCoordinate & {
+  funcId: string;
+};
+
+async function pullSchemaByName(
+  project: Project,
+  api: Api,
+  changeSetCoord: ChangeSetCoordinate,
+  schemaName: string,
+): Promise<PullFullSchemaResult | undefined> {
+  logger.info("Pulling schema {schemaName}", { schemaName });
+
+  const data = await getSchemaAndVariantBySchemaName(
+    api,
+    changeSetCoord,
+    schemaName,
+  );
+
+  if (!data) {
+    // TODO(fnichol): log error, throw, or other here?
+    return undefined;
+  }
+
+  const formatVersionBody = SCHEMA_FILE_FORMAT_VERSION.toString();
+
+  const metadata = schemaMetadata(data);
+  const metadataBody = JSON.stringify(metadata, null, 2);
+
+  const { codeBody } = await fetchFuncMetadataAndCode(api, {
+    funcId: data.func.schemaId,
+    ...changeSetCoord,
+  });
+
+  await materialize.materializeSchemaBase(project, schemaName);
+  const { formatVersionPath } = await materialize
+    .materializeSchemaFormatVersion(
+      project,
+      schemaName,
+      formatVersionBody,
+    );
+  const { metadataPath, codePath } = await materialize.materializeSchema(
+    project,
+    schemaName,
+    metadataBody,
+    codeBody,
+  );
+
+  // Render all action funcs
+  if (data.func.actionIds.length > 0) {
+    await materialize.materializeSchemaActionBase(project, schemaName);
+  }
+  const actionPaths = [];
+  for (const funcId of data.func.actionIds) {
+    const { metadata, codeBody } = await fetchFuncMetadataAndCode(api, {
+      funcId,
+      ...changeSetCoord,
+    });
+    const metadataBody = JSON.stringify(metadata, null, 2);
+
+    const paths = await materialize.materializeSchemaAction(
+      project,
+      schemaName,
+      metadata.name,
+      metadataBody,
+      codeBody,
+    );
+    actionPaths.push(paths);
+  }
+
+  // Render all codegen funcs
+  if (data.func.codegenIds.length > 0) {
+    await materialize.materializeSchemaCodegenBase(project, schemaName);
+  }
+  const codegenPaths = [];
+  for (const funcId of data.func.codegenIds) {
+    const { metadata, codeBody } = await fetchFuncMetadataAndCode(api, {
+      funcId,
+      ...changeSetCoord,
+    });
+    const metadataBody = JSON.stringify(metadata, null, 2);
+
+    const paths = await materialize.materializeSchemaCodegen(
+      project,
+      schemaName,
+      metadata.name,
+      metadataBody,
+      codeBody,
+    );
+    codegenPaths.push(paths);
+  }
+
+  // Render all management funcs
+  if (data.func.managementIds.length > 0) {
+    await materialize.materializeSchemaManagementBase(project, schemaName);
+  }
+  const managementPaths = [];
+  for (const funcId of data.func.managementIds) {
+    const { metadata, codeBody } = await fetchFuncMetadataAndCode(api, {
+      funcId,
+      ...changeSetCoord,
+    });
+    const metadataBody = JSON.stringify(metadata, null, 2);
+
+    const paths = await materialize.materializeSchemaManagement(
+      project,
+      schemaName,
+      metadata.name,
+      metadataBody,
+      codeBody,
+    );
+    managementPaths.push(paths);
+  }
+
+  // Render all qualification funcs
+  if (data.func.qualificationIds.length > 0) {
+    await materialize.materializeSchemaQualificationBase(project, schemaName);
+  }
+  const qualificationPaths = [];
+  for (const funcId of data.func.qualificationIds) {
+    const { metadata, codeBody } = await fetchFuncMetadataAndCode(api, {
+      funcId,
+      ...changeSetCoord,
+    });
+    const metadataBody = JSON.stringify(metadata, null, 2);
+
+    const paths = await materialize.materializeSchemaQualification(
+      project,
+      schemaName,
+      metadata.name,
+      metadataBody,
+      codeBody,
+    );
+    qualificationPaths.push(paths);
+  }
+
+  return {
+    formatVersionPath,
+    metadataPath,
+    codePath,
+    actionPaths,
+    codegenPaths,
+    managementPaths,
+    qualificationPaths,
+  };
+}
+
+async function fetchFuncMetadataAndCode(
+  api: Api,
+  funcCoord: FuncCoord,
+): Promise<{ metadata: FunctionMetadata; codeBody: string }> {
+  const { data: func } = await api.funcs.getFunc({ ...funcCoord });
+
+  return {
+    metadata: {
+      name: func.name,
+      displayName: func.displayName,
+      description: func.description,
+    },
+    codeBody: func.code,
+  };
+}
+
+async function getSchemaAndVariantBySchemaName(
+  api: Api,
+  changeSetCoord: ChangeSetCoordinate,
+  schemaName: string,
+): Promise<SchemaAndVariantData | undefined> {
+  const response = await api.schemas.findSchema(
+    {
+      schema: schemaName,
+      ...changeSetCoord,
+    },
+    {
+      // Not found is an expected response
+      validateStatus: (status) =>
+        (status >= 200 && status < 300) || status == 404,
+    },
+  );
+  const { status: schemaStatus, data: schema } = response;
+
+  if (schemaStatus == 404) {
+    // TODO(fnichol): log and return or throw?
+    logger.error("remote schema not found named {schemaName}", {
+      schemaName,
+    });
+    return undefined;
+  }
+
+  const schemaCoord = {
+    schemaId: schema.schemaId,
+    ...changeSetCoord,
+  };
+
+  const { data: variant } = await api.schemas.getDefaultVariant({
+    ...schemaCoord,
+  });
+  // TODO(fnichol): handle HTTP/202 to try again as variant could be building
+
+  const funcs = new SchemaVariantFuncs(variant.variantFuncs);
+
+  return {
+    schema: {
+      id: schema.schemaId,
+      name: schema.schemaName,
+    },
+    variant: {
+      id: variant.variantId,
+      displayName: variant.displayName,
+      description: variant.description,
+      category: variant.category,
+      link: variant.link,
+    },
+    func: {
+      schemaId: variant.assetFuncId,
+      actionIds: funcs.actionIds(),
+      codegenIds: funcs.codegenIds(),
+      managementIds: funcs.managementIds(),
+      qualificationIds: funcs.qualificationIds(),
+    },
+  };
+}
+
+function schemaMetadata(data: SchemaAndVariantData): SchemaMetadata {
+  return {
+    name: data.schema.name,
+    category: data.variant.category,
+    description: data.variant.description,
+    documentation: data.variant.link,
+  };
+}
+
+class SchemaVariantFuncs {
+  constructor(public readonly funcs: SchemaVariantFunc[]) {}
+
+  public actionFuncs(): SchemaVariantFunc[] {
+    return this.funcs.filter((svf) => svf.funcKind.kind === "action");
+  }
+
+  public actionIds(): string[] {
+    return this.actionFuncs().map((func) => func.id);
+  }
+
+  public codegenFuncs(): SchemaVariantFunc[] {
+    return this.funcs.filter(
+      (svf) =>
+        svf.funcKind.kind === "other" &&
+        svf.funcKind.funcKind === "CodeGeneration",
+    );
+  }
+
+  public codegenIds(): string[] {
+    return this.codegenFuncs().map((func) => func.id);
+  }
+
+  public managementFuncs(): SchemaVariantFunc[] {
+    return this.funcs.filter((svf) => svf.funcKind.kind === "management");
+  }
+
+  public managementIds(): string[] {
+    return this.managementFuncs().map((func) => func.id);
+  }
+
+  public qualificationFuncs(): SchemaVariantFunc[] {
+    return this.funcs.filter(
+      (svf) =>
+        svf.funcKind.kind === "other" &&
+        svf.funcKind.funcKind === "Qualification",
+    );
+  }
+
+  public qualificationIds(): string[] {
+    return this.qualificationFuncs().map((func) => func.id);
+  }
+}
+
+export interface PullFullSchemaResult {
+  formatVersionPath: AbsoluteFilePath;
+  metadataPath: AbsoluteFilePath;
+  codePath: AbsoluteFilePath;
+  actionPaths: { metadataPath: AbsoluteFilePath; codePath: AbsoluteFilePath }[];
+  codegenPaths: {
+    metadataPath: AbsoluteFilePath;
+    codePath: AbsoluteFilePath;
+  }[];
+  managementPaths: {
+    metadataPath: AbsoluteFilePath;
+    codePath: AbsoluteFilePath;
+  }[];
+  qualificationPaths: {
+    metadataPath: AbsoluteFilePath;
+    codePath: AbsoluteFilePath;
+  }[];
+}

--- a/bin/si-conduit/src/command/schema/action/generate.ts
+++ b/bin/si-conduit/src/command/schema/action/generate.ts
@@ -1,41 +1,41 @@
 import { Context } from "../../../context.ts";
 import * as generator from "../../../generators.ts";
+import { getLogger } from "../../../logger.ts";
 import { Project } from "../../../project.ts";
 import type { AbsoluteFilePath } from "../../../project.ts";
+
+const logger = getLogger();
 
 export async function callSchemaActionGenerate(
   ctx: Context,
   project: Project,
   schemaName: string,
-  actionName: string,
+  name: string,
 ): Promise<GeneratorResult> {
-  const logger = ctx.logger;
-
-  logger.info("Generating action function {actionName} for {schemaName}", {
+  logger.info("Generating action function {name} for schema {schemaName}", {
     schemaName,
-    actionName,
+    name,
   });
+  logger.info("---");
+  logger.info("");
 
-  await generator.generateSchemaActionBase(ctx, project, schemaName);
+  await generator.generateSchemaActionBase(project, schemaName);
 
-  const paths = await generator.generateSchemaAction(
-    ctx,
-    project,
-    schemaName,
-    actionName,
-  );
+  const paths = await generator.generateSchemaAction(project, schemaName, name);
 
+  logger.info("");
+  logger.info("---");
   logger.info(
-    "Successfully generated action function {actionName} for schema {schemaName}",
+    "Successfully generated action function for schema {schemaName}",
     {
       schemaName,
-      actionName,
     },
   );
+  logger.info(`  - ${name}`);
 
-  ctx.analytics.trackEvent("generate_action_function", {
+  ctx.analytics.trackEvent("schema_action_generate", {
     schemaName: schemaName,
-    actionName: actionName,
+    actionName: name,
   });
 
   return paths;

--- a/bin/si-conduit/src/command/schema/codegen/generate.ts
+++ b/bin/si-conduit/src/command/schema/codegen/generate.ts
@@ -1,41 +1,45 @@
 import { Context } from "../../../context.ts";
 import * as generator from "../../../generators.ts";
+import { getLogger } from "../../../logger.ts";
 import { Project } from "../../../project.ts";
 import type { AbsoluteFilePath } from "../../../project.ts";
+
+const logger = getLogger();
 
 export async function callSchemaCodegenGenerate(
   ctx: Context,
   project: Project,
   schemaName: string,
-  codegenName: string,
+  name: string,
 ) {
-  const logger = ctx.logger;
-
-  logger.info("Generating codegen function {codegenName} for {schemaName}", {
+  logger.info("Generating codegen function {name} for schema {schemaName}", {
     schemaName,
-    codegenName,
+    name,
   });
+  logger.info("---");
+  logger.info("");
 
-  await generator.generateSchemaCodegenBase(ctx, project, schemaName);
+  await generator.generateSchemaCodegenBase(project, schemaName);
 
   const paths = await generator.generateSchemaCodegen(
-    ctx,
     project,
     schemaName,
-    codegenName,
+    name,
   );
 
+  logger.info("");
+  logger.info("---");
   logger.info(
-    "Successfully generated action function {codegenName} for schema {schemaName}",
+    "Successfully generated codegen function for schema {schemaName}",
     {
       schemaName,
-      codegenName,
     },
   );
+  logger.info(`  - ${name}`);
 
-  ctx.analytics.trackEvent("generate_codegen_function", {
+  ctx.analytics.trackEvent("schema_codegen_generate", {
     schemaName: schemaName,
-    codegenName: codegenName,
+    codegenName: name,
   });
 
   return paths;

--- a/bin/si-conduit/src/command/schema/management/generate.ts
+++ b/bin/si-conduit/src/command/schema/management/generate.ts
@@ -1,44 +1,45 @@
 import { Context } from "../../../context.ts";
 import * as generator from "../../../generators.ts";
+import { getLogger } from "../../../logger.ts";
 import { Project } from "../../../project.ts";
 import type { AbsoluteFilePath } from "../../../project.ts";
+
+const logger = getLogger();
 
 export async function callSchemaManagementGenerate(
   ctx: Context,
   project: Project,
   schemaName: string,
-  managementName: string,
+  name: string,
 ): Promise<GeneratorResult> {
-  const logger = ctx.logger;
+  logger.info("Generating management function {name} for schema {schemaName}", {
+    schemaName,
+    name,
+  });
+  logger.info("---");
+  logger.info("");
 
-  logger.info(
-    "Generating management function {managementName} for {schemaName}",
-    {
-      schemaName,
-      managementName,
-    },
-  );
-
-  await generator.generateSchemaManagementBase(ctx, project, schemaName);
+  await generator.generateSchemaManagementBase(project, schemaName);
 
   const paths = await generator.generateSchemaManagement(
-    ctx,
     project,
     schemaName,
-    managementName,
+    name,
   );
 
+  logger.info("");
+  logger.info("---");
   logger.info(
-    "Successfully generated management function {managementName} for schema {schemaName}",
+    "Successfully generated management function for schema {schemaName}",
     {
       schemaName,
-      managementName,
     },
   );
+  logger.info(`  - ${name}`);
 
-  ctx.analytics.trackEvent("generate_management_function", {
+  ctx.analytics.trackEvent("schema_management_generate", {
     schemaName: schemaName,
-    managementName: managementName,
+    managementName: name,
   });
 
   return paths;

--- a/bin/si-conduit/src/command/schema/qualification/generate.ts
+++ b/bin/si-conduit/src/command/schema/qualification/generate.ts
@@ -1,44 +1,48 @@
 import { Context } from "../../../context.ts";
 import * as generator from "../../../generators.ts";
+import { getLogger } from "../../../logger.ts";
 import { Project } from "../../../project.ts";
 import type { AbsoluteFilePath } from "../../../project.ts";
+
+const logger = getLogger();
 
 export async function callSchemaQualificationGenerate(
   ctx: Context,
   project: Project,
   schemaName: string,
-  qualificationName: string,
+  name: string,
 ): Promise<GeneratorResult> {
-  const logger = ctx.logger;
-
   logger.info(
-    "Generating qualification function {qualificationName} for {schemaName}",
+    "Generating qualification function {name} for schema {schemaName}",
     {
       schemaName,
-      qualificationName,
+      name,
     },
   );
+  logger.info("---");
+  logger.info("");
 
-  await generator.generateSchemaQualificationBase(ctx, project, schemaName);
+  await generator.generateSchemaQualificationBase(project, schemaName);
 
   const paths = await generator.generateSchemaQualification(
-    ctx,
     project,
     schemaName,
-    qualificationName,
+    name,
   );
 
+  logger.info("");
+  logger.info("---");
   logger.info(
-    "Successfully generated qualification function {qualificationName} for schema {schemaName}",
+    "Successfully generated qualification function for schema {schemaName}",
     {
       schemaName,
-      qualificationName,
     },
   );
+  logger.info(`  - ${name}`);
 
-  ctx.analytics.trackEvent("generate_qualification_function", {
+  ctx.analytics.trackEvent("schema_qualification_generate", {
     schemaName: schemaName,
-    qualificationName: qualificationName,
+    qualificationName: name,
   });
 
   return paths;

--- a/bin/si-conduit/src/command/schema/scaffold/generate.ts
+++ b/bin/si-conduit/src/command/schema/scaffold/generate.ts
@@ -1,35 +1,45 @@
 import { Context } from "../../../context.ts";
 import * as generator from "../../../generators.ts";
+import { getLogger } from "../../../logger.ts";
 import type { AbsoluteFilePath } from "../../../project.ts";
 import { Project } from "../../../project.ts";
+
+const logger = getLogger();
 
 export async function callSchemaScaffoldGenerate(
   ctx: Context,
   project: Project,
   schemaName: string,
 ): Promise<SchemaScaffoldResult> {
-  const logger = ctx.logger;
-
-  logger.info("Generating scaffold for {schemaName}", {
+  logger.info("Generating scaffold for schema {schemaName}", {
     schemaName,
   });
+  logger.info("---");
+  logger.info("");
 
-  const { formatVersionPath } = await generator.generateSchemaBase(
-    ctx,
+  // Check that the schema directory doesn't exist
+  const schemaBasePath = project.schemaBasePath(schemaName);
+  if (await schemaBasePath.exists()) {
+    logger.error("Directory already exists at {schemaBasePath}", {
+      schemaBasePath: schemaBasePath.toString(),
+    });
+    throw new DirectoryExistsError(schemaBasePath.toString());
+  }
+
+  await generator.generateSchemaBase(project, schemaName);
+  const { formatVersionPath } = await generator.generateSchemaFormatVersion(
     project,
     schemaName,
   );
   const { metadataPath, codePath } = await generator.generateSchema(
-    ctx,
     project,
     schemaName,
   );
 
-  await generator.generateSchemaActionBase(ctx, project, schemaName);
+  await generator.generateSchemaActionBase(project, schemaName);
   const actionPaths = [];
   for (const actionName of Project.DEFAULT_ACTION_NAMES) {
     const paths = await generator.generateSchemaAction(
-      ctx,
       project,
       schemaName,
       actionName,
@@ -37,11 +47,10 @@ export async function callSchemaScaffoldGenerate(
     actionPaths.push(paths);
   }
 
-  await generator.generateSchemaCodegenBase(ctx, project, schemaName);
+  await generator.generateSchemaCodegenBase(project, schemaName);
   const codegenPaths = [];
   for (const codegenName of Project.DEFAULT_CODEGEN_NAMES) {
     const paths = await generator.generateSchemaCodegen(
-      ctx,
       project,
       schemaName,
       codegenName,
@@ -49,11 +58,10 @@ export async function callSchemaScaffoldGenerate(
     codegenPaths.push(paths);
   }
 
-  await generator.generateSchemaManagementBase(ctx, project, schemaName);
+  await generator.generateSchemaManagementBase(project, schemaName);
   const managementPaths = [];
   for (const managementName of Project.DEFAULT_MANAGEMENT_NAMES) {
     const paths = await generator.generateSchemaManagement(
-      ctx,
       project,
       schemaName,
       managementName,
@@ -61,11 +69,10 @@ export async function callSchemaScaffoldGenerate(
     managementPaths.push(paths);
   }
 
-  await generator.generateSchemaQualificationBase(ctx, project, schemaName);
+  await generator.generateSchemaQualificationBase(project, schemaName);
   const qualificationPaths = [];
   for (const qualificationName of Project.DEFAULT_QUALIFICATION_NAMES) {
     const paths = await generator.generateSchemaQualification(
-      ctx,
       project,
       schemaName,
       qualificationName,
@@ -73,11 +80,15 @@ export async function callSchemaScaffoldGenerate(
     qualificationPaths.push(paths);
   }
 
+  logger.info("");
+  logger.info("---");
   logger.info("Successfully generated scaffold for schema {schemaName}", {
     schemaName,
   });
 
-  ctx.analytics.trackEvent("generate_scaffold", { schemaName: schemaName });
+  ctx.analytics.trackEvent("schema_scaffold_generate", {
+    schemaName: schemaName,
+  });
 
   return {
     formatVersionPath,
@@ -113,4 +124,14 @@ export interface SchemaScaffoldResult {
     metadataPath: AbsoluteFilePath;
     codePath: AbsoluteFilePath;
   }[];
+}
+
+/**
+ * Error thrown when attempting to create a schema in a directory that already exists.
+ */
+export class DirectoryExistsError extends Error {
+  constructor(public readonly path: string) {
+    super(`Directory already exists at: ${path}`);
+    this.name = "DirectoryExistsError";
+  }
 }

--- a/bin/si-conduit/src/context.ts
+++ b/bin/si-conduit/src/context.ts
@@ -33,7 +33,12 @@
 import type { Logger } from "@logtape/logtape";
 import { Analytics } from "./analytics.ts";
 import type { UserData } from "./jwt.ts";
-import { configureLogger, getLogger, type VerbosityLevel } from "./logger.ts";
+import {
+  configureLogger,
+  getLogger,
+  isInteractive as loggerIsInteractive,
+  type VerbosityLevel,
+} from "./logger.ts";
 
 /** Event prefix for all analytics events tracked by this application. */
 const ANALYTICS_EVENT_PREFIX = "conduit";
@@ -69,9 +74,17 @@ export class Context {
   /** Analytics instance for event tracking. */
   public readonly analytics: Analytics;
 
-  private constructor(logger: Logger, analytics: Analytics) {
+  /** Whether or not the CLI is running in an interactive session. */
+  public readonly isInteractive: boolean;
+
+  private constructor(
+    logger: Logger,
+    analytics: Analytics,
+    isInteractive: boolean,
+  ) {
     this.logger = logger;
     this.analytics = analytics;
+    this.isInteractive = isInteractive;
   }
 
   /**
@@ -103,7 +116,9 @@ export class Context {
 
     const analytics = new Analytics(ANALYTICS_EVENT_PREFIX, options.userData);
 
-    this.context = new Context(logger, analytics);
+    const isInteractive = loggerIsInteractive();
+
+    this.context = new Context(logger, analytics, isInteractive);
 
     return this.context;
   }

--- a/bin/si-conduit/src/generators.ts
+++ b/bin/si-conduit/src/generators.ts
@@ -25,9 +25,8 @@
  * @module
  */
 
-import type { Logger } from "@logtape/logtape";
 import { SCHEMA_FILE_FORMAT_VERSION } from "./config.ts";
-import { Context } from "./context.ts";
+import * as materialize from "./materialize.ts";
 import { Project } from "./project.ts";
 import type { AbsoluteFilePath } from "./project.ts";
 
@@ -48,41 +47,8 @@ import type { AbsoluteFilePath } from "./project.ts";
  * const { formatVersionPath } = await generateSchemaBase(ctx, project, "MySchema");
  * ```
  */
-export async function generateSchemaBase(
-  ctx: Context,
-  project: Project,
-  schemaName: string,
-): Promise<{ formatVersionPath: AbsoluteFilePath }> {
-  const logger = ctx.logger;
-
-  const schemaBasePath = project.schemaBasePath(schemaName);
-
-  // Check that the schema directory doesn't exist
-  if (await schemaBasePath.exists()) {
-    logger.error("Directory already exists at {schemaBasePath}", {
-      schemaBasePath: schemaBasePath.toString(),
-    });
-    throw new DirectoryExistsError(schemaBasePath.toString());
-  }
-
-  // Create schema base directory
-  await schemaBasePath.mkdir({ recursive: true });
-  logger.info("Created schema directory: {schemaBasePath}", {
-    schemaBasePath: schemaBasePath.toString(),
-  });
-
-  // Create the format version file
-  const formatVersionFilePath = project.schemaFormatVersionPath(schemaName);
-  await ensureFileDoesNotExist(formatVersionFilePath, logger);
-  await createFileWithLogging(
-    formatVersionFilePath,
-    SCHEMA_FILE_FORMAT_VERSION.toString(),
-    logger,
-  );
-
-  return {
-    formatVersionPath: formatVersionFilePath,
-  };
+export async function generateSchemaBase(project: Project, schemaName: string) {
+  return await materialize.materializeSchemaBase(project, schemaName);
 }
 
 /**
@@ -96,21 +62,10 @@ export async function generateSchemaBase(
  * @param schemaName - Name of the schema
  */
 export async function generateSchemaActionBase(
-  ctx: Context,
   project: Project,
   schemaName: string,
 ) {
-  const logger = ctx.logger;
-
-  const actionBasePath = project.actionBasePath(schemaName);
-
-  // Create the action base directory
-  if (!(await actionBasePath.exists())) {
-    await actionBasePath.mkdir({ recursive: true });
-    logger.info("Created actions directory: {actionBasePath}", {
-      actionBasePath: actionBasePath.toString(),
-    });
-  }
+  return await materialize.materializeSchemaActionBase(project, schemaName);
 }
 
 /**
@@ -124,21 +79,10 @@ export async function generateSchemaActionBase(
  * @param schemaName - Name of the schema
  */
 export async function generateSchemaCodegenBase(
-  ctx: Context,
   project: Project,
   schemaName: string,
 ) {
-  const logger = ctx.logger;
-
-  const codegenBasePath = project.codegenBasePath(schemaName);
-
-  // Create the codegen base directory
-  if (!(await codegenBasePath.exists())) {
-    await codegenBasePath.mkdir({ recursive: true });
-    logger.info("Created code generators directory: {codegenBasePath}", {
-      codegenBasePath: codegenBasePath.toString(),
-    });
-  }
+  return await materialize.materializeSchemaCodegenBase(project, schemaName);
 }
 
 /**
@@ -152,21 +96,10 @@ export async function generateSchemaCodegenBase(
  * @param schemaName - Name of the schema
  */
 export async function generateSchemaManagementBase(
-  ctx: Context,
   project: Project,
   schemaName: string,
 ) {
-  const logger = ctx.logger;
-
-  const managementBasePath = project.managementBasePath(schemaName);
-
-  // Create the management base directory
-  if (!(await managementBasePath.exists())) {
-    await managementBasePath.mkdir({ recursive: true });
-    logger.info("Created management directory: {managementBasePath}", {
-      managementBasePath: managementBasePath.toString(),
-    });
-  }
+  return await materialize.materializeSchemaManagementBase(project, schemaName);
 }
 
 /**
@@ -180,21 +113,26 @@ export async function generateSchemaManagementBase(
  * @param schemaName - Name of the schema
  */
 export async function generateSchemaQualificationBase(
-  ctx: Context,
   project: Project,
   schemaName: string,
 ) {
-  const logger = ctx.logger;
+  return await materialize.materializeSchemaQualificationBase(
+    project,
+    schemaName,
+  );
+}
 
-  const qualificationBasePath = project.qualificationBasePath(schemaName);
+export async function generateSchemaFormatVersion(
+  project: Project,
+  schemaName: string,
+): Promise<{ formatVersionPath: AbsoluteFilePath }> {
+  const formatVersionBody = SCHEMA_FILE_FORMAT_VERSION.toString();
 
-  // Create the qualification base directory
-  if (!(await qualificationBasePath.exists())) {
-    await qualificationBasePath.mkdir({ recursive: true });
-    logger.info("Created qualifications directory: {qualificationBasePath}", {
-      qualificationBasePath: qualificationBasePath.toString(),
-    });
-  }
+  return await materialize.materializeSchemaFormatVersion(
+    project,
+    schemaName,
+    formatVersionBody,
+  );
 }
 
 /**
@@ -211,35 +149,19 @@ export async function generateSchemaQualificationBase(
  * @throws {FileExistsError} If either file already exists
  */
 export async function generateSchema(
-  ctx: Context,
   project: Project,
   schemaName: string,
 ): Promise<{ metadataPath: AbsoluteFilePath; codePath: AbsoluteFilePath }> {
-  const logger = ctx.logger;
-
-  // Create schema metadata file
-  const metadataFilePath = project.schemaMetadataPath(schemaName);
-  await ensureFileDoesNotExist(metadataFilePath, logger);
   const metadata = schemaMetadata(schemaName);
-  await createFileWithLogging(
-    metadataFilePath,
-    JSON.stringify(metadata, null, 2),
-    logger,
-  );
+  const metadataBody = JSON.stringify(metadata, null, 2);
+  const codeBody = schemaCodeTemplate(schemaName);
 
-  // Create schema func code file
-  const schemaCodeFilePath = project.schemaFuncCodePath(schemaName);
-  await ensureFileDoesNotExist(schemaCodeFilePath, logger);
-  await createFileWithLogging(
-    schemaCodeFilePath,
-    schemaCodeTemplate(schemaName),
-    logger,
+  return await materialize.materializeSchema(
+    project,
+    schemaName,
+    metadataBody,
+    codeBody,
   );
-
-  return {
-    metadataPath: metadataFilePath,
-    codePath: schemaCodeFilePath,
-  };
 }
 
 /**
@@ -257,7 +179,6 @@ export async function generateSchema(
  * @throws {FileExistsError} If either file already exists
  */
 export async function generateSchemaAction(
-  ctx: Context,
   project: Project,
   schemaName: string,
   actionName: string,
@@ -265,34 +186,17 @@ export async function generateSchemaAction(
   metadataPath: AbsoluteFilePath;
   codePath: AbsoluteFilePath;
 }> {
-  const logger = ctx.logger;
+  const metadata = actionMetadata(schemaName, actionName);
+  const metadataBody = JSON.stringify(metadata, null, 2);
+  const codeBody = actionCodeTemplate(schemaName, actionName);
 
-  // Create action func metadata file
-  const actionMetadataFilePath = project.actionFuncMetadataPath(
+  return await materialize.materializeSchemaAction(
+    project,
     schemaName,
     actionName,
+    metadataBody,
+    codeBody,
   );
-  await ensureFileDoesNotExist(actionMetadataFilePath, logger);
-  const metadata = actionMetadata(schemaName, actionName);
-  await createFileWithLogging(
-    actionMetadataFilePath,
-    JSON.stringify(metadata, null, 2),
-    logger,
-  );
-
-  // Create action func code file
-  const actionCodeFilePath = project.actionFuncCodePath(schemaName, actionName);
-  await ensureFileDoesNotExist(actionCodeFilePath, logger);
-  await createFileWithLogging(
-    actionCodeFilePath,
-    actionCodeTemplate(schemaName, actionName),
-    logger,
-  );
-
-  return {
-    metadataPath: actionMetadataFilePath,
-    codePath: actionCodeFilePath,
-  };
 }
 
 /**
@@ -310,7 +214,6 @@ export async function generateSchemaAction(
  * @throws {FileExistsError} If either file already exists
  */
 export async function generateSchemaCodegen(
-  ctx: Context,
   project: Project,
   schemaName: string,
   codegenName: string,
@@ -318,37 +221,17 @@ export async function generateSchemaCodegen(
   metadataPath: AbsoluteFilePath;
   codePath: AbsoluteFilePath;
 }> {
-  const logger = ctx.logger;
-
-  // Create codegen func metadata file
-  const codegenMetadataFilePath = project.codegenFuncMetadataPath(
-    schemaName,
-    codegenName,
-  );
-  await ensureFileDoesNotExist(codegenMetadataFilePath, logger);
   const metadata = codegenMetadata(schemaName, codegenName);
-  await createFileWithLogging(
-    codegenMetadataFilePath,
-    JSON.stringify(metadata, null, 2),
-    logger,
-  );
+  const metadataBody = JSON.stringify(metadata, null, 2);
+  const codeBody = codegenCodeTemplate(schemaName, codegenName);
 
-  // Create codegen func code file
-  const codegenCodeFilePath = project.codegenFuncCodePath(
+  return await materialize.materializeSchemaCodegen(
+    project,
     schemaName,
     codegenName,
+    metadataBody,
+    codeBody,
   );
-  await ensureFileDoesNotExist(codegenCodeFilePath, logger);
-  await createFileWithLogging(
-    codegenCodeFilePath,
-    codegenCodeTemplate(schemaName, codegenName),
-    logger,
-  );
-
-  return {
-    metadataPath: codegenMetadataFilePath,
-    codePath: codegenCodeFilePath,
-  };
 }
 
 /**
@@ -366,7 +249,6 @@ export async function generateSchemaCodegen(
  * @throws {FileExistsError} If either file already exists
  */
 export async function generateSchemaManagement(
-  ctx: Context,
   project: Project,
   schemaName: string,
   managementName: string,
@@ -374,37 +256,17 @@ export async function generateSchemaManagement(
   metadataPath: AbsoluteFilePath;
   codePath: AbsoluteFilePath;
 }> {
-  const logger = ctx.logger;
-
-  // Create management func metadata file
-  const managementMetadataFilePath = project.managementFuncMetadataPath(
-    schemaName,
-    managementName,
-  );
-  await ensureFileDoesNotExist(managementMetadataFilePath, logger);
   const metadata = managementMetadata(schemaName, managementName);
-  await createFileWithLogging(
-    managementMetadataFilePath,
-    JSON.stringify(metadata, null, 2),
-    logger,
-  );
+  const metadataBody = JSON.stringify(metadata, null, 2);
+  const codeBody = managementCodeTemplate(schemaName, managementName);
 
-  // Create management func code file
-  const managementCodeFilePath = project.managementFuncCodePath(
+  return await materialize.materializeSchemaManagement(
+    project,
     schemaName,
     managementName,
+    metadataBody,
+    codeBody,
   );
-  await ensureFileDoesNotExist(managementCodeFilePath, logger);
-  await createFileWithLogging(
-    managementCodeFilePath,
-    managementCodeTemplate(schemaName, managementName),
-    logger,
-  );
-
-  return {
-    metadataPath: managementMetadataFilePath,
-    codePath: managementCodeFilePath,
-  };
 }
 
 /**
@@ -422,7 +284,6 @@ export async function generateSchemaManagement(
  * @throws {FileExistsError} If either file already exists
  */
 export async function generateSchemaQualification(
-  ctx: Context,
   project: Project,
   schemaName: string,
   qualificationName: string,
@@ -430,37 +291,17 @@ export async function generateSchemaQualification(
   metadataPath: AbsoluteFilePath;
   codePath: AbsoluteFilePath;
 }> {
-  const logger = ctx.logger;
-
-  // Create qualification func metadata file
-  const qualificationMetadataFilePath = project.qualificationFuncMetadataPath(
-    schemaName,
-    qualificationName,
-  );
-  await ensureFileDoesNotExist(qualificationMetadataFilePath, logger);
   const metadata = createQualificationMetadata(schemaName, qualificationName);
-  await createFileWithLogging(
-    qualificationMetadataFilePath,
-    JSON.stringify(metadata, null, 2),
-    logger,
-  );
+  const metadataBody = JSON.stringify(metadata, null, 2);
+  const codeBody = qualificationCodeTemplate(schemaName, qualificationName);
 
-  // Create qualification func code file
-  const qualificationCodeFilePath = project.qualificationFuncCodePath(
+  return await materialize.materializeSchemaQualification(
+    project,
     schemaName,
     qualificationName,
+    metadataBody,
+    codeBody,
   );
-  await ensureFileDoesNotExist(qualificationCodeFilePath, logger);
-  await createFileWithLogging(
-    qualificationCodeFilePath,
-    qualificationCodeTemplate(schemaName, qualificationName),
-    logger,
-  );
-
-  return {
-    metadataPath: qualificationMetadataFilePath,
-    codePath: qualificationCodeFilePath,
-  };
 }
 
 export interface SchemaMetadata {
@@ -469,18 +310,18 @@ export interface SchemaMetadata {
   /** The category this schema belongs to */
   category: string;
   /** Optional description of the schema */
-  description: string;
+  description?: string | null;
   /** Optional documentation link for the schema */
-  documentation: string;
+  documentation?: string | null;
 }
 
-interface FunctionMetadata {
+export interface FunctionMetadata {
   /** The name of the function */
   name: string;
   /** The display name of the function */
-  displayName: string;
+  displayName?: string | null;
   /** Optional description of the function */
-  description: string;
+  description?: string | null;
 }
 
 function schemaMetadata(schemaName: string): SchemaMetadata {
@@ -605,54 +446,4 @@ function qualificationCodeTemplate(
     message: "${schemaName} ${qualificationName} qualification is not implemented"
   }
 }`;
-}
-
-/**
- * Ensures that a file does not exist at the given path.
- * Throws FileExistsError if the file already exists.
- */
-async function ensureFileDoesNotExist(
-  filePath: AbsoluteFilePath,
-  logger: Logger,
-): Promise<void> {
-  if (await filePath.exists()) {
-    logger.error("File already exists at {filePath}", {
-      filePath: filePath.toString(),
-    });
-    throw new FileExistsError(filePath.toString());
-  }
-}
-
-/**
- * Creates a file with the given content and logs the creation.
- */
-async function createFileWithLogging(
-  filePath: AbsoluteFilePath,
-  content: string,
-  logger: Logger,
-) {
-  await filePath.writeTextFile(content);
-  logger.info("Created: {filePath}", {
-    filePath: filePath.toString(),
-  });
-}
-
-/**
- * Error thrown when attempting to create a file that already exists.
- */
-export class FileExistsError extends Error {
-  constructor(public readonly path: string) {
-    super(`File already exists at: ${path}`);
-    this.name = "FileExistsError";
-  }
-}
-
-/**
- * Error thrown when attempting to create a schema in a directory that already exists.
- */
-export class DirectoryExistsError extends Error {
-  constructor(public readonly path: string) {
-    super(`Directory already exists at: ${path}`);
-    this.name = "DirectoryExistsError";
-  }
 }

--- a/bin/si-conduit/src/jwt.ts
+++ b/bin/si-conduit/src/jwt.ts
@@ -82,15 +82,16 @@ interface JWTPayload {
  * ```
  */
 export function getUserDataFromToken(apiToken?: string): UserData | undefined {
-  if (!apiToken) {
+  if (apiToken) {
+    return tryGetUserDataFromToken(apiToken);
+  } else {
     return undefined;
   }
+}
 
+export function tryGetUserDataFromToken(apiToken: string): UserData {
   // Trim whitespace that might have been accidentally included
   const trimmedToken = apiToken.trim();
-  if (trimmedToken.length === 0) {
-    return undefined;
-  }
 
   const payload = decodeJWT(trimmedToken);
 

--- a/bin/si-conduit/src/logger.ts
+++ b/bin/si-conduit/src/logger.ts
@@ -11,6 +11,8 @@
 import {
   configure,
   getConsoleSink,
+  getLogger as logtapeGetLogger,
+  Logger,
   type LogLevel,
   type LogRecord,
 } from "@logtape/logtape";
@@ -90,7 +92,7 @@ function verbosityToLogLevel(verbosity: VerbosityLevel): LogLevel {
  *
  * @internal
  */
-function isInteractive(): boolean {
+export function isInteractive(): boolean {
   return Deno.stdout.isTerminal();
 }
 
@@ -138,7 +140,9 @@ function createNonInteractiveFormatter(record: LogRecord): string {
   // LogRecord.timestamp is a number (milliseconds since epoch)
   const timestamp = new Date(record.timestamp).toISOString();
   return `[${timestamp}] ${String(record.level).toUpperCase()}: ${
-    record.message.join(" ")
+    record.message.join(
+      " ",
+    )
   }`;
 }
 
@@ -214,7 +218,6 @@ export async function configureLogger(
   });
 }
 
-/**
- * Re-export getLogger from LogTape for convenience
- */
-export { getLogger } from "@logtape/logtape";
+export function getLogger(category?: string | readonly string[]): Logger {
+  return logtapeGetLogger([APP_LOGGER_CATEGORY, ...(category ?? [])]);
+}

--- a/bin/si-conduit/src/materialize.ts
+++ b/bin/si-conduit/src/materialize.ts
@@ -1,0 +1,599 @@
+/**
+ * Materialize Module - File System Operations for Schema Materialization
+ *
+ * This module provides functions to create and write schema files, metadata,
+ * and function code to the file system. It is primarily used when pulling
+ * schemas from remote workspaces or generating new schema structures locally.
+ *
+ * ## Key Responsibilities
+ *
+ * - Creating directory structures for schemas and their functions
+ * - Writing schema metadata and code files to disk
+ * - Writing function (action, codegen, management, qualification) files
+ * - Ensuring files don't already exist before creation
+ * - Logging file creation operations
+ *
+ * ## Usage Pattern
+ *
+ * Functions in this module follow a consistent pattern:
+ * 1. Check if directories need to be created
+ * 2. Ensure target files don't already exist (throws FileExistsError if they
+ *    do)
+ * 3. Write files to disk
+ * 4. Log the creation operations
+ *
+ * @module
+ */
+
+import { getLogger } from "./logger.ts";
+import { Project } from "./project.ts";
+import type { AbsoluteFilePath } from "./project.ts";
+
+const logger = getLogger();
+
+/**
+ * Creates the base directory for a schema if it doesn't already exist.
+ *
+ * This is typically the first operation when materializing a schema, creating
+ * the `schemas/<schema-name>/` directory.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema to create a directory for
+ *
+ * @example
+ * ```ts
+ * await materializeSchemaBase(project, "MyAwsResource");
+ * // Creates: schemas/MyAwsResource/
+ * ```
+ */
+export async function materializeSchemaBase(
+  project: Project,
+  schemaName: string,
+) {
+  const schemaBasePath = project.schemaBasePath(schemaName);
+
+  // Create schema base directory
+  if (!(await schemaBasePath.exists())) {
+    await schemaBasePath.mkdir({ recursive: true });
+    logger.info("  - Created schema directory: {schemaBasePath}", {
+      schemaBasePath: schemaBasePath.relativeToStr(project),
+    });
+  }
+}
+
+/**
+ * Creates the actions directory for a schema if it doesn't already exist.
+ *
+ * This creates the `schemas/<schema-name>/actions/` directory where action
+ * function files (create, destroy, refresh, update) will be stored.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ *
+ * @example
+ * ```ts
+ * await materializeSchemaActionBase(project, "MyAwsResource");
+ * // Creates: schemas/MyAwsResource/actions/
+ * ```
+ */
+export async function materializeSchemaActionBase(
+  project: Project,
+  schemaName: string,
+) {
+  const actionBasePath = project.actionBasePath(schemaName);
+
+  // Create the action base directory
+  if (!(await actionBasePath.exists())) {
+    await actionBasePath.mkdir({ recursive: true });
+    logger.info("  - Created actions directory: {actionBasePath}", {
+      actionBasePath: actionBasePath.relativeToStr(project),
+    });
+  }
+}
+
+/**
+ * Creates the code generators directory for a schema if it doesn't already
+ * exist.
+ *
+ * This creates the `schemas/<schema-name>/codeGenerators/` directory where
+ * code generation function files will be stored.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ *
+ * @example
+ * ```ts
+ * await materializeSchemaCodegenBase(project, "MyAwsResource");
+ * // Creates: schemas/MyAwsResource/codeGenerators/
+ * ```
+ */
+export async function materializeSchemaCodegenBase(
+  project: Project,
+  schemaName: string,
+) {
+  const codegenBasePath = project.codegenBasePath(schemaName);
+
+  // Create the codegen base directory
+  if (!(await codegenBasePath.exists())) {
+    await codegenBasePath.mkdir({ recursive: true });
+    logger.info("  - Created code generators directory: {codegenBasePath}", {
+      codegenBasePath: codegenBasePath.relativeToStr(project),
+    });
+  }
+}
+
+/**
+ * Creates the management directory for a schema if it doesn't already exist.
+ *
+ * This creates the `schemas/<schema-name>/management/` directory where
+ * management function files will be stored.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ *
+ * @example
+ * ```ts
+ * await materializeSchemaManagementBase(project, "MyAwsResource");
+ * // Creates: schemas/MyAwsResource/management/
+ * ```
+ */
+export async function materializeSchemaManagementBase(
+  project: Project,
+  schemaName: string,
+) {
+  const managementBasePath = project.managementBasePath(schemaName);
+
+  // Create the management base directory
+  if (!(await managementBasePath.exists())) {
+    await managementBasePath.mkdir({ recursive: true });
+    logger.info("  - Created management directory: {managementBasePath}", {
+      managementBasePath: managementBasePath.relativeToStr(project),
+    });
+  }
+}
+
+/**
+ * Creates the qualifications directory for a schema if it doesn't already
+ * exist.
+ *
+ * This creates the `schemas/<schema-name>/qualifications/` directory where
+ * qualification function files will be stored.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ *
+ * @example
+ * ```ts
+ * await materializeSchemaQualificationBase(project, "MyAwsResource");
+ * // Creates: schemas/MyAwsResource/qualifications/
+ * ```
+ */
+export async function materializeSchemaQualificationBase(
+  project: Project,
+  schemaName: string,
+) {
+  const qualificationBasePath = project.qualificationBasePath(schemaName);
+
+  // Create the qualification base directory
+  if (!(await qualificationBasePath.exists())) {
+    await qualificationBasePath.mkdir({ recursive: true });
+    logger.info(
+      "  - Created qualifications directory: {qualificationBasePath}",
+      {
+        qualificationBasePath: qualificationBasePath.relativeToStr(project),
+      },
+    );
+  }
+}
+
+/**
+ * Materializes the format version file for a schema.
+ *
+ * Creates the `.format-version` file that indicates the schema file format
+ * version. This file is used to ensure compatibility when reading and writing
+ * schema files.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ * @param formatVersionBody - The format version content (typically a version
+ * number)
+ * @returns An object containing the path to the created format version file
+ * @throws {FileExistsError} If the format version file already exists
+ *
+ * @example
+ * ```ts
+ * const result = await materializeSchemaFormatVersion(
+ *   project,
+ *   "MyAwsResource",
+ *   "1",
+ * );
+ * // Creates: schemas/MyAwsResource/.format-version
+ * console.log(result.formatVersionPath);
+ * ```
+ */
+export async function materializeSchemaFormatVersion(
+  project: Project,
+  schemaName: string,
+  formatVersionBody: string,
+): Promise<{ formatVersionPath: AbsoluteFilePath }> {
+  // Create the format version file
+  const formatVersionFilePath = project.schemaFormatVersionPath(schemaName);
+  await ensureFileDoesNotExist(formatVersionFilePath);
+  await createFileWithLogging(
+    project,
+    formatVersionFilePath,
+    formatVersionBody,
+  );
+
+  return {
+    formatVersionPath: formatVersionFilePath,
+  };
+}
+
+/**
+ * Materializes the main schema files (metadata and code).
+ *
+ * Creates both the schema metadata JSON file and the schema TypeScript code
+ * file. These files define the schema's properties, structure, and asset
+ * function.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ * @param metadataBody - The JSON metadata content for the schema
+ * @param codeBody - The TypeScript code for the schema's asset function
+ * @returns An object containing paths to the created metadata and code files
+ * @throws {FileExistsError} If either file already exists
+ *
+ * @example
+ * ```ts
+ * const metadata = JSON.stringify({
+ *   name: "MyAwsResource",
+ *   category: "AWS",
+ *   description: "An AWS resource"
+ * });
+ * const code = "export default function() { ... }";
+ *
+ * const result = await materializeSchema(
+ *   project,
+ *   "MyAwsResource",
+ *   metadata,
+ *   code,
+ * );
+ * // Creates:
+ * //   schemas/MyAwsResource/schema.metadata.json
+ * //   schemas/MyAwsResource/schema.ts
+ * ```
+ */
+export async function materializeSchema(
+  project: Project,
+  schemaName: string,
+  metadataBody: string,
+  codeBody: string,
+): Promise<{ metadataPath: AbsoluteFilePath; codePath: AbsoluteFilePath }> {
+  // Create schema metadata file
+  const metadataFilePath = project.schemaMetadataPath(schemaName);
+  await ensureFileDoesNotExist(metadataFilePath);
+  await createFileWithLogging(project, metadataFilePath, metadataBody);
+
+  // Create schema func code file
+  const schemaCodeFilePath = project.schemaFuncCodePath(schemaName);
+  await ensureFileDoesNotExist(schemaCodeFilePath);
+  await createFileWithLogging(project, schemaCodeFilePath, codeBody);
+
+  return {
+    metadataPath: metadataFilePath,
+    codePath: schemaCodeFilePath,
+  };
+}
+
+/**
+ * Materializes an action function for a schema.
+ *
+ * Creates both the action metadata JSON file and the action TypeScript code
+ * file. Actions are functions that perform operations on resources (e.g.,
+ * create, destroy, refresh, update).
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ * @param actionName - The name of the action (e.g., "create", "destroy")
+ * @param metadataBody - The JSON metadata content for the action
+ * @param codeBody - The TypeScript code for the action function
+ * @returns An object containing paths to the created metadata and code files
+ * @throws {FileExistsError} If either file already exists
+ *
+ * @example
+ * ```ts
+ * const metadata = JSON.stringify({
+ *   name: "create",
+ *   displayName: "Create Resource"
+ * });
+ * const code = "export default async function() { ... }";
+ *
+ * const result = await materializeSchemaAction(
+ *   project,
+ *   "MyAwsResource",
+ *   "create",
+ *   metadata,
+ *   code
+ * );
+ * // Creates:
+ * //   schemas/MyAwsResource/actions/create.metadata.json
+ * //   schemas/MyAwsResource/actions/create.ts
+ * ```
+ */
+export async function materializeSchemaAction(
+  project: Project,
+  schemaName: string,
+  actionName: string,
+  metadataBody: string,
+  codeBody: string,
+): Promise<{
+  metadataPath: AbsoluteFilePath;
+  codePath: AbsoluteFilePath;
+}> {
+  // Create action func metadata file
+  const actionMetadataFilePath = project.actionFuncMetadataPath(
+    schemaName,
+    actionName,
+  );
+  await ensureFileDoesNotExist(actionMetadataFilePath);
+  await createFileWithLogging(project, actionMetadataFilePath, metadataBody);
+
+  // Create action func code file
+  const actionCodeFilePath = project.actionFuncCodePath(schemaName, actionName);
+  await ensureFileDoesNotExist(actionCodeFilePath);
+  await createFileWithLogging(project, actionCodeFilePath, codeBody);
+
+  return {
+    metadataPath: actionMetadataFilePath,
+    codePath: actionCodeFilePath,
+  };
+}
+
+/**
+ * Materializes a code generation function for a schema.
+ *
+ * Creates both the codegen metadata JSON file and the codegen TypeScript code
+ * file. Code generators produce configuration files or infrastructure code
+ * from schema component data.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ * @param codegenName - The name of the code generator
+ * @param metadataBody - The JSON metadata content for the code generator
+ * @param codeBody - The TypeScript code for the code generator function
+ * @returns An object containing paths to the created metadata and code files
+ * @throws {FileExistsError} If either file already exists
+ *
+ * @example
+ * ```ts
+ * const metadata = JSON.stringify({
+ *   name: "terraform",
+ *   displayName: "Terraform HCL Generator"
+ * });
+ * const code = "export default function() { return 'resource ...'; }";
+ *
+ * const result = await materializeSchemaCodegen(
+ *   project,
+ *   "MyAwsResource",
+ *   "terraform",
+ *   metadata,
+ *   code
+ * );
+ * // Creates:
+ * //   schemas/MyAwsResource/codeGenerators/terraform.metadata.json
+ * //   schemas/MyAwsResource/codeGenerators/terraform.ts
+ * ```
+ */
+export async function materializeSchemaCodegen(
+  project: Project,
+  schemaName: string,
+  codegenName: string,
+  metadataBody: string,
+  codeBody: string,
+): Promise<{
+  metadataPath: AbsoluteFilePath;
+  codePath: AbsoluteFilePath;
+}> {
+  // Create codegen func metadata file
+  const codegenMetadataFilePath = project.codegenFuncMetadataPath(
+    schemaName,
+    codegenName,
+  );
+  await ensureFileDoesNotExist(codegenMetadataFilePath);
+  await createFileWithLogging(project, codegenMetadataFilePath, metadataBody);
+
+  // Create codegen func code file
+  const codegenCodeFilePath = project.codegenFuncCodePath(
+    schemaName,
+    codegenName,
+  );
+  await ensureFileDoesNotExist(codegenCodeFilePath);
+  await createFileWithLogging(project, codegenCodeFilePath, codeBody);
+
+  return {
+    metadataPath: codegenMetadataFilePath,
+    codePath: codegenCodeFilePath,
+  };
+}
+
+/**
+ * Materializes a management function for a schema.
+ *
+ * Creates both the management metadata JSON file and the management TypeScript
+ * code file. Management functions handle reconciliation and lifecycle
+ * operations for resources.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ * @param managementName - The name of the management function
+ * @param metadataBody - The JSON metadata content for the management function
+ * @param codeBody - The TypeScript code for the management function
+ * @returns An object containing paths to the created metadata and code files
+ * @throws {FileExistsError} If either file already exists
+ *
+ * @example
+ * ```ts
+ * const metadata = JSON.stringify({
+ *   name: "reconcile",
+ *   displayName: "Reconcile Resource"
+ * });
+ * const code = "export default async function() { ... }";
+ *
+ * const result = await materializeSchemaManagement(
+ *   project,
+ *   "MyAwsResource",
+ *   "reconcile",
+ *   metadata,
+ *   code
+ * );
+ * // Creates:
+ * //   schemas/MyAwsResource/management/reconcile.metadata.json
+ * //   schemas/MyAwsResource/management/reconcile.ts
+ * ```
+ */
+export async function materializeSchemaManagement(
+  project: Project,
+  schemaName: string,
+  managementName: string,
+  metadataBody: string,
+  codeBody: string,
+): Promise<{
+  metadataPath: AbsoluteFilePath;
+  codePath: AbsoluteFilePath;
+}> {
+  // Create management func metadata file
+  const managementMetadataFilePath = project.managementFuncMetadataPath(
+    schemaName,
+    managementName,
+  );
+  await ensureFileDoesNotExist(managementMetadataFilePath);
+  await createFileWithLogging(
+    project,
+    managementMetadataFilePath,
+    metadataBody,
+  );
+
+  // Create management func code file
+  const managementCodeFilePath = project.managementFuncCodePath(
+    schemaName,
+    managementName,
+  );
+  await ensureFileDoesNotExist(managementCodeFilePath);
+  await createFileWithLogging(project, managementCodeFilePath, codeBody);
+
+  return {
+    metadataPath: managementMetadataFilePath,
+    codePath: managementCodeFilePath,
+  };
+}
+
+/**
+ * Materializes a qualification function for a schema.
+ *
+ * Creates both the qualification metadata JSON file and the qualification
+ * TypeScript code file. Qualifications validate component state and properties
+ * to ensure they meet required criteria.
+ *
+ * @param project - The project instance containing path configuration
+ * @param schemaName - The name of the schema
+ * @param qualificationName - The name of the qualification function
+ * @param metadataBody - The JSON metadata content for the qualification
+ * @param codeBody - The TypeScript code for the qualification function
+ * @returns An object containing paths to the created metadata and code files
+ * @throws {FileExistsError} If either file already exists
+ *
+ * @example
+ * ```ts
+ * const metadata = JSON.stringify({
+ *   name: "validate",
+ *   displayName: "Validate Configuration"
+ * });
+ * const code = "export default function() { return { status: 'ok' }; }";
+ *
+ * const result = await materializeSchemaQualification(
+ *   project,
+ *   "MyAwsResource",
+ *   "validate",
+ *   metadata,
+ *   code
+ * );
+ * // Creates:
+ * //   schemas/MyAwsResource/qualifications/validate.metadata.json
+ * //   schemas/MyAwsResource/qualifications/validate.ts
+ * ```
+ */
+export async function materializeSchemaQualification(
+  project: Project,
+  schemaName: string,
+  qualificationName: string,
+  metadataBody: string,
+  codeBody: string,
+): Promise<{
+  metadataPath: AbsoluteFilePath;
+  codePath: AbsoluteFilePath;
+}> {
+  // Create qualification func metadata file
+  const qualificationMetadataFilePath = project.qualificationFuncMetadataPath(
+    schemaName,
+    qualificationName,
+  );
+  await ensureFileDoesNotExist(qualificationMetadataFilePath);
+  await createFileWithLogging(
+    project,
+    qualificationMetadataFilePath,
+    metadataBody,
+  );
+
+  // Create qualification func code file
+  const qualificationCodeFilePath = project.qualificationFuncCodePath(
+    schemaName,
+    qualificationName,
+  );
+  await ensureFileDoesNotExist(qualificationCodeFilePath);
+  await createFileWithLogging(project, qualificationCodeFilePath, codeBody);
+
+  return {
+    metadataPath: qualificationMetadataFilePath,
+    codePath: qualificationCodeFilePath,
+  };
+}
+
+/**
+ * Ensures that a file does not exist at the given path.
+ * Throws FileExistsError if the file already exists.
+ */
+export async function ensureFileDoesNotExist(
+  filePath: AbsoluteFilePath,
+): Promise<void> {
+  if (await filePath.exists()) {
+    logger.error("File already exists at {filePath}", {
+      filePath: filePath.toString(),
+    });
+    throw new FileExistsError(filePath.toString());
+  }
+}
+
+/**
+ * Creates a file with the given content and logs the creation.
+ */
+export async function createFileWithLogging(
+  project: Project,
+  filePath: AbsoluteFilePath,
+  content: string,
+) {
+  await filePath.writeTextFile(content);
+  logger.info("  - Created: {filePath}", {
+    filePath: filePath.relativeToStr(project),
+  });
+}
+
+/**
+ * Error thrown when attempting to create a file that already exists.
+ */
+export class FileExistsError extends Error {
+  constructor(public readonly path: string) {
+    super(`File already exists at: ${path}`);
+    this.name = "FileExistsError";
+  }
+}


### PR DESCRIPTION
This change extracts file system write operations from `generators.ts` into a new `materialize.ts` module and implements the remote schema pull command. The generator functions were handling both workflow orchestration and file I/O, which made them harder to test and reuse.

The new `materialize.ts` module provides functions for creating schema directories and writing metadata and code files to disk. Each function checks if files already exist before writing to prevent accidental overwrites, throwing a `FileExistsError` if a file is already present. The functions handle actions, code generators, management functions, and qualifications with a consistent pattern: check for existing files, create directories as needed, write content, and log what was created using project-relative paths.

The `remote schema pull` command in `src/command/remote/schema/pull.ts` uses the System Initiative API client to fetch schemas from a remote workspace and materialize them to the local file system. The command accepts schema names as arguments, retrieves the schema and default variant data from the API, fetches all attached function code and metadata, and writes everything to disk using the new materialization functions. A `SchemaVariantFuncs` helper class filters functions by kind since the API represents function kinds in a way that needs interpretation.

Generator functions in `src/command/schema/` have been refactored to use the materialization module rather than handling file writes directly. This removes duplication where each generator was implementing the same "create directory, check file exists, write, log" pattern. The generators now focus on preparing content and delegate file operations to the materialize module.

The `Project` class gained helper methods for constructing function metadata and code file paths, providing a single place where path construction logic lives. The `relativeToStr` method returns project-relative path strings for cleaner log output.

The CLI integration adds the `remote schema pull` command structure and ensures users are authenticated with a workspace selected before attempting to pull. Analytics tracking captures which schemas were pulled and which weren't found remotely.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZ2ZweHAzM240a3hqYXVrMTllazVmeWt3azNhMGVra2llMWp0YWxvMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IXhoLbioqMZAmoM5AF/giphy.gif"/>