### PR TITLE
Add clover quickstart guide

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -608,6 +608,10 @@ You can combine this with the `DEBUG` environment variable for `lang-js` for eve
 DEBUG=* SI_TEST_LOG=info buck2 run <CRATE>:test-integration -- <PATTERN> -- --nocapture
 ```
 
+# Generating Clover Schemas
+
+See the [README in `bin/clover`](bin/clover/README.md) for more information.
+
 # Preparing Your Pull Request
 
 This section contains information related to preparing changes for a pull request.

--- a/bin/clover/README.md
+++ b/bin/clover/README.md
@@ -1,23 +1,51 @@
-clover generates full AWS asset coverage for all resource types in the
-[Cloudformation schema](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html).
+# Clover
 
-# Initial Setup
+Clover generates full AWS schema coverage for all resource types in the
+[Cloudformation schema](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html).
+It may be used to generate schemas for other providers in the future.
+
+## Quickstart
+
+This guide is for using generated Clover schemas for a local dev SI instance.
+
+1. Run an instance of SI locally. See the [README](../../README.md) for more details.
+1. In your local workspace, find the bearer token. You can find it in the headers of any request made to the SI backend and it starts with "Bearer". Or you can make and use a Workspace token following [this guide](https://docs.systeminit.com/reference/workspaces#generate-api-token).
+1. Copy the token to a safe location and remove the leading "Bearer" portion.
+1. Open your terminal for the next steps.
+1. Make your bearer token available for clover: `export SI_BEARER_TOKEN=<your-token>`.
+1. Change to the clover directory: `cd bin/clover`.
+1. Initialize the git submodule: `git submodule init src/provider-schemas/azure-rest-api-specs`.
+1. Change to the si-specs directory: `cd si-specs`.
+1. Generate clover schemas using `deno`. For this guide, we'll use Azure: `deno task run generate-specs --provider=azure`. The directory will contain all generated Azure schemas.
+1. In your local workspace in your browser, navigate to the customization screen.
+1. On the upper left, switch to the "MODULES (INTERNAL)" tab and click the upload to cloud button. You'll be prompted to choose which files to upload. The file names correspond with the modules that will be uploaded. You can find the generated JSON files in `bin/clover/si-specs`
+1. In either a newly created change set or your non-HEAD change set, you will now be able to create components with your Azure module(s)!
+
+> [!TIP]
+> If you have issues generating schemas, you may need to ensure you are using your local module index or that your submodule need to be re-configured.
+>
+> For the former, run the following command: `unset SI_MODULE_INDEX_URL`.
+> This ensures that clover will use default settings for generation.
+>
+> For the latter, you may need to update the submodule with `git submodule update` or to de-initialize the submodule and start over via `git submodule deinit -f src/provider-schemas/azure-rest-api-specs` (assuming you are using Azure).
+
+## Initial Setup for Development
 
 Before you can run the schema generator, you must download the latest
 [Cloudformation resource type schema](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html)
 to cloudformation-schema/*.json:
 
-```sh
-$ deno task run fetch-schema
+```shell
+deno task run fetch-schema
 ```
 
-# Generating Assets
+## Generating Schemas
 
 This will fetch the current ID for each schema, and then regenerate all schemas
 into the si-specs directory.
 
-```sh
-$ deno task run generate-specs [...SCHEMA]
+```shell
+deno task run generate-specs [...SCHEMA]
 ```
 
 - `generate-specs` with no arguments to regenerate all specs
@@ -30,7 +58,7 @@ $ deno task run generate-specs [...SCHEMA]
   production--they will have the wrong module IDs.**)
 - `LOG_LEVEL=debug` (or info, warning, error) for log output
 
-## Diffing Your Changes
+### Diffing Your Changes
 
 When you have changed heuristics, you will want to look at the differences--but
 the specs contain ULIDs, which change each time. You can run
@@ -60,28 +88,28 @@ the anonymized specs to see what your heuristic affected.
 
 4. Repeat steps 2-3 until satisfied.
 
-## Note about Asset Code changes
+### Note about Schema Code changes
 
-If you are changing a lot of asset functions themselves, every package will show
+If you are changing a lot of schema functions themselves, every package will show
 `codeBase64` changed, which is a giant blob and can get overwhelming.
 
 To exclude codeBase64, add this to anonymize-specs.sh:
 
-```sh
-$ ./anonymize-specs.sh --remove-props ".funcs[].data.codeBase64"
+```shell
+./anonymize-specs.sh --remove-props ".funcs[].data.codeBase64"
 ```
 
-Just note that if you do this, you won't know which modules had their asset code
+Just note that if you do this, you won't know which modules had their schema code
 changed! Don't run it all the time.
 
-# Running tests
+## Running tests
 
-```sh
-$ buck2 run //bin/clover:test-unit
+```shell
+buck2 run //bin/clover:test-unit
 ```
 
-## Changing log output
+### Changing log output
 
-```sh
-$ env LOG_LEVEL=verbose deno test --unstable-sloppy-imports -A
+```shell
+env LOG_LEVEL=verbose deno test --unstable-sloppy-imports -A
 ```


### PR DESCRIPTION
This change adds a quickstart guide for clover. It also reformats the guide to match "DEV_DOCS" conventions.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOW5xeG1meHRyMmtjNXZxajNvajNjOWhjODZyd2c1ejlmdmo2anU1diZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Kxhjn8IbCXMggzNVfV/giphy.gif"/>
