### PR TITLE
feat: add create overlay action and management funcs on builtins

### DIFF
--- a/bin/si-mcp-server/deno.json
+++ b/bin/si-mcp-server/deno.json
@@ -12,7 +12,7 @@
     "@onjara/optic": "jsr:@onjara/optic@^2.0.3",
     "@std/assert": "jsr:@std/assert@1",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.4.0",
+    "@systeminit/api-client": "jsr:@systeminit/api-client@^1.6.1",
     "axios": "npm:axios@^1.6.1",
     "jwt-decode": "npm:jwt-decode@^4.0.0",
     "lodash": "npm:lodash@^4.17.21",

--- a/bin/si-mcp-server/deno.lock
+++ b/bin/si-mcp-server/deno.lock
@@ -12,7 +12,7 @@
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/text@~1.0.7": "1.0.16",
-    "jsr:@systeminit/api-client@^1.4.0": "1.4.0",
+    "jsr:@systeminit/api-client@^1.6.1": "1.6.1",
     "npm:@modelcontextprotocol/sdk@^1.16.0": "1.18.1_express@5.1.0_zod@3.25.76",
     "npm:axios@*": "1.12.2",
     "npm:axios@^1.12.0": "1.12.2",
@@ -76,8 +76,8 @@
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
     },
-    "@systeminit/api-client@1.4.0": {
-      "integrity": "b409d4d0f063cc78096cde37617a19f1f5a5ae174d50f05349e6f30f1ba903d5",
+    "@systeminit/api-client@1.6.1": {
+      "integrity": "3a095195f7f363973a50dd4d2ff5aa30fe117effe78b0deae05030fbc20af158",
       "dependencies": [
         "npm:axios@^1.6.1"
       ]
@@ -673,7 +673,7 @@
       "jsr:@onjara/optic@^2.0.3",
       "jsr:@std/assert@1",
       "jsr:@std/encoding@^1.0.10",
-      "jsr:@systeminit/api-client@^1.4.0",
+      "jsr:@systeminit/api-client@^1.6.1",
       "npm:@modelcontextprotocol/sdk@^1.16.0",
       "npm:axios@^1.6.1",
       "npm:jwt-decode@4",


### PR DESCRIPTION
## How does this PR change the system?

Gives our MCP server the ability to create overlay functions for action and management types on builtin schemas.

#### Screenshots:

<img width="1706" height="808" alt="Screenshot 2025-10-24 at 16 35 56" src="https://github.com/user-attachments/assets/7e7d97bd-7724-4309-a77d-0a3129e20f80" />

#### Out of Scope:

Agreed out of scope was the returning the contents of a function when requested via MCP that is listed in the Linear - https://linear.app/system-initiative/issue/ENG-3267/allow-users-to-author-action-mgmt-overlays-using-the-ai-agent

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: new functionality works via claude - create new overlay management func, create new overlay action func, cannot add an extra overlay func for either action or management funcs
- [X] Manual test: (regression check) authoring still works as expected following the previously implemented path.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdldWNybGZkY2J4cGJpM3poZzRmMGl5N3ZlYW5ha2swcW9nNzU0Z2RraCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eOkRika6x2zXkmumso/giphy.gif"/>
