### PR TITLE
style(fmt): format snapshot-eviction `Cargo.toml` via `fix-format-toml`

### DIFF
--- a/lib/snapshot-eviction/Cargo.toml
+++ b/lib/snapshot-eviction/Cargo.toml
@@ -1,32 +1,24 @@
 [package]
 name = "snapshot-eviction"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
 
 [dependencies]
-# Configuration
+chrono = { workspace = true }
 serde = { workspace = true }
-
-# Async runtime
-tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true }
-
-# Database and caching
-si-data-pg = { path = "../si-data-pg" }
-si-layer-cache = { path = "../si-layer-cache" }
-
-# Events
-si-events = { path = "../si-events-rs" }
 si-data-nats = { path = "../si-data-nats" }
-
-# Observability
+si-data-pg = { path = "../si-data-pg" }
+si-events = { path = "../si-events-rs" }
+si-layer-cache = { path = "../si-layer-cache" }
 telemetry = { path = "../telemetry-rs" }
 telemetry-utils = { path = "../telemetry-utils-rs" }
-
-# Error handling
 thiserror = { workspace = true }
-
-# Time
-chrono = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This way the crate's Cargo.toml format check won't fail the next time it's updated

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlN2FyenZveWFxYjkwYzZkMW9tenpza3h6ZWM2aWV1cTdpejA4aXVodCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/aUCj0Y42WTG224roZA/giphy.gif"/>