### PR TITLE
better colors, fixed borders, reverse truncation, and more!

### DIFF
--- a/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
+++ b/app/auth-portal/src/pages/WorkspaceAuthTokensPage.vue
@@ -79,7 +79,7 @@
       <Modal ref="tokenDisplayModalRef" size="lg" title="Token Generated">
         <ErrorMessage
           v-if="tokenCopied"
-          class="rounded-md text-md px-xs py-xs"
+          class="rounded-md text-md p-xs"
           icon="check-circle"
           tone="success"
           variant="block"
@@ -90,7 +90,7 @@
         </ErrorMessage>
         <ErrorMessage
           v-else
-          class="rounded-md text-md px-xs py-xs"
+          class="rounded-md text-md p-xs"
           icon="alert-circle"
           tone="info"
           variant="block"

--- a/app/web/src/components/ChangesetRenameModal.vue
+++ b/app/web/src/components/ChangesetRenameModal.vue
@@ -18,7 +18,7 @@
       />
       <ErrorMessage
         v-if="apiErrorMessage"
-        class="rounded-md text-md px-xs py-xs"
+        class="rounded-md text-md p-xs"
         icon="x-circle"
         variant="block"
       >

--- a/app/web/src/components/StatusIndicatorIcon.vue
+++ b/app/web/src/components/StatusIndicatorIcon.vue
@@ -3,6 +3,7 @@
     :name="iconName"
     :tone="tone !== 'inherit' ? iconTone : undefined"
     :size="size"
+    :useNewIconTones="type === 'qualification' || type === 'management'"
   />
 </template>
 

--- a/app/web/src/newhotness/Onboarding.vue
+++ b/app/web/src/newhotness/Onboarding.vue
@@ -101,7 +101,7 @@
                 </div>
                 <!-- Secret Values -->
                 <ErrorMessage
-                  class="rounded-md text-md px-xs py-xs bg-action-900 mt-xs"
+                  class="rounded-md text-md p-xs bg-action-900 mt-xs"
                   tone="action"
                   variant="block"
                   noIcon
@@ -252,7 +252,7 @@
                   Copy this API token to use as part of the AI Agent setup
                 </span>
                 <ErrorMessage
-                  class="rounded-md text-md px-xs py-xs bg-action-900 my-xs"
+                  class="rounded-md text-md p-xs bg-action-900 my-xs"
                   icon="alert-circle"
                   tone="action"
                   variant="block"
@@ -267,7 +267,7 @@
                 />
                 <ErrorMessage
                   v-if="!isSkippable && !hasUsedAiAgent"
-                  class="rounded-md text-md px-xs py-xs bg-newhotness-warningdark my-xs"
+                  class="rounded-md text-md p-xs bg-newhotness-warningdark my-xs"
                   icon="loader"
                   tone="warning"
                   variant="block"

--- a/app/web/src/newhotness/Onboarding2.vue
+++ b/app/web/src/newhotness/Onboarding2.vue
@@ -138,7 +138,7 @@ export const DEBUG_ONBOARDING_START = OnboardingStep.INITIALIZE;
                   <ErrorMessage
                     :class="
                       clsx(
-                        'rounded-sm px-xs py-xs',
+                        'rounded-sm p-xs',
                         themeClasses('bg-action-200', 'bg-action-900'),
                       )
                     "
