### PR TITLE
Allow AVs to subscribe to other values on the same component

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -1577,8 +1577,6 @@ const filteredConnections = computed(() => {
         matches = matches.filter((m) => !m.path.startsWith("/secrets/"));
       }
 
-      matches = matches.filter((m) => m.componentId !== props.component.id);
-
       const fuzzyMatches: PossibleConnection[] = [];
 
       if (filterStr.value) {


### PR DESCRIPTION
## How does this PR change the system?

Azure assets have AVs that need the values from other places on its own AV tree

#### Screenshots:
<img width="680" height="154" alt="image" src="https://github.com/user-attachments/assets/48ad0af9-3f50-45a2-a71e-e070d01b5d53" />
<img width="738" height="215" alt="image" src="https://github.com/user-attachments/assets/972b2376-58ed-4010-b63e-fc3620ef79f1" />

## How was it tested?

1. Subscribed to name from a tag value
2. Change the name
3. Watch the tag value update