### PR TITLE
Fix: this was set up incorrectly, getting exceptions

### DIFF
--- a/app/web/src/newhotness/ResourceValuesPanel.vue
+++ b/app/web/src/newhotness/ResourceValuesPanel.vue
@@ -75,6 +75,7 @@ import { keyEmitter } from "./logic_composables/emitters";
 import { AttrTree, makeAvTree } from "./logic_composables/attribute_tree";
 import EmptyState from "./EmptyState.vue";
 import { AttributeInputContext } from "./types";
+import { AttributeErrors } from "./AttributePanel.vue";
 
 const q = ref("");
 
@@ -84,12 +85,15 @@ const props = defineProps<{
 }>();
 
 provide<AttributeInputContext>("ATTRIBUTEINPUT", { blankInput: false });
-provide(
-  "ATTRIBUTE_ERRORS",
-  computed(() => {
-    return { saveErrors: {} };
-  }),
-);
+
+const saveErrors = ref<Record<string, string>>({});
+
+const errorContext = computed<AttributeErrors>(() => {
+  return {
+    saveErrors,
+  };
+});
+provide("ATTRIBUTE_ERRORS", errorContext);
 
 // TODO(nick): move the root computation to a shared location since this is a copy from "AttributePanel".
 const root = computed<AttrTree>(() => {

--- a/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
+++ b/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
@@ -329,6 +329,7 @@ import {
   AttributeInputContext,
   ExploreContext,
 } from "../types";
+import { AttributeErrors } from "../AttributePanel.vue";
 
 const ctx = useContext();
 const exploreContext = inject<ExploreContext>("EXPLORE_CONTEXT");
@@ -424,12 +425,15 @@ const showHistory = reactive<Record<AttributePath, boolean>>(
 );
 
 provide<AttributeInputContext>("ATTRIBUTEINPUT", { blankInput: true });
-provide(
-  "ATTRIBUTE_ERRORS",
-  computed(() => {
-    return { saveErrors: ref({}) };
-  }),
-);
+
+const saveErrors = ref<Record<string, string>>({});
+
+const errorContext = computed<AttributeErrors>(() => {
+  return {
+    saveErrors,
+  };
+});
+provide("ATTRIBUTE_ERRORS", errorContext);
 
 const setHistory = (path: AttributePath) => {
   showHistory[path] = true;


### PR DESCRIPTION
## How does this PR change the system?

When I loaded up Azure Assets that have a resource I saw these errors fly by. They were coming in from the `ResourcesValuePanel`. 

These errors were the source of the slow down.

```
can't access property "01K870D3TQQ3B9DPVKBSSJGA1D-/resource_value/etag", ze.value.saveErrors.value is undefined
```

## How was it tested?

1. I brought down to local the change set from Clover Asset Testing
2. In prod the exceptions get swallowed, but [are reported in honeycomb](https://ui.honeycomb.io/system-initiative/environments/production/datasets/si-vue/result/dMEkiwPnzoj)
3. Can see them locally, and the slow down locally.
4. Fix implemented, no more error and its fast