### PR TITLE
feat(clover): discover discriminants and put them in the domain

### DIFF
--- a/bin/clover/src/pipelines/azure/funcs/actions/update.ts
+++ b/bin/clover/src/pipelines/azure/funcs/actions/update.ts
@@ -97,6 +97,55 @@ function cleanPayload(domain) {
   delete payload.name;
   delete payload.extra;
 
+  // Merge discriminator subtypes into parent
+  // propUsageMap.discriminators maps discriminator property -> subtype name -> enum value
+  // e.g., { "kind": { "AzurePowerShellScript": "AzurePowerShell", "AzureCliScript": "AzureCLI" } }
+  for (
+    const [discriminatorProp, subtypeMap] of Object.entries(
+      propUsageMap.discriminators || {},
+    )
+  ) {
+    const discriminatorObject = payload[discriminatorProp];
+
+    if (!discriminatorObject || typeof discriminatorObject !== "object") {
+      continue;
+    }
+
+    // Find which subtype is filled in
+    const filledSubtypes = Object.keys(subtypeMap).filter((subtype) => discriminatorObject[subtype]);
+
+    if (filledSubtypes.length > 1) {
+      throw new Error(
+        `Multiple discriminator subtypes filled for "${discriminatorProp}": ${
+          filledSubtypes.join(", ")
+        }. Only one should be filled.`,
+      );
+    }
+
+    if (filledSubtypes.length === 0) {
+      // No subtype filled in, remove the discriminator property
+      delete payload[discriminatorProp];
+      continue;
+    }
+
+    const subtypeName = filledSubtypes[0];
+    const subtypeValue = discriminatorObject[subtypeName];
+
+    if (
+      subtypeValue && typeof subtypeValue === "object" &&
+      !Array.isArray(subtypeValue)
+    ) {
+      // Merge subtype properties into parent (subtype values take precedence)
+      Object.assign(payload, subtypeValue);
+
+      // Set the discriminator property to the enum value from the map
+      payload[discriminatorProp] = subtypeMap[subtypeName];
+    } else {
+      // If no subtype data, remove the discriminator property
+      delete payload[discriminatorProp];
+    }
+  }
+
   // Only check top-level properties - once a property is included, keep all its descendants
   const propsToVisit = _.keys(payload).map((k: string) => [k]);
 

--- a/bin/clover/src/pipelines/azure/schema.ts
+++ b/bin/clover/src/pipelines/azure/schema.ts
@@ -12,9 +12,30 @@ import { OpenAPIV3_1 } from "openapi-types";
 import path from "node:path";
 import { Extend } from "../../extend.ts";
 
+/// Azure schema property
+export type AzureSchemaProperty = JSONSchema.Interface & AzureSchemaExtensions;
+
+/// Azure-specific schema extensions
+export type AzureSchemaExtensions = {
+  "x-ms-discriminator-value"?: string;
+  discriminator?: string;
+  properties?: Record<string, AzureSchemaProperty>;
+};
+
+/// Azure schema definition
+export type AzureSchemaDefinition = JSONSchema & AzureSchemaExtensions;
+
+/// Azure definitions object
+export type AzureDefinitions = Record<string, AzureSchemaDefinition>;
+
 /// OpenAPI.Document without $ref, with some Azure-specific extensions
 export type AzureOpenApiDocument =
-  OpenAPIV3_1.Document<AzureOpenApiOperationExt>;
+  & OpenAPIV3_1.Document<
+    AzureOpenApiOperationExt
+  >
+  & {
+    definitions?: AzureDefinitions;
+  };
 /// OpenAPI.Operation without $ref, with some Azure-specific extensions
 export type AzureOpenApiOperation = Extend<
   OpenAPIV3_1.OperationObject,
@@ -38,6 +59,7 @@ export type NormalizedAzureSchema = Extend<
     properties?: Record<string, NormalizedAzureSchema>;
     patternProperties?: Record<string, NormalizedAzureSchema>;
     additionalProperties?: NormalizedAzureSchema;
+    discriminators?: Record<string, Record<string, string>>;
   }
 >;
 
@@ -59,6 +81,7 @@ export type PropertySet = Set<string>;
 export interface AzureSchema extends SuperSchema {
   requiredProperties: Set<string>;
   apiVersion?: string;
+  discriminators?: Record<string, Record<string, string>>;
 }
 
 export type AzureProperty = CfProperty & AzurePropExtensions;


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Azure schemas can contain `discriminants` where an enum prop may map to a complicated object. 

```
discriminant: "kind",
properties : {
  "kind": {
    "type": "string",
    "description": "Type of the script.",
    "enum": [
      "AzurePowerShell",
      "AzureCLI"
    ]
  },
}
```
Elsewhere, in the definitions, you'll find the matching discriminators.

```
 "AzurePowerShellScript": {
      "type": "object",
      "x-ms-discriminator-value": "AzurePowerShell",
      "description": "Object model for the Azure PowerShell script.",
      "properties": {
        "properties": {
          "description": "Properties of the Azure PowerShell script object.",
          "$ref": "#/definitions/AzurePowerShellScriptProperties",
          "x-ms-client-flatten": true
        }
      },
    }
...
```

So we need to detect when discriminants exist, gather all of the relevant objects, and put them in the domain. Because the UI does not support either/or style displays, all of them will be present.

