### PR TITLE
Add new 422 case for prototypes when authoring

### DIFF
--- a/lib/dal/src/func/binding.rs
+++ b/lib/dal/src/func/binding.rs
@@ -169,6 +169,22 @@ pub enum FuncBindingError {
 impl FuncBindingError {
     pub fn is_create_graph_cycle(&self) -> bool {
         match self {
+            Self::AttributePrototype(err) => matches!(
+                err.as_ref(),
+                AttributePrototypeError::WorkspaceSnapshot(
+                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                        WorkspaceSnapshotGraphError::CreateGraphCycle,
+                    ) | WorkspaceSnapshotError::SplitGraph(SplitGraphError::WouldCreateGraphCycle),
+                )
+            ),
+            Self::AttributePrototypeArgument(err) => matches!(
+                err.as_ref(),
+                AttributePrototypeArgumentError::WorkspaceSnapshot(
+                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
+                        WorkspaceSnapshotGraphError::CreateGraphCycle,
+                    ) | WorkspaceSnapshotError::SplitGraph(SplitGraphError::WouldCreateGraphCycle),
+                )
+            ),
             Self::SchemaVariant(err) => match err.as_ref() {
                 SchemaVariantError::AttributePrototypeArgument(err) => matches!(
                     err.as_ref(),
@@ -182,14 +198,6 @@ impl FuncBindingError {
                 ),
                 _ => false,
             },
-            Self::AttributePrototypeArgument(err) => matches!(
-                err.as_ref(),
-                AttributePrototypeArgumentError::WorkspaceSnapshot(
-                    WorkspaceSnapshotError::WorkspaceSnapshotGraph(
-                        WorkspaceSnapshotGraphError::CreateGraphCycle,
-                    ) | WorkspaceSnapshotError::SplitGraph(SplitGraphError::WouldCreateGraphCycle),
-                )
-            ),
             _ => false,
         }
     }

--- a/lib/dal/src/workspace_snapshot/graph/v4.rs
+++ b/lib/dal/src/workspace_snapshot/graph/v4.rs
@@ -812,6 +812,8 @@ impl WorkspaceSnapshotGraphV4 {
             old_root_indexes = self
                 .graph
                 .externals(Incoming)
+                // NOTE(nick,jacob): HEY YOU! Comment this out if you want to leave behind all
+                // nodes involved in cycles after cleanup. Good for debugging with snapshot surfer.
                 .filter(|node_id| *node_id != self.root_index)
                 .collect();
             if old_root_indexes.is_empty() {


### PR DESCRIPTION
## Description

This change adds a 422 case for attribute prototypes when authoring func bindings for attribute funcs. It also adds a comment to indicate where to test for cycles in the graph.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZmU0ZDNnM245d294bG52M2R5NzV3Mmt5dDV1MnU3b2VzcGp3bnplZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o6ozymuzrBpskGS88/giphy.gif"/>
