### PR TITLE
fix(buck2): ensure `:check-format-toml` is present for rust_library

### DIFF
--- a/lib/acceptable/Cargo.toml
+++ b/lib/acceptable/Cargo.toml
@@ -8,6 +8,18 @@ edition.workspace = true
 rust-version.workspace = true
 publish.workspace = true
 
+[features]
+default = [
+  "derive",
+  "deserialize",
+  "nats-headers",
+  "serialize",
+] # NOTE: if extracted, then default should probably be empty
+derive = ["acceptable-macros"]
+deserialize = ["ciborium", "serde_json"]
+nats-headers = ["async-nats", "nats-std"]
+serialize = ["ciborium", "serde_json"]
+
 [dependencies]
 acceptable-macros = { path = "../../lib/acceptable-macros", optional = true }
 async-nats = { workspace = true, optional = true }
@@ -18,10 +30,3 @@ serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 ulid = { workspace = true }
-
-[features]
-default = ["derive", "deserialize", "nats-headers", "serialize"] # NOTE: if extracted, then default should probably be empty
-derive = ["acceptable-macros"]
-deserialize = ["ciborium", "serde_json"]
-nats-headers = ["async-nats", "nats-std"]
-serialize = ["ciborium", "serde_json"]

--- a/lib/luminork-server/Cargo.toml
+++ b/lib/luminork-server/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 convert_case = { workspace = true }
 dal = { path = "../../lib/dal" }
-dal-materialized-views = { path = "../../lib/dal-materialized-views"}
+dal-materialized-views = { path = "../../lib/dal-materialized-views" }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 edda-client = { path = "../../lib/edda-client" }

--- a/lib/naxum-extractor-acceptable/Cargo.toml
+++ b/lib/naxum-extractor-acceptable/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 
 [dependencies]
 acceptable = { path = "../../lib/acceptable" }
-async-nats = { workspace = true }                           # NOTE: left with vanilla tracing for potential future extraction
+async-nats = { workspace = true }              # NOTE: left with vanilla tracing for potential future extraction
 nats-std = { path = "../../lib/nats-std" }
 naxum = { path = "../../lib/naxum" }
-tracing = { workspace = true }                              # NOTE: left with vanilla tracing for potential future extraction
+tracing = { workspace = true }                 # NOTE: left with vanilla tracing for potential future extraction

--- a/lib/sdf-server/Cargo.toml
+++ b/lib/sdf-server/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 rust-version.workspace = true
 publish.workspace = true
 
+[features]
+buck2_build = []
+
 [dependencies]
 async-trait = { workspace = true }
 audit-database = { path = "../../lib/audit-database" }
@@ -87,9 +90,6 @@ ulid = { workspace = true }
 url = { workspace = true }
 veritech-client = { path = "../../lib/veritech-client" }
 y-sync = { workspace = true }
-
-[features]
-buck2_build = []
 
 [dev-dependencies]
 dal-test = { path = "../../lib/dal-test" }

--- a/prelude-si/macros/rust.bzl
+++ b/prelude-si/macros/rust.bzl
@@ -230,6 +230,13 @@ def rust_library(
         actual = ":{}".format(name),
     )
 
+    if toml_srcs:
+        _toml_format_check(
+            name = "check-format-toml",
+            srcs = toml_srcs,
+            visibility = visibility,
+        )
+
     if not rule_exists("test-unit"):
         native.rust_test(
             name = "test-unit",


### PR DESCRIPTION
This change fixes a mistake when the `:check-format-toml` and `:fix-format-toml` Buck2 rules were introduced in #6752. Prior to this change, only the `rust_binary` macro added these rules and the `rust_library` missing the `:check-format-toml` rule addition.

All now-failing format checks are also addressed and confirmed by running:

```sh
buck2 uquery \
  'filter("check-format-toml", set("//bin/..." "//lib/..."))' \
  | xargs buck2 test
```

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOXB0eHN6aXBoa3EwaWcwMWtlMHdxdzhtbWZlcGFmNDBjenpueDNwdiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/UYApNmtmEkxZCgloJI/giphy.gif"/>