### PR TITLE
refactoring/updates to genericize MCP away from AWS

### DIFF
--- a/bin/si-mcp-server/README.md
+++ b/bin/si-mcp-server/README.md
@@ -1,6 +1,8 @@
 # System Initiative MCP Server
 
-A Model Context Protocol (MCP) server that provides Claude Code with direct access to System Initiative's API for managing infrastructure components, change sets, schemas, and actions.
+A Model Context Protocol (MCP) server that provides Claude Code with direct
+access to System Initiative's API for managing infrastructure components, change
+sets, schemas, and actions.
 
 ## Development Setup
 
@@ -31,7 +33,7 @@ deno task inspector
 This opens a browser interface where you can:
 
 - Test individual tools with parameters
-- Inspect tool schemas and validate responses  
+- Inspect tool schemas and validate responses
 - Debug authentication and connection issues
 - View real-time tool execution
 
@@ -52,13 +54,13 @@ claude mcp list
 
 ## Available Tasks
 
-| Task | Command | Description |
-|------|---------|-------------|
-| `dev` | `deno task dev` | Run with auto-reload for development |
-| `inspector` | `deno task inspector` | Start MCP Inspector for testing |
-| `build` | `deno task build` | Compile to standalone binary |
-| `docker:build` | `deno task docker:build` | Build Docker image |
-| `docker:run` | `deno task docker:run` | Run Docker container |
+| Task           | Command                  | Description                          |
+| -------------- | ------------------------ | ------------------------------------ |
+| `dev`          | `deno task dev`          | Run with auto-reload for development |
+| `inspector`    | `deno task inspector`    | Start MCP Inspector for testing      |
+| `build`        | `deno task build`        | Compile to standalone binary         |
+| `docker:build` | `deno task docker:build` | Build Docker image                   |
+| `docker:run`   | `deno task docker:run`   | Run Docker container                 |
 
 ## Adding New Tools
 

