### PR TITLE
Re-fire the component debug api call when component details change

### DIFF
--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash-es";
 import { Ref, unref } from "vue";
 import {
   IconNames,
@@ -119,3 +120,48 @@ export const openWorkspaceMigrationDocumentation = () => {
     "_blank",
   );
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+export interface MemoizeDebouncedFn<F extends AnyFn>
+  extends _.DebouncedFunc<F> {
+  (...args: Parameters<F>): ReturnType<F> | undefined;
+  flush: (...args: Parameters<F>) => ReturnType<F> | undefined;
+  cancel: (...args: Parameters<F>) => void;
+}
+/**
+ * Debounce based on args to the fn
+ */
+export function memoizeDebounce<F extends AnyFn>(
+  func: F,
+  wait = 0,
+  options: _.DebounceSettings = {},
+  resolver?: (...args: Parameters<F>) => unknown,
+): MemoizeDebouncedFn<F> {
+  const dbMemo = _.memoize<(...args: Parameters<F>) => _.DebouncedFunc<F>>(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (..._args: Parameters<F>) => _.debounce(func, wait, options),
+    resolver,
+  );
+
+  function wrappedFn(
+    this: MemoizeDebouncedFn<F>,
+    ...args: Parameters<F>
+  ): ReturnType<F> | undefined {
+    return dbMemo(...args)(...args);
+  }
+
+  const flush: MemoizeDebouncedFn<F>["flush"] = (...args) => {
+    return dbMemo(...args).flush();
+  };
+
+  const cancel: MemoizeDebouncedFn<F>["cancel"] = (...args) => {
+    return dbMemo(...args).cancel();
+  };
+
+  wrappedFn.flush = flush;
+  wrappedFn.cancel = cancel;
+
+  return wrappedFn;
+}


### PR DESCRIPTION
Note: we're de-bouncing this because we get 2-3 cache busts of the same ID but for different MVs.

## How was it tested?

1. Go to a component
2. Change its name
3. See in the network panel the debug API fired

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNmp4YjdxNzdwc3Z2ZDU4NGt1YWtzd2JlNGFyMmF0bXMwNWl6a3U1ZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1wLCfgoruo3ciRDGhT/giphy.gif"/>