### PR TITLE
fix: can't update any schema due to an unrelated subscription cycle

### DIFF
--- a/lib/dal/tests/integration_test/cycle_check_guard.rs
+++ b/lib/dal/tests/integration_test/cycle_check_guard.rs
@@ -1,14 +1,138 @@
 use dal::DalContext;
-use dal_test::test;
+use dal_test::{
+    Result,
+    helpers::{
+        attribute::value,
+        component,
+        schema::variant,
+    },
+    test,
+};
 
 #[test]
-async fn cycle_check_guard_test(ctx: &DalContext) {
-    let snap = ctx.workspace_snapshot().expect("get snap");
-    let guard = snap.enable_cycle_check().await;
-
-    assert!(snap.cycle_check().await);
-
-    drop(guard);
-
+async fn cycle_check_guard_test(ctx: &DalContext) -> Result<()> {
+    // Cycle check should be disabled by default
+    let snap = ctx.workspace_snapshot()?;
+    let root = snap.root().await?;
     assert!(!snap.cycle_check().await);
+
+    // Shouldn't be able to create a cycle when the guard is on
+    {
+        let _guard = snap.enable_cycle_check().await;
+        assert!(snap.cycle_check().await);
+        assert!(
+            snap.add_edge(
+                root,
+                dal::EdgeWeight::new(dal::EdgeWeightKind::new_use_default()),
+                root
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    // Now we should be able to create the cycle
+    assert!(!snap.cycle_check().await);
+    snap.add_edge(
+        root,
+        dal::EdgeWeight::new(dal::EdgeWeightKind::new_use_default()),
+        root,
+    )
+    .await?;
+
+    Ok(())
 }
+
+#[test]
+async fn cycle_cannot_be_created_when_cycle_check_is_enabled(ctx: &DalContext) -> Result<()> {
+    variant::create(ctx, "test", TEST_ASSET_FUNCTION).await?;
+    component::create(ctx, "test", "test").await?;
+
+    // Try to create a second cycle (self-subscription) while cycle check is enabled
+    {
+        let _guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+        assert!(
+            value::subscribe(ctx, ("test", "/domain/A"), ("test", "/domain/B"))
+                .await
+                .is_err()
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+async fn cycle_can_be_created_when_cycle_check_is_disabled(ctx: &DalContext) -> Result<()> {
+    variant::create(ctx, "test", TEST_ASSET_FUNCTION).await?;
+    component::create(ctx, "test", "test").await?;
+    component::create(ctx, "test", "test2").await?;
+
+    // Create a cycle (self-subscription) while cycle check is disabled
+    value::subscribe(ctx, ("test", "/domain/A"), ("test", "/domain/B")).await?;
+
+    // Try to create a second cycle (self-subscription) while cycle check is enabled
+    {
+        let _guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+        assert!(
+            value::subscribe(ctx, ("test2", "/domain/A"), ("test2", "/domain/B"))
+                .await
+                .is_err()
+        );
+    }
+
+    // Create a second cycle (self-subscription) while cycle check is disabled
+    value::subscribe(ctx, ("test2", "/domain/A"), ("test2", "/domain/B")).await?;
+
+    Ok(())
+}
+
+#[test]
+async fn edges_can_be_added_when_there_is_an_existing_cycle(ctx: &DalContext) -> Result<()> {
+    variant::create(ctx, "test", TEST_ASSET_FUNCTION).await?;
+    component::create(ctx, "test", "test").await?;
+    component::create(ctx, "test", "test2").await?;
+
+    // Create a cycle (self-subscription) while cycle check is disabled
+    value::subscribe(ctx, ("test", "/domain/A"), ("test", "/domain/B")).await?;
+
+    // Create a non-cycle subscription while cycle check is enabled
+    {
+        let _guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+        value::subscribe(ctx, ("test", "/domain/A"), ("test2", "/domain/B")).await?;
+    }
+
+    Ok(())
+}
+
+#[test]
+async fn cycle_cannot_be_created_when_there_is_an_existing_cycle(ctx: &DalContext) -> Result<()> {
+    variant::create(ctx, "test", TEST_ASSET_FUNCTION).await?;
+    component::create(ctx, "test", "test").await?;
+    component::create(ctx, "test", "test2").await?;
+
+    // Create a cycle (self-subscription) while cycle check is disabled
+    value::subscribe(ctx, ("test", "/domain/A"), ("test", "/domain/B")).await?;
+
+    // Create a another cycle (self-subscription) on another component while cycle check is enabled
+    {
+        let _guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
+        assert!(
+            value::subscribe(ctx, ("test2", "/domain/A"), ("test2", "/domain/B"))
+                .await
+                .is_err()
+        );
+    }
+
+    Ok(())
+}
+
+const TEST_ASSET_FUNCTION: &str = r#"
+    function main() {
+        return {
+            props: [
+                { name: "A", kind: "string" },
+                { name: "B", kind: "string" },
+            ]
+        };
+    }
+"#;


### PR DESCRIPTION
When there is a self-subscription or a cycle of subscriptions, you can't update any attribute function bindings anywhere. There are multiple other endpoints (many of them schema endpoints) that also fail.

The problem is these endpoints enable cycle checking, which will throw if there is *any* cycle in the graph, not just if the edges being added create cycles. But we allow certain graph cycles due to subscriptions: for example, Foo:/domain/A -> Bar:/domain/B -> Foo:/domain/C is not a cycle in practice, but because each subscription points at the component root and has a string path, there is a cycle in the *graph* (Foo:/domain/A -> Bar (+ "/domain/B" string path), Bar:/domain/B -> Foo (+ "/domain/C" string path)).

This will get worse in Azure, where self-subscriptions can actually be desirable.

## How does this PR change the system?

This PR narrows down our cycle checks, so they only throw if *the edge you are adding* would create a cycle.

There are ways we could eliminate these cycles entirely, but narrowly-focused errors (and code that doesn't topologically sort the whole graph) are probably desirable either way.

## How was it tested?

- [X] Integration tests pass
- [X] New tests
- [ ] Manual test: create subscription cycle and update an asset

## In short: [:link:](https://giphy.com/)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNW45bzBpNG01c3duc2o4cHFqNmRmeHk2NWJpNnNocTAzMm90a3QwaSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/8YikHvDpzhZZXeF9VT/giphy.gif"/>