@@ -483,7 +483,7 @@ export const DEBUG_ONBOARDING_START = OnboardingStep.INITIALIZE;
                     <ErrorMessage
                       :class="
                         clsx(
-                          'rounded-sm px-xs py-xs my-xs border',
+                          'rounded-sm p-xs my-xs border',
                           themeClasses(
                             'bg-warning-100 border-warning-600',
                             'bg-newhotness-warningdark border-warning-500',

--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -1110,7 +1110,7 @@ body.light .scrollable {
   grid-row-gap: 2px;
   grid-column-gap: 0.5rem;
   // 32px is the icon size
-  grid-template-columns: 20px minmax(0, 1fr) 32px;
+  grid-template-columns: 20px minmax(0, 1fr) 20px;
   grid-template-rows: 16px 16px;
   grid-template-areas:
     "logo h2 spinner"

--- a/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGridRow.vue
@@ -8,8 +8,8 @@
       )
     "
   >
-    <Icon
-      :name="row.collapsed ? 'chevron--right' : 'chevron--down'"
+    <CollapseExpandChevron
+      :open="!row.collapsed"
       @click="emit('clickCollapse', row.title, !row.collapsed)"
     />
     <Icon
@@ -46,9 +46,8 @@
       )
     "
   >
-    <Icon
-      class="cursor-pointer hover:scale-125"
-      :name="row.collapsed ? 'chevron--right' : 'chevron--down'"
+    <CollapseExpandChevron
+      :open="!row.collapsed"
       @click="emit('clickCollapse', row.subKey, !row.collapsed)"
     />
     <Icon :name="getAssetIcon(row.schemaCategory)" size="md" />
@@ -122,7 +121,7 @@
     "
     @click="emit('clickCollapse', row.title, !row.collapsed)"
   >
-    <Icon :name="row.collapsed ? 'chevron--right' : 'chevron--down'" />
+    <CollapseExpandChevron :open="!row.collapsed" />
     <span class="select-none">
       {{ row.title }}
     </span>
@@ -334,6 +333,7 @@ import {
   Tones,
   TruncateWithTooltip,
   NewButton,
+  CollapseExpandChevron,
 } from "@si/vue-lib/design-system";
 import { tw } from "@si/vue-lib";
 import { useQuery } from "@tanstack/vue-query";

--- a/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
+++ b/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
@@ -28,10 +28,7 @@
       "
       @click="() => (open = !open)"
     >
-      <Icon
-        :name="open ? 'chevron--down' : 'chevron--right'"
-        class="group-hover/header:scale-125 flex-none"
-      />
+      <CollapseExpandChevron :open="open" />
       <slot name="header" />
     </dt>
     <dd v-if="open" class="p-2xs">
@@ -42,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { Icon, themeClasses } from "@si/vue-lib/design-system";
+import { CollapseExpandChevron, themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { ref } from "vue";
 

--- a/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingFlexItem.vue
@@ -43,12 +43,7 @@
       "
       @click="toggleOpen"
     >
-      <Icon
-        v-if="!disableCollapse"
-        class="group-hover/header:scale-125"
-        :name="showOpen ? 'chevron-down' : 'chevron-right'"
-        size="sm"
-      />
+      <CollapseExpandChevron v-if="!disableCollapse" :open="showOpen" />
       <slot name="header" />
       <div v-if="$slots.headerIcons || showExpandButton" class="ml-auto" />
       <slot name="headerIcons" />
@@ -101,9 +96,9 @@
 import {
   themeClasses,
   Modal,
-  Icon,
   SpacingSizes,
   NewButton,
+  CollapseExpandChevron,
 } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { computed, onMounted, ref } from "vue";

--- a/app/web/src/newhotness/layout_components/CollapsingGridItem.vue
+++ b/app/web/src/newhotness/layout_components/CollapsingGridItem.vue
@@ -4,7 +4,8 @@
       :class="
         clsx(
           'group/header flex flex-row items-center h-[40px]',
-          'text-lg px-xs py-xs flex-none border',
+          'text-lg p-xs flex-none',
+          funcRunScreen ? 'border' : 'border-y',
           themeClasses(
             'bg-neutral-300 border-neutral-400',
             'bg-neutral-800 border-neutral-600',
@@ -17,11 +18,10 @@
       "
       @click="toggleOpen"
     >
-      <Icon
+      <CollapseExpandChevron
         v-if="!disableCollapse"
-        class="group-hover/header:scale-125 mr-xs"
-        :name="openState.open.value ? 'chevron-down' : 'chevron-right'"
-        size="sm"
+        :open="openState.open.value"
+        class="mr-xs"
       />
       <slot name="header" />
       <div class="ml-auto" />
@@ -49,7 +49,7 @@
 </template>
 
 <script lang="ts" setup>
-import { Icon, themeClasses } from "@si/vue-lib/design-system";
+import { CollapseExpandChevron, themeClasses } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { useToggle } from "../logic_composables/toggle_containers";
 

--- a/app/web/src/newhotness/layout_components/FuncRunListLayout.vue
+++ b/app/web/src/newhotness/layout_components/FuncRunListLayout.vue
@@ -8,7 +8,7 @@
       <div
         :class="
           clsx(
-            'flex flex-row items-center gap-sm flex-wrap border-l border-r border-b py-2xs -mx-2xs pl-xs pr-2xs',
+            'flex flex-row items-center gap-xs justify-between flex-wrap border-b py-2xs -mx-2xs px-xs',
             themeClasses('border-neutral-400', 'border-neutral-600'),
           )
         "

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -27,6 +27,7 @@ const USER_FLAG_MAPPING = {
   INITIALIZER_ONBOARD: "initializer-onboard",
   INITIALIZER_ONBOARD_FORCE_AGENT: "initializer-onboard-force-agent",
   COMPONENT_HISTORY_FUNCS: "component-history-funcs",
+  REVERSE_TRUNCATION: "reverse-truncation",
 } as const;
 const WORKSPACE_FLAG_MAPPING = {
   FRONTEND_ARCH_VIEWS: "workspace-frontend-arch-views",

--- a/lib/vue-lib/src/design-system/general/CollapseExpandChevron.vue
+++ b/lib/vue-lib/src/design-system/general/CollapseExpandChevron.vue
@@ -1,0 +1,15 @@
+<template>
+  <Icon
+    :name="open ? 'chevron-down' : 'chevron-right'"
+    size="sm"
+    class="cursor-pointer flex-none"
+  />
+</template>
+
+<script setup lang="ts">
+import Icon from "../icons/Icon.vue";
+
+defineProps({
+  open: Boolean,
+});
+</script>

--- a/lib/vue-lib/src/design-system/general/TruncateWithTooltip.vue
+++ b/lib/vue-lib/src/design-system/general/TruncateWithTooltip.vue
@@ -12,13 +12,14 @@
             ],
       )
     "
+    :dir="reverse && tooltip.content ? 'rtl' : undefined"
     @click="toggleExpand"
   >
     <template v-if="expandableStringArray && !lineClamp">
       <template v-if="expanded">
-        <TruncateWithTooltip v-for="s in expandableStringArray" :key="s">{{
-          s
-        }}</TruncateWithTooltip>
+        <TruncateWithTooltip v-for="s in expandableStringArray" :key="s">
+          {{ s }}
+        </TruncateWithTooltip>
       </template>
       <template v-else>{{ expandableStringArray.join(", ") }}</template>
     </template>
@@ -49,6 +50,7 @@ const props = defineProps({
   expandOnClick: { type: Boolean },
   expandableStringArray: { type: Array<string> },
   lineClamp: { type: Number as PropType<LineClamps> }, // not compatible with the other features
+  reverse: { type: Boolean }, // not compatible with the other features
 });
 
 const expanded = ref(false);

--- a/lib/vue-lib/src/design-system/icons/Icon.vue
+++ b/lib/vue-lib/src/design-system/icons/Icon.vue
@@ -34,7 +34,11 @@
 import * as _ from "lodash-es";
 import { computed, PropType } from "vue";
 import clsx from "clsx";
-import { getToneTextColorClass, Tones } from "../utils/color_utils";
+import {
+  getIconToneColorClass,
+  getToneTextColorClass,
+  Tones,
+} from "../utils/color_utils";
 import { getIconByName, IconNames } from "./icon_set";
 import { tw } from "../../utils/tw-utils";
 
@@ -58,6 +62,9 @@ const props = defineProps({
   tone: {
     type: String as PropType<Tones>,
   },
+  useNewIconTones: {
+    type: Boolean,
+  },
 });
 
 const iconSvgRaw = computed(() => {
@@ -69,7 +76,12 @@ const iconSvgRaw = computed(() => {
 });
 
 const toneColorClass = computed(() => {
-  return props.tone ? getToneTextColorClass(props.tone) : undefined;
+  if (props.tone) {
+    return props.useNewIconTones
+      ? getIconToneColorClass(props.tone)
+      : getToneTextColorClass(props.tone);
+  }
+  return undefined;
 });
 
 const computedRotate = computed(() => {

--- a/lib/vue-lib/src/design-system/icons/icon_set.ts
+++ b/lib/vue-lib/src/design-system/icons/icon_set.ts
@@ -43,7 +43,7 @@ import Socket from "./custom-icons/socket.svg?raw";
 import OutputSocket from "./custom-icons/output-socket.svg?raw";
 import InputSocket from "./custom-icons/input-socket.svg?raw";
 
-import QuestionMarkCircle from "~icons/heroicons-solid/question-mark-circle";
+import CarbonHelp from "~icons/carbon/help";
 import Play from "~icons/ion/play-sharp";
 
 import Arrow from "~icons/heroicons-solid/arrow-up";
@@ -54,7 +54,7 @@ import Sparkles from "~icons/heroicons/sparkles-solid";
 import Gear from "~icons/heroicons-solid/cog-8-tooth";
 import Save from "~icons/heroicons-solid/save";
 import Download from "~icons/heroicons-solid/download";
-import Trash from "~icons/heroicons-solid/trash";
+import CarbonTrashCan from "~icons/carbon/trash-can";
 import TrashRestore from "~icons/material-symbols/restore-from-trash";
 import Eraser from "~icons/solar/eraser-bold";
 
@@ -387,7 +387,7 @@ export const ICONS = Object.freeze({
   "plus-hex-outline": PlusHexOutline,
   "plus-minus": IcBaselinePlusMinusAlt,
   "plus-square": PlusSquare,
-  "question-circle": QuestionMarkCircle,
+  "question-circle": CarbonHelp,
   "question-hex-outline": QuestionHexOutline,
   "read-only": PencilOff,
   refresh: Refresh,
@@ -421,7 +421,7 @@ export const ICONS = Object.freeze({
   "tilde-hex-outline": TildeHexOutline,
   "tilde-square": TildeSquare,
   tools: Tools,
-  trash: Trash,
+  trash: CarbonTrashCan,
   "trash-restore": TrashRestore,
   "tree-parents": TreeParents,
   triangle: MdiTriangle,

--- a/lib/vue-lib/src/design-system/index.ts
+++ b/lib/vue-lib/src/design-system/index.ts
@@ -15,6 +15,7 @@ export { default as LoadingMessage } from "./general/LoadingMessage.vue";
 export { default as PillCounter } from "./general/PillCounter.vue";
 export { default as TextPill } from "./general/TextPill.vue";
 export { default as Toggle } from "./general/Toggle.vue";
+export { default as CollapseExpandChevron } from "./general/CollapseExpandChevron.vue";
 
 export { default as RichText } from "./general/RichText.vue";
 export { default as Timestamp } from "./general/Timestamp.vue";

--- a/lib/vue-lib/src/design-system/utils/color_utils.ts
+++ b/lib/vue-lib/src/design-system/utils/color_utils.ts
@@ -23,66 +23,87 @@ export const BRAND_COLOR_FILTER_HEX_CODES = {
   Tailscale: "#A7DAC2",
 };
 
+// TODO(Wendy) - a LOT of this system is outdated, we need to revamp it!
 const TONES = {
   action: {
-    colorHex: COLOR_PALETTE.action[500],
+    colorHexLight: COLOR_PALETTE.action[500],
+    colorHexDark: COLOR_PALETTE.action[300],
     bgColorClassLight: tw`bg-action-500`,
     bgColorClassDark: tw`bg-action-300`,
     textColorClassLight: tw`text-action-500`,
     textColorClassDark: tw`text-action-300`,
     borderColorClassLight: tw`border-action-500`,
     borderColorClassDark: tw`border-action-300`,
+    iconColorClassLight: tw`text-action-500`,
+    iconColorClassDark: tw`text-action-300`,
   },
   info: {
-    colorHex: COLOR_PALETTE.action[500],
+    colorHexLight: COLOR_PALETTE.action[500],
+    colorHexDark: COLOR_PALETTE.action[300],
     bgColorClass: tw`bg-action-500`,
     textColorClassLight: tw`text-action-500`,
     textColorClassDark: tw`text-action-300`,
     borderColorClassLight: tw`border-action-500`,
     borderColorClassDark: tw`border-action-300`,
+    iconColorClassLight: tw`text-action-500`,
+    iconColorClassDark: tw`text-action-300`,
   },
   destructive: {
-    colorHex: COLOR_PALETTE.destructive[500],
+    colorHexLight: COLOR_PALETTE.destructive[600],
+    colorHexDark: COLOR_PALETTE.destructive[200],
     bgColorClassLight: tw`bg-destructive-500`,
     bgColorClassDark: tw`bg-destructive-600`,
     textColorClassLight: tw`text-destructive-500`,
     textColorClassDark: tw`text-destructive-600`,
     borderColorClassLight: tw`border-destructive-500`,
     borderColorClassDark: tw`border-destructive-600`,
+    iconColorClassLight: tw`text-destructive-600`,
+    iconColorClassDark: tw`text-destructive-300`,
   },
   error: {
-    colorHex: COLOR_PALETTE.destructive[500],
+    colorHexLight: COLOR_PALETTE.destructive[600],
+    colorHexDark: COLOR_PALETTE.destructive[200],
     bgColorClass: tw`bg-destructive-500`,
     textColorClass: tw`text-destructive-500`,
     borderColorClass: tw`border-destructive-500`,
+    iconColorClassLight: tw`text-destructive-600`,
+    iconColorClassDark: tw`text-destructive-300`,
   },
   success: {
-    colorHex: COLOR_PALETTE.success[500],
+    colorHexLight: COLOR_PALETTE.success[600],
+    colorHexDark: COLOR_PALETTE.success[300],
     bgColorClassLight: tw`bg-success-500`,
     bgColorClassDark: tw`bg-success-300`,
     textColorClass: tw`text-success-500`,
     borderColorClass: tw`border-success-500`,
+    iconColorClassLight: tw`text-success-600`,
+    iconColorClassDark: tw`text-success-300`,
   },
   warning: {
-    colorHex: COLOR_PALETTE.warning[500],
+    colorHexLight: COLOR_PALETTE.warning[500],
+    colorHexDark: COLOR_PALETTE.warning[200],
     bgColorClassLight: tw`bg-warning-500`,
     bgColorClassDark: tw`bg-warning-400`,
     textColorClassLight: tw`text-warning-500`,
     textColorClassDark: tw`text-warning-400`,
     borderColorClassLight: tw`border-warning-500`,
     borderColorClassDark: tw`border-warning-400`,
+    iconColorClassLight: tw`text-warning-500`,
+    iconColorClassDark: tw`text-warning-200`,
   },
   neutral: {
     colorHex: COLOR_PALETTE.neutral[500],
     bgColorClass: tw`bg-neutral-500`,
     textColorClass: tw`text-neutral-500`,
     borderColorClass: tw`border-neutral-500`,
+    iconColorClass: tw`text-neutral-500`,
   },
   empty: {
     colorHex: "#00000000",
     bgColorClass: tw`bg-transparent`,
     textColorClass: tw`text-transparent border-transparent bg-transparent border-0 border-hidden opacity-0`,
     borderColorClass: tw`border-transparent`,
+    iconColorClass: tw`text-transparent border-transparent bg-transparent border-0 border-hidden opacity-0`,
   },
   shade: {
     colorHexLight: COLOR_PALETTE.shade[0],
@@ -93,6 +114,8 @@ const TONES = {
     textColorClassDark: tw`text-shade-0`,
     borderColorClassLight: tw`bg-shade-0`,
     borderColorClassDark: tw`bg-shade-100`,
+    iconColorClassLight: tw`text-shade-100`,
+    iconColorClassDark: tw`text-shade-0`,
   },
 };
 
@@ -146,4 +169,16 @@ export function getToneColorHex(tone: Tones) {
   if (theme.value === "dark")
     return toneSettings.colorHexDark || toneSettings.colorHex;
   return toneSettings.colorHexLight || toneSettings.colorHex;
+}
+
+export function getIconToneColorClass(tone: Tones) {
+  const { theme } = useTheme();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const toneSettings = TONES[tone] as any;
+
+  if (theme?.value === "dark") {
+    return toneSettings?.iconColorClassDark ?? toneSettings.iconColorClass;
+  }
+
+  return toneSettings?.iconColorClassLight ?? toneSettings.iconColorClass;
 }


### PR DESCRIPTION
## How does this PR change the system?

This PR closes out the UI improvements in [ENG-3199](https://linear.app/system-initiative/issue/ENG-3199/ui-improvements). Major highlights include adjusted colors, fixed borders, changed icons, a unified collapsing icon, and reverse truncation.

See the code for comments explaining the changes in detail.

Reverse truncation is behind a feature flag and only used on ExploreGridTile headers for now.

#### Screenshots:

<img width="287" height="298" alt="Screenshot 2025-10-24 at 5 49 19 PM" src="https://github.com/user-attachments/assets/deca64e9-b4ea-4f84-950c-aff1caeab3cc" />

#### Out of Scope:

This PR sidesteps the major overhaul we have due for the colors system eventually.

We may want to adjust the appearance/functionality of the reverse truncation feature in the future. For now, this iteration is just to test if we prefer it to standard truncation in places where we think that the end of the string is more important for the user to see than the beginning.

## How was it tested?

Oodles of manual testing, including checking across the UI to make sure no adjustments break other parts of the UI!
