### PR TITLE
fix(dal): Allow searching for schema names case insensitive

### DIFF
--- a/lib/dal/src/cached_module.rs
+++ b/lib/dal/src/cached_module.rs
@@ -422,7 +422,7 @@ impl CachedModule {
                 SELECT DISTINCT ON (schema_id)
                     {CACHED_MODULE_GET_FIELDS}
                 FROM cached_modules
-                WHERE schema_name = $1
+                WHERE LOWER(schema_name) = LOWER($1)
                 ORDER BY schema_id, created_at DESC
             "
         );

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -579,7 +579,7 @@ impl Schema {
                     .get_content_node_weight_of_kind(ContentAddressDiscriminants::Schema)?
             };
             let schema = Self::get_by_id(ctx, schema_node_weight.id().into()).await?;
-            if schema.name == name.as_ref() {
+            if schema.name.eq_ignore_ascii_case(name.as_ref()) {
                 return Ok(Some(schema));
             }
         }

--- a/lib/dal/tests/integration_test/schema/variant.rs
+++ b/lib/dal/tests/integration_test/schema/variant.rs
@@ -256,6 +256,40 @@ async fn list_user_facing_works(ctx: &DalContext) {
         .expect("could not list user facing schema variants");
 }
 
+#[test]
+async fn find_schema_case_insensitive(ctx: &DalContext) {
+    let schema_name = "AWS::VpcLattice::Service";
+    let schema = Schema::new(ctx, schema_name)
+        .await
+        .expect("could not create schema");
+
+    assert_eq!(schema_name, schema.name());
+
+    let found_schema = Schema::get_by_name_opt(ctx, "aws::vpclattice::service")
+        .await
+        .expect("could not search for schema")
+        .expect("schema not found with lowercase name");
+
+    assert_eq!(schema.id(), found_schema.id());
+    assert_eq!(schema.name(), found_schema.name());
+
+    let found_schema_upper = Schema::get_by_name_opt(ctx, "AWS::VPCLattice::Service")
+        .await
+        .expect("could not search for schema")
+        .expect("schema not found with mixed case name");
+
+    assert_eq!(schema.id(), found_schema_upper.id());
+    assert_eq!(schema.name(), found_schema_upper.name());
+
+    let found_schema_mixed = Schema::get_by_name_opt(ctx, "AWS::VPCLATTICE::SERVICE")
+        .await
+        .expect("could not search for schema")
+        .expect("schema not found with upper case name");
+
+    assert_eq!(schema.id(), found_schema_mixed.id());
+    assert_eq!(schema.name(), found_schema_mixed.name());
+}
+
 fn prepare_for_assertion(expected: &[&str], all_funcs: &[Func]) -> (Vec<String>, Vec<String>) {
     let expected = expected.iter().map(|s| s.to_string()).collect();
 


### PR DESCRIPTION
```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 295 filtered out; finished in 6.78s
```

The find_schema endpoint in luminork now performs case-insensitive searches when looking up schemas by name. Previously, searching for "aws" when the schema was named "AWS" would fail to find the schema.

Users expect schema name searches to be case-insensitive, as schema names often contain mixed case (e.g., "AWS::VPCLattice::Service", "DockerImage"). This caused friction when:
  - Users typed schema names in different cases than they were stored
  - API consumers had to know the exact casing of schema names
  - Schema names with acronyms (AWS, VPC, etc.) were particularly problematic