It's important to note that discriminators may be of entirely different shapes or have the same props of different types, so we can't just smash the entirety of them into the prop tree or attempt to gather them using `anyOf`.

After we add the objects to the domain, we also keep a record of `dicscriminant:discriminators` in the `PropUsageMap` so we can:

1. Detect if multiple are filled out. This should error
2. Merge the properties of the filled out ones into the request payload

#### Screenshots:

Successful create with domain before and after merging
```
[Fri, 24 Oct 2025 19:13:14 GMT] [info] Running CLI command: "az 'login' '--service-principal' '--username' '[redacted]' '--password' '[redacted]' '--tenant' '[redacted]'"
[Fri, 24 Oct 2025 19:13:17 GMT] [info] Registering environment variable AZURE_TENANT_ID
[Fri, 24 Oct 2025 19:13:17 GMT] [info] Registering environment variable AZURE_CLIENT_ID
[Fri, 24 Oct 2025 19:13:17 GMT] [info] Registering environment variable AZURE_CLIENT_SECRET
[Fri, 24 Oct 2025 19:13:18 GMT] [info] {
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   kind: "AzurePowerShell",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   location: "eastus",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   name: "test",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   subscriptionId: "2cd357b4-5d4f-471b-ac9c-cd4f2a4ccd07",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   resourceGroup: "clover",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   AzurePowerShellScript: {
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     kind: "AzurePowerShell",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     properties: {
[Fri, 24 Oct 2025 19:13:18 GMT] [info]       azPowerShellVersion: "7.4",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]       retentionInterval: "P1D",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]       scriptContent: "test"
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     }
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   },
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   extra: {
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     apiVersion: "2023-08-01",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     AzureResourceType: "Azure::Resources::DeploymentScripts",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     PropUsageMap: '{"createOnly":["subscriptionId","resourceGroup","name"],"updatable":["AzureCliScript","AzurePowerShellScript","kind","tags","location","identity","identity","location","tags","kind","properties","identity","location","tags","kind","properties","type","userAssignedIdentities","type","userAssignedIdentities","containerSettings","storageAccountSettings","cleanupPreference","primaryScriptUri","supportingScriptUris","scriptContent","arguments","environmentVariables","forceUpdateTag","retentionInterval","timeout","azCliVersion","type","userAssignedIdentities","containerSettings","storageAccountSettings","cleanupPreference","primaryScriptUri","supportingScriptUris","scriptContent","arguments","environmentVariables","forceUpdateTag","retentionInterval","timeout","azPowerShellVersion","containerGroupName","subnetIds","storageAccountName","storageAccountKey","containerGroupName","subnetIds","storageAccountName","storageAccountKey"],"discriminators":{"kind":["AzurePowerShellScript","AzureCliScript"]}}'
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   }
[Fri, 24 Oct 2025 19:13:18 GMT] [info] }
[Fri, 24 Oct 2025 19:13:18 GMT] [info] {
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   kind: "AzurePowerShell",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   location: "eastus",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   properties: {
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     azPowerShellVersion: "7.4",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     retentionInterval: "P1D",
[Fri, 24 Oct 2025 19:13:18 GMT] [info]     scriptContent: "test"
[Fri, 24 Oct 2025 19:13:18 GMT] [info]   }
[Fri, 24 Oct 2025 19:13:18 GMT] [info] }
[Fri, 24 Oct 2025 19:13:19 GMT] [info] Output: {
  "protocol": "result",
  "status": "success",
  "executionId": "01K8BT7BQ4GXZR21VANTNHFXG6",
  "resourceId": "/subscriptions/2cd357b4-5d4f-471b-ac9c-cd4f2a4ccd07/resourceGroups/clover/providers/Microsoft.Resources/deploymentScripts/test",
  "payload": {
    "kind": "AzurePowerShell",
    "location": "eastus",
    "properties": {
      "provisioningState": "Creating",
      "azPowerShellVersion": "7.4",
      "scriptContent": "test",
      "retentionInterval": "P1D",
      "timeout": "P1D",
      "containerSettings": {},
      "status": {},
      "cleanupPreference": "Always"
    },
    "systemData": {
      "createdBy": "[redacted]",
      "createdByType": "Application",
      "createdAt": "2025-10-24T19:13:19.4392268Z",
      "lastModifiedBy": "[redacted]",
      "lastModifiedByType": "Application",
      "lastModifiedAt": "2025-10-24T19:13:19.4392268Z"
    },
    "id": "/subscriptions/2cd357b4-5d4f-471b-ac9c-cd4f2a4ccd07/resourceGroups/clover/providers/Microsoft.Resources/deploymentScripts/test",
    "type": "Microsoft.Resources/deploymentScripts",
    "name": "test"
  },
```

Showing the failure case if multiples are filled out: 

```
[Fri, 24 Oct 2025 19:24:00 GMT] [info] Output: {
  "protocol": "result",
  "status": "success",
  "executionId": "01K8BTTZ3FBDKF3KQ7CRA5ZYRQ",
  "payload": null,
  "health": "error",
  "message": "Multiple discriminator subtypes filled for \"kind\": AzurePowerShellScript, AzureCliScript. Only one should be filled."
}
```

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: new functionality works in UI

## In short: [:link:](https://giphy.com/)

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZ3E2aGIzMnE4ZGQwd3o1ZTVkeDBkZmJtbjdpdHY2eGFreTc4MjdiaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/sN3dABJRtyzciTOHKX/giphy.gif"/>