--- a/bin/si-mcp-server/src/data/actions.ts
+++ b/bin/si-mcp-server/src/data/actions.ts
@@ -2,8 +2,12 @@ import { z } from "zod";
 
 export const ActionSchemaRaw = {
   actionId: z.string().describe("the action id"),
-  componentId: z.string().nullable().optional().describe("the component id the action is on"),
-  componentName: z.string().optional().describe("the component name the action is on"),
+  componentId: z.string().nullable().optional().describe(
+    "the component id the action is on",
+  ),
+  componentName: z.string().optional().describe(
+    "the component name the action is on",
+  ),
   funcRunId: z.string().nullable().optional().describe(
     "the function run id for the last executed function for this action",
   ),

--- a/bin/si-mcp-server/src/data/schemaAttributes.ts
+++ b/bin/si-mcp-server/src/data/schemaAttributes.ts
@@ -90,8 +90,8 @@ function collectFlatAttributes(
 
     switch (node.propType) {
       case "object": {
-        const hasChildren =
-          Array.isArray(node.children) && node.children.length > 0;
+        const hasChildren = Array.isArray(node.children) &&
+          node.children.length > 0;
         if (hasChildren) {
           collectFlatAttributes(node.children!, nodePath, outAttrs, outDocs);
         } else {
@@ -102,8 +102,8 @@ function collectFlatAttributes(
 
       case "array": {
         const arrayPath = `${nodePath}/[array]`;
-        const hasChildren =
-          Array.isArray(node.children) && node.children.length > 0;
+        const hasChildren = Array.isArray(node.children) &&
+          node.children.length > 0;
 
         if (!hasChildren) {
           addLeaf(outAttrs, outDocs, node, arrayPath);
@@ -112,8 +112,8 @@ function collectFlatAttributes(
 
         for (const item of node.children!) {
           if (item.propType === "object") {
-            const itemHasChildren =
-              Array.isArray(item.children) && item.children.length > 0;
+            const itemHasChildren = Array.isArray(item.children) &&
+              item.children.length > 0;
             if (itemHasChildren) {
               collectFlatAttributes(
                 item.children!,
@@ -204,8 +204,7 @@ export function buildDocumentationForPaths(
 ): SchemaDocumentationData {
   const docsIndex = buildAttributeDocsIndex(variant);
   const attributes = schemaAttributePaths.map((p) => {
-    const documentation =
-      formatDocumentation(docsIndex, p) ??
+    const documentation = formatDocumentation(docsIndex, p) ??
       "There is no documentation for this attribute; if it is an AWS schema, consider looking up the data for the corresponding cloudformation resource";
     return { schemaAttributePath: p, documentation };
   });

--- a/bin/si-mcp-server/src/server.ts
+++ b/bin/si-mcp-server/src/server.ts
@@ -31,7 +31,6 @@ import { templateListTool } from "./tools/templateList.ts";
 import { changeSetAbandonTool } from "./tools/changeSetAbandon.ts";
 import { changeSetForceApplyTool } from "./tools/changeSetForceApply.ts";
 
-
 export function createServer(): McpServer {
   const server = new McpServer({
     name: "si-server",

--- a/bin/si-mcp-server/src/tools/changeSetAbandon.ts
+++ b/bin/si-mcp-server/src/tools/changeSetAbandon.ts
@@ -12,7 +12,8 @@ import {
 
 const name = "change-set-abandon";
 const title = "Abandon a change set";
-const description = `<description>Abandon a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon a change set. You may *never* abandon the HEAD change set.</usage>`;
+const description =
+  `<description>Abandon a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Abandon a change set. You may *never* abandon the HEAD change set.</usage>`;
 
 const AbandonChangeSetInputSchemaRaw = {
   changeSetId: z.string().describe("the ID of the change set to abandon"),

--- a/bin/si-mcp-server/src/tools/changeSetForceApply.ts
+++ b/bin/si-mcp-server/src/tools/changeSetForceApply.ts
@@ -12,7 +12,8 @@ import {
 
 const name = "change-set-force-apply";
 const title = "Force apply a change set";
-const description = `<description>Force apply a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Force apply a change set. This tool will avoid *all* workspace approval flows and apply directly to HEAD. You may *never* force apply the HEAD change set.</usage>`;
+const description =
+  `<description>Force apply a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Force apply a change set. This tool will avoid *all* workspace approval flows and apply directly to HEAD. You may *never* force apply the HEAD change set.</usage>`;
 
 const ForceApplyChangeSetInputSchemaRaw = {
   changeSetId: z.string().describe("the ID of the change set to force apply"),

--- a/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
+++ b/bin/si-mcp-server/src/tools/changeSetUpdateStatus.ts
@@ -12,7 +12,8 @@ import {
 
 const name = "change-set-update-status";
 const title = "Apply a change set";
-const description = `<description>Apply a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Apply a change set. If the change set requires approval, you should be told that it's waiting for approval on the web application and you should review the changes on that page before merging. You may *never* update the status of the HEAD change set.</usage>`;
+const description =
+  `<description>Apply a change set. Returns 'success' if the status was changed. On failure, returns error details</description><usage>Use this tool to Apply a change set. If the change set requires approval, you should be told that it's waiting for approval on the web application and you should review the changes on that page before merging. You may *never* update the status of the HEAD change set.</usage>`;
 
 const UpdateChangeSetInputSchemaRaw = {
   changeSetId: z.string().describe("the ID of the change set to apply"),

--- a/bin/si-mcp-server/src/tools/componentCreate.ts
+++ b/bin/si-mcp-server/src/tools/componentCreate.ts
@@ -23,7 +23,9 @@ const CreateComponentInputSchemaRaw = {
   schemaName: z.string().describe("the schema name of the component to create"),
   componentName: z.string().describe("the name of the component to create"),
   attributes: AttributesSchema,
-  useWorkingCopy: z.boolean().optional().describe("Set this boolean to true in order to create a component using the current working copy of the schema. If the user has been editing the schema of this component, use the working copy. Do not mention schema variants or locked/unlocked to the user. Instead, refer to the unlocked schema variant as the current working copy of the schema."),
+  useWorkingCopy: z.boolean().optional().describe(
+    "Set this boolean to true in order to create a component using the current working copy of the schema. If the user has been editing the schema of this component, use the working copy. Do not mention schema variants or locked/unlocked to the user. Instead, refer to the unlocked schema variant as the current working copy of the schema.",
+  ),
 };
 
 const CreateComponentOutputSchemaRaw = {

--- a/bin/si-mcp-server/src/tools/componentList.ts
+++ b/bin/si-mcp-server/src/tools/componentList.ts
@@ -10,16 +10,15 @@ import {
 import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
 import {
   errorResponse,
+  findHeadChangeSet,
   generateDescription,
   successResponse,
   withAnalytics,
 } from "./commonBehavior.ts";
-import { ChangeSet } from "../data/changeSets.ts";
 
 const name = "component-list";
 const title = "List components";
-const description =
-  `
+const description = `
   <important>
       *DO NOT USE THIS TOOL FOR TEMPLATE GENERATION:*
       - For template generation, use the template-generate tool's built-in search functionality
@@ -105,25 +104,11 @@ export function componentListTool(server: McpServer) {
       return await withAnalytics(name, async () => {
         if (!changeSetId) {
           const changeSetsApi = new ChangeSetsApi(apiConfig);
-          try {
-            const changeSetList = await changeSetsApi.listChangeSets({
-              workspaceId: WORKSPACE_ID,
-            });
-            const changeSets = changeSetList.data.changeSets as ChangeSet[];
-            const head = changeSets.find((cs) => cs.isHead);
-            if (!head) {
-              return errorResponse({
-                message: "Could not find HEAD change set",
-              });
-            }
-            changeSetId = head.id;
-          } catch (error) {
-            return errorResponse({
-              message:
-                `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${
-                  error instanceof Error ? error.message : String(error)
-                }`,
-            });
+          const headChangeSet = await findHeadChangeSet(changeSetsApi, false);
+          if (headChangeSet.changeSetId) {
+            changeSetId = headChangeSet.changeSetId;
+          } else {
+            return errorResponse(headChangeSet);
           }
         }
         try {

--- a/bin/si-mcp-server/src/tools/funcRunGet.ts
+++ b/bin/si-mcp-server/src/tools/funcRunGet.ts
@@ -5,16 +5,17 @@ import { ChangeSetsApi, FuncsApi } from "@systeminit/api-client";
 import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
 import {
   errorResponse,
+  findHeadChangeSet,
   generateDescription,
   successResponse,
   withAnalytics,
 } from "./commonBehavior.ts";
-import { ChangeSetItem } from "../data/changeSets.ts";
 import { decodeBase64 } from "@std/encoding/base64";
 
 const name = "func-run-get";
 const title = "Get a function run information";
-const description = `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
+const description =
+  `<description>Get the information about a function exeuction run. Returns the state of the function run, the componentId and componentName it was for, the schemaName, and the function name, description, kind, arguments, and result - if asked, it will also return the logs and the executed source code. On failure, returns error details</description><usage>Use this tool when the user asks you to work with or troubleshoot a function run - for example, when an action, qualification, or other kind of function as failed.</usage>`;
 
 const GetFuncRunInputSchemaRaw = {
   changeSetId: z
@@ -163,26 +164,11 @@ export function funcRunGetTool(server: McpServer) {
       return await withAnalytics(name, async () => {
         if (!changeSetId) {
           const changeSetsApi = new ChangeSetsApi(apiConfig);
-          try {
-            const changeSetList = await changeSetsApi.listChangeSets({
-              workspaceId: WORKSPACE_ID,
-            });
-            const head = (
-              changeSetList.data.changeSets as ChangeSetItem[]
-            ).find((cs) => cs.isHead);
-            if (!head) {
-              return errorResponse({
-                message:
-                  "No HEAD change set found; this is a bug! Tell the user we are sorry.",
-              });
-            }
-            changeSetId = head.id;
-          } catch (error) {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
-            return errorResponse({
-              message: `No change set id was provided, and we could not find HEAD; this is a bug! Tell the user we are sorry: ${errorMessage}`,
-            });
+          const headChangeSet = await findHeadChangeSet(changeSetsApi, false);
+          if (headChangeSet.changeSetId) {
+            changeSetId = headChangeSet.changeSetId;
+          } else {
+            return errorResponse(headChangeSet);
           }
         }
 
@@ -200,8 +186,7 @@ export function funcRunGetTool(server: McpServer) {
             componentId: response.data.funcRun.componentId,
             componentName: response.data.funcRun.componentName,
             schemaName: response.data.funcRun.schemaName,
-            functionName:
-              response.data.funcRun.functionDisplayName ||
+            functionName: response.data.funcRun.functionDisplayName ||
               response.data.funcRun.functionName,
             functionKind: response.data.funcRun
               .functionKind as FuncRunResult["functionKind"],

--- a/bin/si-mcp-server/src/tools/schemaAttributesList.ts
+++ b/bin/si-mcp-server/src/tools/schemaAttributesList.ts
@@ -3,24 +3,28 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   errorResponse,
+  findHeadChangeSet,
   generateDescription,
   successResponse,
   withAnalytics,
 } from "./commonBehavior.ts";
 import { ChangeSetsApi, SchemasApi } from "@systeminit/api-client";
-import { ChangeSetItem } from "../data/changeSets.ts";
 import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
 import { buildAttributesStructure } from "../data/schemaAttributes.ts";
+import { isValid } from "ulid";
 
 const name = "schema-attributes-list";
 const title = "List all the attributes of a schema";
 const description =
-  `<description>Lists all the attributes of a schema. Returns the schema name and an array of attribute objects that contain the Attribute Name, Path, and if it is Required. On failure, returns error details. Only supports AWS schemas.</description><usage>Use this tool to discover what attributes (sometimes called properties) are available for a schema.</usage>`;
+  `<description>Lists all the attributes of a schema. Returns the schema name and an array of attribute objects that contain the Attribute Name, Path, and if it is Required. On failure, returns error details.</description><usage>Use this tool to discover what attributes (sometimes called properties) are available for a schema.</usage>`;
 
 const ListSchemaAttributesInputSchemaRaw = {
-  schemaName: z
-    .string()
-    .describe("The Schema Name to retrieve the attributes for"),
+  schemaNameOrId: z.string().describe(
+    "The Schema Name or Schema ID to retrieve the attributes for.",
+  ),
+  changeSetId: z.string().optional().describe(
+    "The change set to retreive the schema attributes in. If none is provided, the HEAD change set is used.",
+  ),
 };
 
 const ListSchemaAttributesOutputSchemaRaw = {
@@ -76,78 +80,48 @@ export function schemaAttributesListTool(server: McpServer) {
       inputSchema: ListSchemaAttributesInputSchemaRaw,
       outputSchema: ListSchemaAttributesOutputSchemaRaw,
     },
-    async ({ schemaName }): Promise<CallToolResult> => {
+    async ({ schemaNameOrId, changeSetId }): Promise<CallToolResult> => {
       return await withAnalytics(name, async () => {
         let responseData: ListSchemaAttributesOutput["data"];
 
-        let changeSetId = "";
-        const changeSetsApi = new ChangeSetsApi(apiConfig);
-        try {
-          const changeSetList = await changeSetsApi.listChangeSets({
-            workspaceId: WORKSPACE_ID,
-          });
-          const head = (changeSetList.data.changeSets as ChangeSetItem[]).find(
-            (cs) => cs.isHead,
-          );
-          if (!head) {
-            return errorResponse({
-              message:
-                "No HEAD change set found; this is a bug! Tell the user we are sorry.",
-            });
+        if (!changeSetId) {
+          const changeSetsApi = new ChangeSetsApi(apiConfig);
+          const headChangeSet = await findHeadChangeSet(changeSetsApi, false);
+          if (headChangeSet.changeSetId) {
+            changeSetId = headChangeSet.changeSetId;
+          } else {
+            return errorResponse(headChangeSet);
           }
-          changeSetId = head.id;
-        } catch (error) {
-          const errorMessage = error instanceof Error
-            ? error.message
-            : String(error);
-          return errorResponse({
-            message:
-              `We could not find the HEAD change set; this is a bug! Tell the user we are sorry: ${errorMessage}`,
-          });
         }
 
-        const siApi = new SchemasApi(apiConfig);
+        const siSchemasApi = new SchemasApi(apiConfig);
         try {
-          if (schemaName.startsWith("AWS::IAM")) {
-            switch (schemaName) {
-              case "AWS::IAM::User":
-              case "AWS::IAM::Role":
-              case "AWS::IAM::Group":
-              case "AWS::IAM::ManagedPolicy":
-              case "AWS::IAM::UserPolicy":
-              case "AWS::IAM::RolePolicy":
-              case "AWS::IAM::InstanceProfile":
-                break;
-              default:
-                return errorResponse({
-                  message:
-                    "AWS::IAM schema not found. Use one of AWS::IAM::User, AWS::IAM::Role, AWS::IAM::RolePolicy, AWS::IAM::UserPolicy, AWS::IAM::ManagedPolicy, AWS::IAM::InstanceProfile, or AWS::IAM::Group.",
-                });
-            }
-          }
-
           let schemaId = "";
-          try {
-            const response = await siApi.findSchema({
-              workspaceId: WORKSPACE_ID,
-              changeSetId: changeSetId!,
-              schema: schemaName,
-            });
-            schemaId = response.data.schemaId;
-          } catch (error) {
-            const errorMessage = error instanceof Error
-              ? error.message
-              : String(error);
-            return errorResponse({
-              message:
-                `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
-            });
+          if (!isValid(schemaNameOrId)) {
+            try {
+              const response = await siSchemasApi.findSchema({
+                workspaceId: WORKSPACE_ID,
+                changeSetId: changeSetId!,
+                schema: schemaNameOrId,
+              });
+              schemaId = response.data.schemaId;
+            } catch (error) {
+              const errorMessage = error instanceof Error
+                ? error.message
+                : String(error);
+              return errorResponse({
+                message:
+                  `Unable to find the schema - check the name and try again. Tell the user we are sorry: ${errorMessage}`,
+              });
+            }
+          } else {
+            schemaId = schemaNameOrId;
           }
 
-          const response = await siApi.getDefaultVariant({
+          const response = await siSchemasApi.getDefaultVariant({
             workspaceId: WORKSPACE_ID,
             changeSetId: changeSetId!,
-            schemaId: schemaId,
+            schemaId,
           });
 
           if (response.status === 202) {
@@ -165,7 +139,7 @@ export function schemaAttributesListTool(server: McpServer) {
 
           return successResponse(
             responseData,
-            "You can use a web search to find the cloudformation schema",
+            "For AWS schemas, you can use a web search to find the cloudformation schema",
           );
         } catch (error) {
           return errorResponse(error);

--- a/bin/si-mcp-server/src/tools/schemaCreateEditGet.ts
+++ b/bin/si-mcp-server/src/tools/schemaCreateEditGet.ts
@@ -1,6 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { SchemasApi, FuncsApi, SchemaVariantFunc } from "@systeminit/api-client";
+import {
+  FuncsApi,
+  SchemasApi,
+  SchemaVariantFunc,
+} from "@systeminit/api-client";
 import { apiConfig, WORKSPACE_ID } from "../si_client.ts";
 import {
   errorResponse,
@@ -31,15 +35,21 @@ const schemaCreateEditGetInputSchemaRaw = {
     .describe(
       "The change set to create, edit, or get a schema in; schemas cannot be manipulated on HEAD.",
     ),
-  name: z.string().min(1).optional().describe("The name of the schema. A name is required for creating a new schema."),
+  name: z.string().min(1).optional().describe(
+    "The name of the schema. A name is required for creating a new schema.",
+  ),
   description: z.string().optional().describe("The description of the schema."),
-  schemaId: z.string().optional().describe("The id of the schema you want to edit. If none is given, create a new schema. If only a change set id and schema id are given, just get information about the schema."),
+  schemaId: z.string().optional().describe(
+    "The id of the schema you want to edit. If none is given, create a new schema. If only a change set id and schema id are given, just get information about the schema.",
+  ),
   link: z
     .string()
     .optional()
     .describe("A link to documentation about the thing the schema represents."),
   category: z.string().optional().describe("The category of the schema"),
-  color: z.string().optional().describe("The schema's color. Must be a hex color, convert any color words into a hex value."),
+  color: z.string().optional().describe(
+    "The schema's color. Must be a hex color, convert any color words into a hex value.",
+  ),
   definitionFunction: z
     .string()
     .optional()
@@ -164,7 +174,9 @@ const schemaCreateEditGetOutputSchemaRaw = {
           kind: z.literal("action").describe("the function kind"),
         }),
         z.object({
-          managementFuncKind: z.string().describe("the management function kind"),
+          managementFuncKind: z.string().describe(
+            "the management function kind",
+          ),
           kind: z.literal("management").describe("the function kind"),
         }),
         z.object({
@@ -175,8 +187,12 @@ const schemaCreateEditGetOutputSchemaRaw = {
     })).describe("the functions attached to the schema"),
   }),
 };
-const schemaCreateEditGetOutputSchema = z.object(schemaCreateEditGetOutputSchemaRaw);
-type SchemaCreateEditGetOutputData = z.infer<typeof schemaCreateEditGetOutputSchema>["data"];
+const schemaCreateEditGetOutputSchema = z.object(
+  schemaCreateEditGetOutputSchemaRaw,
+);
+type SchemaCreateEditGetOutputData = z.infer<
+  typeof schemaCreateEditGetOutputSchema
+>["data"];
 
 export function schemaCreateEditGetTool(server: McpServer) {
   server.registerTool(
@@ -191,12 +207,23 @@ export function schemaCreateEditGetTool(server: McpServer) {
       inputSchema: schemaCreateEditGetInputSchemaRaw,
       outputSchema: schemaCreateEditGetOutputSchemaRaw,
     },
-    async ({ changeSetId, definitionFunction, schemaId, ...createOrEditSchemaV1Request }) => {
+    async (
+      {
+        changeSetId,
+        definitionFunction,
+        schemaId,
+        ...createOrEditSchemaV1Request
+      },
+    ) => {
       return await withAnalytics(toolName, async () => {
         const siSchemasApi = new SchemasApi(apiConfig);
         const siFuncsApi = new FuncsApi(apiConfig);
 
-        let hints, touchedSchemaId, touchedDefinitionFunction, touchedName: string, touchedFunctions;
+        let hints,
+          touchedSchemaId,
+          touchedDefinitionFunction,
+          touchedName: string,
+          touchedFunctions;
 
         try {
           if (schemaId) {
@@ -230,15 +257,23 @@ export function schemaCreateEditGetTool(server: McpServer) {
 
             // populate data to return from the tool
             touchedSchemaId = schemaId;
-            touchedDefinitionFunction = definitionFunction ?? responseGetFunc.data.code;
-            touchedName = createOrEditSchemaV1Request.name ?? responseGetVariant.data.displayName;
+            touchedDefinitionFunction = definitionFunction ??
+              responseGetFunc.data.code;
+            touchedName = createOrEditSchemaV1Request.name ??
+              responseGetVariant.data.displayName;
             touchedFunctions = responseGetVariant.data.variantFuncs;
 
             // information gathering complete, now only move onto updating if we have new data
-            if (definitionFunction || Object.values(createOrEditSchemaV1Request).some(value => value != undefined)) {
+            if (
+              definitionFunction ||
+              Object.values(createOrEditSchemaV1Request).some((value) =>
+                value != undefined
+              )
+            ) {
               // if this schema is a builtin, we need to warn the user accordingly
               if (responseGetVariant.data.installedFromUpstream) {
-                hints = "Warn the user that because this schema was created by System Initiative that they will lose their customizations to it if they upgrade the schema. Repeat this warning every time the user edits any builtin schema.";
+                hints =
+                  "Warn the user that because this schema was created by System Initiative that they will lose their customizations to it if they upgrade the schema. Repeat this warning every time the user edits any builtin schema.";
               }
 
               // so that we can build the final request with the current data as the default
@@ -275,11 +310,12 @@ export function schemaCreateEditGetTool(server: McpServer) {
             if (!name) {
               return errorResponse({
                 message: "A name is required to make a new schema.",
-                hints: "Ask the user to give this new schema a name."
+                hints: "Ask the user to give this new schema a name.",
               });
             }
 
-            const code = definitionFunction ?? DEFAULT_SCHEMA_DEFINITION_FUNCTION;
+            const code = definitionFunction ??
+              DEFAULT_SCHEMA_DEFINITION_FUNCTION;
 
             // next we call the endpoint to create a new schema
             const responseCreate = await siSchemasApi.createSchema({

--- a/bin/si-mcp-server/src/tools/templateGenerate.ts
+++ b/bin/si-mcp-server/src/tools/templateGenerate.ts
@@ -11,9 +11,9 @@ import {
 } from "./commonBehavior.ts";
 
 const name = "template-generate";
-const title = "Generate a template from user provided or searched for componentIds";
-const description =
-  `
+const title =
+  "Generate a template from user provided or searched for componentIds";
+const description = `
   <important>
   Do not use the component-list tool, *always* prefer this tools search functionality.
   </important>
@@ -83,7 +83,7 @@ const TemplateGenerateInputSchemaRaw = {
 
     </documentation>
 
-    `
+    `,
   ),
   templateName: z.string().describe(
     "the name of the template that will be generated",
@@ -178,16 +178,23 @@ export function templateGenerateTool(server: McpServer) {
               q: searchQuery,
             });
 
-            templateComponentIds = searchResponse.data.components.map((component) => component.id);
+            templateComponentIds = searchResponse.data.components.map((
+              component,
+            ) => component.id);
 
             if (templateComponentIds.length < 1) {
-              return errorResponse("No components found for the provided search query.");
+              return errorResponse(
+                "No components found for the provided search query.",
+              );
             }
-
           } else if (hasListOfIds && searchQuery) {
-            return errorResponse("You cannot use both a list of componentIds and a search query.")
+            return errorResponse(
+              "You cannot use both a list of componentIds and a search query.",
+            );
           } else {
-            return errorResponse("You must provide either a list of componentIds or a search query.");
+            return errorResponse(
+              "You must provide either a list of componentIds or a search query.",
+            );
           }
 
           const response = await siComponentsApi.generateTemplate({

--- a/bin/si-mcp-server/src/validators/funcValidator.ts
+++ b/bin/si-mcp-server/src/validators/funcValidator.ts
@@ -18,18 +18,30 @@ export function validateFunctionCode(
 
   // Parameter heuristics by type (cheap, resilient):
   const paramSig = code.match(/function\s+main\s*\(([^)]*)\)/)?.[1] ?? "";
-  const hasInputParam = /\b(component|thisComponent|.*: ?Input)\b/.test(paramSig);
+  const hasInputParam = /\b(component|thisComponent|.*: ?Input)\b/.test(
+    paramSig,
+  );
 
   switch (functionType) {
     case "qualification": {
-      if (!hasInputParam) issues.push({ message: "Qualification main(component: Input) missing or malformed." });
+      if (!hasInputParam) {
+        issues.push({
+          message: "Qualification main(component: Input) missing or malformed.",
+        });
+      }
       if (!/\bresult\b/.test(code) || !/\bmessage\b/.test(code)) {
-        issues.push({ message: "Qualification must eventually return { result, message }." });
+        issues.push({
+          message: "Qualification must eventually return { result, message }.",
+        });
       }
       break;
     }
     case "codegen": {
-      if (!hasInputParam) issues.push({ message: "Codegen main(component: Input) missing or malformed." });
+      if (!hasInputParam) {
+        issues.push({
+          message: "Codegen main(component: Input) missing or malformed.",
+        });
+      }
       if (!/\bformat\b/.test(code) || !/\bcode\b/.test(code)) {
         issues.push({ message: "Codegen must return { format, code }." });
       }
@@ -38,48 +50,80 @@ export function validateFunctionCode(
     case "management": {
       // Typically needs { thisComponent, components } in Input and returns Output
       if (!/\{[^}]*thisComponent[^}]*\}/s.test(paramSig)) {
-        issues.push({ message: "Management main({ thisComponent, ... }: Input) is recommended." });
+        issues.push({
+          message:
+            "Management main({ thisComponent, ... }: Input) is recommended.",
+        });
       }
       break;
     }
     case "action": {
-      if (!hasInputParam) issues.push({ message: "Action main(component: Input) missing or malformed." });
+      if (!hasInputParam) {
+        issues.push({
+          message: "Action main(component: Input) missing or malformed.",
+        });
+      }
 
       if (actionKind === "Create") {
         // Create actions should use create/post operations, not get/describe
         if (/\b(get-resource|describe-)\w+/i.test(code)) {
-          issues.push({ message: "Create action appears to use get/describe operations instead of create operations." });
+          issues.push({
+            message:
+              "Create action appears to use get/describe operations instead of create operations.",
+          });
         }
         // Create should return resourceId on success
         if (!/\bresourceId\b/.test(code)) {
-          issues.push({ message: "Create action should return { resourceId, status } on success." });
+          issues.push({
+            message:
+              "Create action should return { resourceId, status } on success.",
+          });
         }
       } else if (actionKind === "Destroy") {
         // Destroy actions should use delete operations, not create/get
         if (/\b(create-resource)\b/i.test(code)) {
-          issues.push({ message: "Destroy action appears to use create operations instead of delete operations." });
+          issues.push({
+            message:
+              "Destroy action appears to use create operations instead of delete operations.",
+          });
         }
         // Destroy should return null payload on success
         if (!/payload:\s*null/.test(code)) {
-          issues.push({ message: "Destroy action should return { payload: null, status } on success." });
+          issues.push({
+            message:
+              "Destroy action should return { payload: null, status } on success.",
+          });
         }
       } else if (actionKind === "Refresh") {
         // Refresh should use get/describe operations
-        if (/\b(create-resource|delete-resource|update-resource)\b/i.test(code)) {
-          issues.push({ message: "Refresh action should only read/describe resources, not modify them." });
+        if (
+          /\b(create-resource|delete-resource|update-resource)\b/i.test(code)
+        ) {
+          issues.push({
+            message:
+              "Refresh action should only read/describe resources, not modify them.",
+          });
         }
         // Refresh should return payload
         if (!/\bpayload\b/.test(code)) {
-          issues.push({ message: "Refresh action should return { payload, status }." });
+          issues.push({
+            message: "Refresh action should return { payload, status }.",
+          });
         }
       } else if (actionKind === "Update") {
         // Update should use update/patch operations
         if (/\bcreate-resource\b/i.test(code)) {
-          issues.push({ message: "Update action appears to use create operations instead of update operations." });
+          issues.push({
+            message:
+              "Update action appears to use create operations instead of update operations.",
+          });
         }
         // Update should check for existing resource
         if (!/resource.*payload/.test(code)) {
-          issues.push({ message: "Update action should verify resource exists before updating." });
+          issues.push({
+            message:
+              "Update action should verify resource exists before updating.",
+          });
         }
       }
       // No specific validations for Manual functions since they can be very diverse!

--- a/bin/si-mcp-server/test/README-Testing.md
+++ b/bin/si-mcp-server/test/README-Testing.md
@@ -1,6 +1,8 @@
 # Testing the SI MCP Server
 
-This directory contains a testing setup for the System Initiative MCP Server using mcp-jest. The tests make **real API calls** to System Initiative using your credentials.
+This directory contains a testing setup for the System Initiative MCP Server
+using mcp-jest. The tests make **real API calls** to System Initiative using
+your credentials.
 
 ## Files Created
 
@@ -47,7 +49,7 @@ The tests verify:
 ## Environment Variables
 
 - `SI_API_TOKEN` - Your System Initiative API token (**required**)
-- `SI_BASE_URL` - API base URL (defaults to https://api.systeminit.com)  
+- `SI_BASE_URL` - API base URL (defaults to https://api.systeminit.com)
 - `SI_WORKSPACE_ID` - Workspace ID (extracted from token if not provided)
 
 ## Configuring Tests
@@ -60,18 +62,18 @@ const TEST_CONFIG = {
     "validate-credentials": {},
     "component-list": {},
     "change-set-list": {},
-    
+
     // Add tools with arguments:
     "change-set-create": {
       args: { changeSetName: "Test Change Set" },
     },
     "component-create": {
-      args: { 
+      args: {
         schemaVariantId: "your-schema-variant-id",
-        componentName: "Test Component"
-      }
+        componentName: "Test Component",
+      },
     },
-  }
+  },
 };
 ```
 

--- a/bin/si-mcp-server/test/test-runner.js
+++ b/bin/si-mcp-server/test/test-runner.js
@@ -90,8 +90,7 @@ async function runTests() {
           result?.isError ||
           result?.structuredContent?.status === "failure"
         ) {
-          const errorMsg =
-            result.structuredContent?.errorMessage ||
+          const errorMsg = result.structuredContent?.errorMessage ||
             "Tool returned error response";
           throw new Error(errorMsg);
         }


### PR DESCRIPTION
## How does this PR change the system?

This is the first set of work to refactor and update the SI AI Agent MCP tools to make them not AWS-specific in preparation for making the AI Agent multi-cloud, specifically to work with new Azure and Hetzner schemas.

Doing a format pass (`deno fmt`) meant that a lot of files changes in superficial ways, so the key changes are highlighted with comments.

#### Screenshots:

<img width="758" height="426" alt="Screenshot 2025-10-28 at 2 51 16 PM" src="https://github.com/user-attachments/assets/ee4f3de0-ca46-4576-9d50-3248efd8bca0" />

<img width="790" height="270" alt="Screenshot 2025-10-28 at 3 07 17 PM" src="https://github.com/user-attachments/assets/f98d845b-23e9-4bd5-b879-e99248ce84fa" />

#### Out of Scope:

This PR does not yet Azure or Hetzner specific logic.

## How was it tested?

Each modified tool was run through a basic set of tests using Claude to ensure each branch of its functionality is intact.

I also ran this multi-tool test with a few different Azure schemas to ensure overall functionality and integration of multiple tools -

- In X change set, please find the schema Y and get information about it. Then list its attributes, pick three at random, and print out documentation for each. Then create a component using the schema. Finally, add another property to the schema called "wiggler" and create another component of it using the working copy.