### PR TITLE
Fallback to plain text in func run viewer when the logs are too large

### DIFF
--- a/app/web/src/newhotness/FuncRunDetails.vue
+++ b/app/web/src/newhotness/FuncRunDetails.vue
@@ -7,6 +7,7 @@
     :funcRun="funcRun"
     :status="funcRunStatus(funcRun, managementFuncJobState?.state) || ''"
     :logText="logText"
+    :logsTooLarge="logsTooLarge"
     :errorHint="
       successWithFailedOperations
         ? 'The management function ran successfully, but some component operations failed.'
@@ -280,6 +281,10 @@ const { data: funcRunLogsQuery } = useQuery<FuncRunLog | undefined>({
 });
 
 const funcRunLogs = computed(() => funcRunLogsQuery.value);
+
+const logsTooLarge = computed(
+  () => (funcRunLogs.value?.logs.length ?? 0) > 175,
+);
 
 // Format logs as text for CodeViewer
 const logText = computed<string>(() => {

--- a/app/web/src/newhotness/LatestFuncRunDetails.vue
+++ b/app/web/src/newhotness/LatestFuncRunDetails.vue
@@ -6,6 +6,7 @@
     noLogs
     :status="''"
     :logText="''"
+    :logsTooLarge="false"
     :errorHint="''"
     :errorMessageRaw="''"
   >

--- a/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunDetailsLayout.vue
@@ -80,14 +80,19 @@
         :live="!!isLive && funcRun?.state === 'Running'"
         disableCollapse
       >
-        <CodeViewer
-          v-if="logText"
-          ref="logsContainer"
-          :code="logText"
-          language="log"
-          allowCopy
-          forceLineNumbers
-        />
+        <template v-if="logText">
+          <pre v-if="logsTooLarge">
+            {{ logText }}
+          </pre>
+          <CodeViewer
+            v-else
+            ref="logsContainer"
+            :code="logText"
+            language="log"
+            allowCopy
+            forceLineNumbers
+          />
+        </template>
         <div v-else class="text-neutral-400 italic text-xs p-xs">
           No logs available
         </div>
@@ -120,6 +125,7 @@ const props = defineProps<{
   noLogs?: boolean;
   status: string;
   logText: string;
+  logsTooLarge: boolean;
   isLive?: boolean;
   errorHint?: string;
   errorMessageRaw?: string;


### PR DESCRIPTION
## How does this PR change the system?

Rendering the CodeViewer with such large logs is freezing the main thread of the browser

#### Screenshots:

<img width="2277" height="704" alt="image" src="https://github.com/user-attachments/assets/ee6be67e-765b-46a9-8a44-f766644e125b" />

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlY3lteHlhazE1Nmx4aG5jeTM2b2l5eWt2aWp5NGN4dmZmejlmNXYyMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2d98nRiVVB6HS/giphy.gif"/>
