### PR TITLE
Toggle button for all the AV groups to help exploration and searching

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
+++ b/app/web/src/newhotness/layout_components/AttributeChildLayout.vue
@@ -16,7 +16,7 @@
           'group/header',
           'px-2xs py-xs flex flex-row items-center gap-2xs cursor-pointer h-lg',
           sticky && 'sticky',
-          open && 'border-b',
+          _open && 'border-b',
           themeClasses(
             'bg-white border-neutral-300 hover:bg-neutral-100',
             'bg-neutral-800 border-neutral-600 hover:bg-neutral-700',
@@ -26,12 +26,12 @@
       :style="
         sticky ? { top: `${stickyTopOffset}px`, zIndex: stickyZIndex } : {}
       "
-      @click="() => (open = !open)"
+      @click="() => (_open = !_open)"
     >
-      <CollapseExpandChevron :open="open" />
+      <CollapseExpandChevron :open="_open" />
       <slot name="header" />
     </dt>
-    <dd v-if="open" class="p-2xs">
+    <dd v-if="_open" class="p-2xs">
       <slot />
       <!-- the children are, so far, another list or a button that would create a list -->
     </dd>
@@ -58,5 +58,18 @@ const props = withDefaults(
   },
 );
 
-const open = ref<boolean>(props.defaultOpen);
+const close = () => {
+  _open.value = false;
+};
+
+const open = () => {
+  _open.value = true;
+};
+
+defineExpose({
+  close,
+  open,
+});
+
+const _open = ref<boolean>(props.defaultOpen);
 </script>

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -27,6 +27,7 @@
   >
     <template v-if="showingChildren">
       <AttributeChildLayout
+        ref="childLayout"
         :sticky="
           attributeTree.prop?.kind === 'array' ||
           attributeTree.prop?.kind === 'map' ||
@@ -188,6 +189,7 @@
           <ComponentAttribute
             v-for="(child, index) in attributeTree.children"
             :key="child.id"
+            ref="componentAttributes"
             :component="component"
             :attributeTree="child"
             :parentHasExternalSources="
@@ -337,7 +339,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from "vue";
+import { computed, nextTick, ref, useTemplateRef } from "vue";
 import {
   themeClasses,
   NewButton,
@@ -371,6 +373,14 @@ const props = defineProps<{
   stickyDepth?: number;
   isFirstChild?: boolean;
 }>();
+
+interface HasOpenAndClose {
+  close: () => void;
+  open: () => void;
+}
+const childLayout =
+  useTemplateRef<InstanceType<typeof AttributeChildLayout>>("childLayout");
+const componentAttributes = useTemplateRef("componentAttributes");
 
 const hasChildren = computed(() => {
   if (!props.attributeTree.prop) return false;
@@ -682,4 +692,27 @@ const onConnectButtonTab = (e: KeyboardEvent) => {
 const onDeleteButtonTab = (e: KeyboardEvent) => {
   handleTab(e, deleteButtonRef.value?.mainElRef);
 };
+
+const close = () => {
+  childLayout.value?.close();
+  (componentAttributes.value as (HasOpenAndClose | undefined)[])?.forEach(
+    (el) => {
+      el?.close();
+    },
+  );
+};
+
+const open = () => {
+  childLayout.value?.open();
+  (componentAttributes.value as (HasOpenAndClose | undefined)[])?.forEach(
+    (el) => {
+      el?.open();
+    },
+  );
+};
+
+defineExpose({
+  close,
+  open,
+});
 </script>


### PR DESCRIPTION
## How does this PR change the system?

On searching, open all the groups, since we're filtering things out in that implementation

The Azure components have lots of components and it can be hard to navigate when they're all open.

#### Screenshots:

<img width="864" height="129" alt="image" src="https://github.com/user-attachments/assets/8e5d40d8-9ea5-4143-89e0-7415f4f1af0b" />
<img width="853" height="92" alt="image" src="https://github.com/user-attachments/assets/cf074367-9a45-4277-833b-48fa7571cf24" />
<img width="866" height="455" alt="image" src="https://github.com/user-attachments/assets/e4ea0c4b-2656-407f-bff6-845fa3bab105" />

## How was it tested?

1. Hit the toggle button
2. See that things close
3. Hit the toggle button
4. See that things open
5. Hit the toggle buttojn
6. Search for an AV
7. See that things are open & filtered


<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNXk0ZDZycjI2aW1udmhsaGxvcHJrenJwdDBuaDQ3bTc4eG15djFkbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/8m8RYtMOBWFu1Y7ja7/giphy.gif"/>