### PR TITLE
fix: Thread overlays through to components

### DIFF
--- a/lib/dal-materialized-views/src/action/action_prototype_view_list.rs
+++ b/lib/dal-materialized-views/src/action/action_prototype_view_list.rs
@@ -22,7 +22,7 @@ pub async fn assemble(
     let ctx = &ctx;
 
     let action_prototypes_for_variant =
-        ActionPrototype::for_variant(ctx, schema_variant_id).await?;
+        ActionPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?;
     let mut action_prototypes = Vec::with_capacity(action_prototypes_for_variant.len());
 
     for action_prototype in action_prototypes_for_variant {

--- a/lib/dal-test/src/helpers/schema.rs
+++ b/lib/dal-test/src/helpers/schema.rs
@@ -3,6 +3,7 @@ use dal::{
     FuncId,
     Schema,
     SchemaId,
+    action::prototype::ActionKind,
     func::authoring::FuncAuthoringClient,
 };
 
@@ -50,7 +51,7 @@ impl SchemaKey for &str {
     }
 }
 
-/// Create a management func overaly for the given schema
+/// Create a management func overlay for the given schema
 pub async fn create_overlay_management_func(
     ctx: &DalContext,
     schema: impl SchemaKey,
@@ -60,6 +61,26 @@ pub async fn create_overlay_management_func(
     let schema_id = SchemaKey::id(ctx, schema).await?;
     let func =
         FuncAuthoringClient::create_new_management_func(ctx, Some(name.into()), schema_id).await?;
+    FuncAuthoringClient::save_code(ctx, func.id, code.into()).await?;
+    Ok(func.id)
+}
+
+/// Create an action func overlay for the given schema
+pub async fn create_overlay_action_func(
+    ctx: &DalContext,
+    schema: impl SchemaKey,
+    name: impl Into<String>,
+    code: impl Into<String>,
+    kind: ActionKind,
+) -> Result<FuncId> {
+    let schema_id = SchemaKey::id(ctx, schema).await?;
+    let func = FuncAuthoringClient::create_new_action_func_overlay(
+        ctx,
+        Some(name.into()),
+        kind,
+        schema_id,
+    )
+    .await?;
     FuncAuthoringClient::save_code(ctx, func.id, code.into()).await?;
     Ok(func.id)
 }

--- a/lib/dal-test/src/test_exclusive_schemas/swifty.rs
+++ b/lib/dal-test/src/test_exclusive_schemas/swifty.rs
@@ -168,6 +168,7 @@ pub(crate) async fn migrate_test_exclusive_schema_swifty(
                 .action_func(
                     ActionFuncSpec::builder()
                         .kind(ActionKind::Create)
+                        .name(Some("test:createActionSwifty".to_string()))
                         .func_unique_id(&create_action_func.unique_id)
                         .build()?,
                 )

--- a/lib/dal/tests/integration_test/materialized_views.rs
+++ b/lib/dal/tests/integration_test/materialized_views.rs
@@ -57,11 +57,12 @@ async fn actions(ctx: &DalContext) -> Result<()> {
     let schema_variant_id = Component::schema_variant_id(ctx, component.id()).await?;
 
     // Gather what we need for the assertions after the component has been created.
-    let create_action_prototype = ActionPrototype::for_variant(ctx, schema_variant_id)
-        .await?
-        .into_iter()
-        .find(|ap| ap.kind == dal::action::prototype::ActionKind::Create)
-        .ok_or_eyre("could not find action prototype")?;
+    let create_action_prototype =
+        ActionPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id)
+            .await?
+            .into_iter()
+            .find(|ap| ap.kind == dal::action::prototype::ActionKind::Create)
+            .ok_or_eyre("could not find action prototype")?;
     let func_id = ActionPrototype::func_id(ctx, create_action_prototype.id()).await?;
     let func = Func::get_by_id(ctx, func_id).await?;
     let create_action_id =

--- a/lib/luminork-server/src/service/v1/components/mod.rs
+++ b/lib/luminork-server/src/service/v1/components/mod.rs
@@ -285,7 +285,9 @@ pub async fn get_component_functions(
     let schema_variant_id = Component::schema_variant_id(ctx, component_id).await?;
 
     let mut action_functions = Vec::new();
-    for action_prototype in ActionPrototype::for_variant(ctx, schema_variant_id).await? {
+    for action_prototype in
+        ActionPrototype::list_for_schema_and_variant_id(ctx, schema_variant_id).await?
+    {
         let func_id = ActionPrototype::func_id(ctx, action_prototype.id).await?;
         let func = Func::get_by_id(ctx, func_id).await?;
 


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?
This change does the following: 
- When building the ActionPrototypeViewList for a variant, return overlays if they exist (this allows the front end to see them!)
- When fetching components from luminork, also return the overlays if they exist (so the agent knows about them)
- When upgrading a component, if there is an existing variant scoped action enqueued (Create/Update/Refresh/Destroy), swap it for the overlay if it exists
<!-- Why: briefly what problem this solves and what the aim is as an overview -->

#### Screenshots:

<!-- Are there images that may illustrate the change? (especially if UI was modified) -->

#### Out of Scope:

<!-- Anything this PR explicitly leaves out? -->
I didn't go as far as hydrating which functions are overlays or not - this will come later
## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] New Integration test for this use case, including component upgrade

## In short: [:link:](https://giphy.com/)
<div><img src="https://media3.giphy.com/media/l1JoihoOA6VxIQiD6/giphy.gif?cid=5a38a5a28rrlf92dozknqeibkyj0lx929418gwbbxwf0ksk4&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:225px;width:300px"/><br/>via <a href="https://giphy.com/heyarnold/">Hey Arnold</a> on <a href="https://giphy.com/gifs/heyarnold-hey-arnold-nicksplat-l1JoihoOA6VxIQiD6">GIPHY</a></div>