### PR TITLE
fix(clover): azure assets buried in version files

### DIFF
--- a/bin/clover/src/pipelines/azure/pipeline.ts
+++ b/bin/clover/src/pipelines/azure/pipeline.ts
@@ -46,10 +46,14 @@ async function getLatestAzureSpecs(options: PipelineOptions) {
 
   const specs: ExpandedPkgSpec[] = [];
   let processed = 0;
-  for await (const specPath of findLatestAzureOpenApiSpecFiles(specsRepo)) {
+  for await (
+    const { specPath, resourceTypes } of findLatestAzureOpenApiSpecFiles(
+      specsRepo,
+    )
+  ) {
     try {
       const openApiSpec = await readAzureSwaggerSpec(specPath);
-      const schemas = parseAzureSpec(openApiSpec);
+      const schemas = parseAzureSpec(openApiSpec, resourceTypes);
       specs.push(...schemas);
     } catch (e) {
       console.error(`Failed to process ${specPath}: ${e}`);

--- a/bin/clover/src/pipelines/azure/spec.ts
+++ b/bin/clover/src/pipelines/azure/spec.ts
@@ -33,6 +33,7 @@ const IGNORE_RESOURCE_TYPES = new Set<string>([
 
 export function parseAzureSpec(
   openApiDoc: AzureOpenApiDocument,
+  resourceTypesFilter?: Set<string>,
 ): ExpandedPkgSpec[] {
   const specs: ExpandedPkgSpec[] = [];
 
@@ -64,6 +65,11 @@ export function parseAzureSpec(
     }
     // Ignore certain problematic resource types (temporarily until we fix them)
     if (IGNORE_RESOURCE_TYPES.has(resourceType)) continue;
+
+    // Skip resource types not in the filter (if filter is provided)
+    if (resourceTypesFilter && !resourceTypesFilter.has(resourceType)) {
+      continue;
+    }
 
     resourceOperations[resourceType] ??= { handlers: {} };
     const resource = resourceOperations[resourceType];
@@ -932,7 +938,7 @@ function removeReadOnlyProperty(
   return property;
 }
 
-function parseEndpointPath(path: string) {
+export function parseEndpointPath(path: string) {
   // Form:         /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}
   // Or list form: /subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways
   // TODO support non-{resourceGroupName} get/put/delete and {resourceGroupName} list paths


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Not every resource is updated with every API change in Azure, so instead of just finding the latest azure specs, we need to walk EVERY version directory and accumulate them as we go. Since the file structures can change, it's possible the same resource can appear in multiple specs across version, so we pop off the resource names and keep track of which file has our latest. We determine latest by:

* if there is no `stable`, only `preview`, get the latest version
* if there is a `stable`, get the latest stable version
* if there is a `stable` and `preview`, prefer the latest stable version

Then we ensure spec generation is filters based on which specs should be parse from which files.

## How was it tested?

Generating in this PR we are finding ~50 new assets, including ones we know we were missing. 

- [X] Integration tests pass
- [x] Manual test: validate the changes in some of the assets. We should be taking the same versions, but we should be sure


## In short: [:link:](https://giphy.com/)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlN2F0cmRsNDhyZGt2ZTl5b2Z6dzgzN29mZDRqdW56ZnU4MjgyMHB2cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WuXMXTbBzRlOaoylgV/giphy.gif"/>