### PR TITLE
fix(dal): Send final ws event and update func run state on failure

### DIFF
--- a/lib/dal/src/job/definition/management_func.rs
+++ b/lib/dal/src/job/definition/management_func.rs
@@ -255,6 +255,7 @@ impl ManagementFuncJob {
             geometries,
             placeholders,
             run_channel,
+            func_run_id,
         )
         .await?;
 


### PR DESCRIPTION
This change does a few things:
- On failure, ensure we send the WSEvent that the function was executed, so clients know (namely the front end, which was otherwise stuck thinking the function was still running)
- On failure, update the state of the func run, mimicking actions (and continuing to reuse the action status as we do in the successful case)
- Don’t swallow all errors and trace accordingly in honeycomb

## In short: [:link:](https://giphy.com/)

![](put .gif link here - click the :link: besides the gif on giphy to copy it)
<div><img src="https://media2.giphy.com/media/WnUfmomqsqmxpU4cJv/200.gif?cid=5a38a5a2z8z51lp5m3jw6p0ntx4npmxz6mmnvpjjg8802dun&amp;ep=v1_gifs_search&amp;rid=200.gif&amp;ct=g" style="border:0;height:168px;width:300px"/><br/>via <a href="https://giphy.com/gifs/moodman-WnUfmomqsqmxpU4cJv">GIPHY</a></div>