### PR TITLE
easy copy buttons for ComponentDebugPanel

### DIFF
--- a/app/web/src/newhotness/ComponentDebugPanel.vue
+++ b/app/web/src/newhotness/ComponentDebugPanel.vue
@@ -41,25 +41,25 @@
             :class="
               clsx(
                 'space-y-2xs text-xs',
-                '[&_div]:flex [&_div]:flex-row [&_div]:gap-xs [&_div]:flex-wrap [&_h3]:font-semibold [&_p]:font-mono [&_p]:text-2xs [&_p]:break-all',
+                '[&_div]:flex [&_div]:flex-row [&_div]:items-center [&_div]:gap-xs [&_div]:flex-wrap [&_h3]:font-semibold',
               )
             "
           >
             <div>
               <h3>Name:</h3>
-              <p>{{ componentData.name }}</p>
+              <CopyableTextBlock :text="componentData.name" tiny />
             </div>
             <div>
               <h3>Schema ID:</h3>
-              <p>{{ componentData.schemaId }}</p>
+              <CopyableTextBlock :text="componentData.schemaId" tiny />
             </div>
             <div>
               <h3>Schema Variant ID:</h3>
-              <p>{{ componentData.schemaVariantId }}</p>
+              <CopyableTextBlock :text="componentData.schemaVariantId" tiny />
             </div>
             <div v-if="componentData.parentId">
               <h3>Parent ID:</h3>
-              <p>{{ componentData.parentId }}</p>
+              <CopyableTextBlock :text="componentData.parentId" tiny />
             </div>
           </div>
         </div>
@@ -426,6 +426,7 @@ import clsx from "clsx";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { routes, useApi } from "./api_composables";
 import EmptyState from "./EmptyState.vue";
+import CopyableTextBlock from "./CopyableTextBlock.vue";
 
 interface ComponentDebugView {
   name: string;

--- a/app/web/src/newhotness/CopyableTextBlock.vue
+++ b/app/web/src/newhotness/CopyableTextBlock.vue
@@ -12,7 +12,7 @@
         clsx(
           'flex flex-row gap-sm items-center justify-between border rounded-sm cursor-pointer select-none',
           !expandable && 'h-full',
-          prompt ? 'p-sm' : 'p-xs',
+          tiny ? 'px-2xs' : [prompt ? 'p-sm' : 'p-xs'],
           themeClasses(
             'bg-neutral-100 border-neutral-400',
             'bg-neutral-900 border-neutral-600',
@@ -46,16 +46,23 @@
       <div
         :class="
           clsx(
-            'flex-grow text-sm',
+            'flex-grow',
+            tiny ? 'text-2xs' : 'text-sm',
             breakWords && 'break-all',
             !prompt &&
-              'overflow-hidden text-ellipsis whitespace-nowrap py-2xs font-mono',
+              'overflow-hidden text-ellipsis whitespace-nowrap font-mono',
+            !tiny && !prompt && 'py-2xs',
           )
         "
       >
         {{ text }}
       </div>
-      <Icon v-tooltip="'Copy'" name="copy" class="flex-none" size="sm" />
+      <Icon
+        v-tooltip="'Copy'"
+        name="copy"
+        class="flex-none"
+        :size="tiny ? '2xs' : 'sm'"
+      />
     </div>
     <div
       v-if="expandable && expanded"
@@ -84,6 +91,7 @@ defineProps({
   prompt: Boolean,
   expandable: Boolean,
   breakWords: Boolean,
+  tiny: Boolean,
 });
 
 const expanded = ref(false);


### PR DESCRIPTION
## How does this PR change the system?

I got annoyed at manually copying values from the ComponentDebugPanel while running manual tests, so I quickly added these nice buttons :)

#### Screenshots:

<img width="449" height="125" alt="Screenshot 2025-10-28 at 5 38 47 PM" src="https://github.com/user-attachments/assets/058097c1-d60b-4392-b7f7-7c45e5c9a6df" />