### PR TITLE
fix(clover): permissive path casing

### DIFF
--- a/bin/clover/src/pipelines/azure/spec.ts
+++ b/bin/clover/src/pipelines/azure/spec.ts
@@ -673,7 +673,7 @@ function parseEndpointPath(path: string) {
   // Or list form: /subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways
   // TODO support non-{resourceGroupName} get/put/delete and {resourceGroupName} list paths
   const match = path.match(
-    /\/subscriptions\/\{([^/}]+)\}(?:\/resourceGroups\/\{([^/}]+)\})?\/providers\/([^/]+)\/([^/{]+)(?:\/\{([^/}]+)\})?$/,
+    /\/subscriptions\/\{([^/}]+)\}(?:\/resource[Gg]roups\/\{([^/}]+)\})?\/providers\/([^/]+)\/([^/{]+)(?:\/\{([^/}]+)\})?$/,
   );
   if (!match) return undefined;
   const [


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

we found some azure specs that use `resourcegroup` instead of `resourceGroup` in the path. 


## How was it tested?

Works locally, we now generate the `DeploymentScripts`  asset

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI


## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOTV6M3h3M2U5dHVhM2k0MzBpcDkydmlqNzE0YzV3azg0M21kZWhhaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/RJAjTowsU0K1a/giphy.gif"/>