### PR TITLE
Prevent orphaned update actions

### DIFF
--- a/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
+++ b/lib/dal/src/workspace_snapshot/node_weight/attribute_prototype_argument_node_weight.rs
@@ -172,14 +172,9 @@ impl CorrectTransforms for AttributePrototypeArgumentNodeWeight {
             }
         }
 
-        // If there is a difference between the sets, we need to check that there are updates to
-        // remove. If the conditional passes, there should be exactly one: the new node update for
-        // ourself.
-        if destinations_that_do_not_exist
-            .difference(&all_new_nodes)
-            .next()
-            .is_some()
-        {
+        // If the destinations that no longer exist will not be included, then we need to remove the
+        // update for ourself.
+        if !destinations_that_do_not_exist.is_subset(&all_new_nodes) {
             if indices_for_new_node_updates_for_ourself.len() > 1 {
                 warn!(
                     attribute_prototype_argument_id=%self.id,

--- a/lib/dal/tests/integration_test/node_weight.rs
+++ b/lib/dal/tests/integration_test/node_weight.rs
@@ -1,3 +1,4 @@
+mod action;
 mod action_prototype;
 mod attribute_prototype_argument;
 mod attribute_value;

--- a/lib/dal/tests/integration_test/node_weight/action.rs
+++ b/lib/dal/tests/integration_test/node_weight/action.rs
@@ -1,0 +1,83 @@
+use std::collections::HashSet;
+
+use dal::{
+    self,
+    Component,
+    ComponentId,
+    DalContext,
+    action::{
+        Action,
+        prototype::ActionKind,
+    },
+    component::delete::delete_component,
+};
+use dal_test::{
+    Result,
+    helpers::{
+        ChangeSetTestHelpers,
+        attribute::value,
+        component,
+    },
+    test,
+};
+use pretty_assertions_sorted::assert_eq;
+use si_events::ActionState;
+
+#[test]
+async fn prevent_orphaned_update_actions(ctx: &mut DalContext) -> Result<()> {
+    // Create a component with both create and update actions and apply to HEAD.
+    let component_id = component::create(ctx, "swifty", "taylor swift").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
+
+    // Make sure we start with a clean slate.
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    Action::remove_all_for_component_id(ctx, component_id).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
+
+    // Create two change sets needed to reproduce the issue.
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    let alpha_change_set_id = ctx.change_set_id();
+    assert!(Action::list_topologically(ctx).await?.is_empty());
+    ChangeSetTestHelpers::fork_from_head_change_set(ctx).await?;
+    let beta_change_set_id = ctx.change_set_id();
+    assert!(Action::list_topologically(ctx).await?.is_empty());
+
+    // In the "beta", change set, erase the component.
+    let component = Component::get_by_id(ctx, component_id).await?;
+    let head_components: HashSet<ComponentId> =
+        Component::exists_on_head_by_ids(ctx, &[component_id]).await?;
+    delete_component(ctx, &component, true, &head_components).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    assert!(Action::list_topologically(ctx).await?.is_empty());
+
+    // In the "alpha" change set, change the component name, which auto-enqueues an update action.
+    ctx.update_visibility_and_snapshot_to_visibility(alpha_change_set_id)
+        .await?;
+    assert!(Action::list_topologically(ctx).await?.is_empty());
+    value::set(ctx, ("taylor swift", "/si/name"), "travis kelce").await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    let mut actions = Action::list_topologically(ctx).await?;
+    assert_eq!(1, actions.len());
+    let action_id = actions.pop().unwrap();
+    let prototype = Action::prototype(ctx, action_id).await?;
+    assert_eq!(ActionKind::Update, prototype.kind);
+
+    // Put the action "OnHold" to ensure it stays on HEAD after apply. Then, apply the change set to HEAD.
+    Action::set_state(ctx, action_id, ActionState::OnHold).await?;
+    ChangeSetTestHelpers::commit_and_update_snapshot_to_visibility(ctx).await?;
+    ChangeSetTestHelpers::apply_change_set_to_base(ctx).await?;
+    ChangeSetTestHelpers::wait_for_actions_to_run(ctx).await?;
+
+    // Switch to the "beta" change set and ensure that the action does not exist. Before the change
+    // introduced alongside this test, the action would exist in this change set, but not point to
+    // a component. In the UI, the action would looked "orphaned" to the end user.
+    ctx.update_visibility_and_snapshot_to_visibility(beta_change_set_id)
+        .await?;
+    assert!(Action::list_topologically(ctx).await?.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This change prevents orphaned update actions in a non-HEAD change set by adding a correct transform. The transform ensures that the action has a corresponding component in either the graph or the list of updates.

This change also refactors the correct transforms in the action node weight module to separate scenarios where the node exists on the graph or not. The split graph implementation remains knowingly untested (checked with @zacharyhamm), but has been ported.

Finally, this change uses an "is subset" check rather than a "difference" check for both the attribute prototype argument node (PR https://github.com/systeminit/si/pull/7571) to ensure we do not remove updates when "valid additions" occur. This is the same motion used for action nodes in this PR.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNDV4aG5mYTRiNG1iazNjbW96cjNzaDk0aWd5Yzl6YTk4NnUxNzFkeiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3ohze2Pewc9VRVJkuA/giphy.gif"/>

## Testing

1. Have a component with a resource on HEAD
2. Create two change sets, "A" and "B"
3. In change set "B", erase the component
4. In change set "A", change one field that will trigger an update action, put that action on hold, and then apply the change set
5. Switch to change set "B", and see that no actions exists (without this change an "orphaned" action would exist)