### PR TITLE
fix(si-mcp-server): Add ability to check for import and discover pre-requisites in Azure

### DIFF
--- a/bin/si-mcp-server/src/data/schemaHints.ts
+++ b/bin/si-mcp-server/src/data/schemaHints.ts
@@ -33,5 +33,18 @@ export function validateSchemaPrereqs(
     }
   }
 
+  if (schemaName.startsWith("Microsoft") || schemaName.startsWith("Azure")) {
+    const hasCredential = has("/secrets/Azure Credential");
+    const hasLocation = has("/domain/location");
+    const hasSubscriptionDetails = has("/domain/subscriptionId");
+    if (!hasLocation || !hasCredential || !hasSubscriptionDetails) {
+      return errorResponse({
+        response: { status: "bad prereq", data: {} },
+        message:
+          "This is an Azure resource, and to import it we must have /domain/location and domain/subscriptionId set to a valid value or subscription and /secrets/Azure Credential set to a subscription.",
+      });
+    }
+  }
+
   return null;
 }

--- a/bin/si-mcp-server/src/tools/schemaFind.ts
+++ b/bin/si-mcp-server/src/tools/schemaFind.ts
@@ -15,7 +15,7 @@ import { isValid } from "ulid";
 const name = "schema-find";
 const title = "Find component schemas";
 const description =
-  `<description>Finds component schemas by name or Schema ID. Returns the Schema ID, Name, Description, and external documentation Link. On failure, returns error details. When looking for AWS Schemas, you can use the AWS Cloudformation Resource name (examples: AWS::EC2::Instance, AWS::Bedrock::Agent, or AWS::ControlTower::EnabledBaseline)</description><usage>Use this tool to find if a schema exists in System Initiative, to look up the Schema Name or Schema ID if you need it, or to display high level information about the schema.</usage>`;
+  `<description>Finds component schemas by name or Schema ID. Returns the Schema ID, Name, Description, and external documentation Link. On failure, returns error details. When looking for AWS Schemas, you can use the AWS Cloudformation Resource name (examples: AWS::EC2::Instance, AWS::Bedrock::Agent, or AWS::ControlTower::EnabledBaseline). When looking for Azure Schemas, you can use the Azure ARM Resource name (examples: Microsoft.Compute/sshKeys, Microsoft.Compute/virtualMachineScaleSets,  Microsoft.Cdn/profiles or Microsoft.KeyVault/vaults)</description><usage>Use this tool to find if a schema exists in System Initiative, to look up the Schema Name or Schema ID if you need it, or to display high level information about the schema.</usage>`;
 
 const FindSchemaInputSchemaRaw = {
   changeSetId: z


### PR DESCRIPTION
Minimal prompt changes!

```
can you open a new change set and import the Microsoft.Compute sshKey with the name demo-key

⏺ I'll help you create a new change set and import the Microsoft.Compute sshKey. Let me break this down into steps.

⏺ si-mcp-server - change-set-create (MCP)(changeSetName: "Import demo-key SSH Key")
  ⎿  {
       "status": "success",
       "data": {
     … +6 lines (ctrl+o to expand)

⏺ si-mcp-server - schema-find (MCP)(schemaNameOrId: "Azure::Compute::SshPublicKey", changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV")
  ⎿  Error: {"status":"failure","errorMessage":"Error setting up request: Unable to find the schema - check the name and try again. Tell the
     user we are sorry: Request failed with status code 404"}

⏺ si-mcp-server - schema-find (MCP)(schemaNameOrId: "Microsoft.Compute/sshPublicKeys", changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV")
  ⎿  {
       "status": "success",
       "data": {
     … +6 lines (ctrl+o to expand)

⏺ Great! I found the schema. Now let me check what attributes are required for importing this resource.

⏺ si-mcp-server - schema-attributes-list (MCP)(schemaNameOrId: "Microsoft.Compute/sshPublicKeys", changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV")
  ⎿  {
       "status": "success",
       "data": {
     … +50 lines (ctrl+o to expand)

⏺ To import the SSH key, I need some additional information. Azure resources require:

  1. Resource Group - Which resource group contains the demo-key?
  2. Location - Which Azure region (e.g., eastus, westus2)?
  3. Subscription ID - Your Azure subscription ID
  4. Azure Credential - Do you have an Azure Credential component already set up in the workspace, or should I look for one?

  Could you provide these details so I can complete the import?

> Let's use engineering-Subscription component, aZ-Location component, az-Credential component and the resource group name
"Paul-Testing0Import-from-AI"

⏺ Perfect! Let me find those components and then import the SSH key. I'll need to locate the existing components first.

⏺ si-mcp-server - component-list (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", filters:
                                      {"logic":"OR","filterGroups":[{"responseField":"componentName","regularExpressions":["engineering-Subscri
                                      ption","aZ-Location","az-Credential"],"logic":"OR"}]})
  ⎿  {
       "status": "success",
       "data": [
     … +12 lines (ctrl+o to expand)

⏺ I found the aZ-Location and engineering-Subscription components, but I need to search for the az-Credential component. Let me search for
  it.

⏺ si-mcp-server - component-list (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", filters: {"logic":"AND","filterGroups":[{"responseField":"com
                                      ponentName","regularExpressions":[".*[Cc]redential.*"],"logic":"OR"}]})
  ⎿  {
       "status": "success",
       "data": [
     … +7 lines (ctrl+o to expand)

⏺ Perfect! I found all three components. Now let me get their details to understand the correct subscription paths, then import the SSH
  key.

⏺ si-mcp-server - component-get (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", componentId: "01K8NV36S8E562W0DKGH6WWWBB")
  ⎿  {
       "status": "success",
       "data": {
     … +17 lines (ctrl+o to expand)

⏺ si-mcp-server - component-get (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", componentId: "01K8NV40A0YC31ZVQ5Q8Z54YF2")
  ⎿  {
       "status": "success",
       "data": {
     … +11 lines (ctrl+o to expand)

⏺ si-mcp-server - component-get (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", componentId: "01K8NV2KBHT935GP0FQSXGYZ36")
  ⎿  {
       "status": "success",
       "data": {
     … +10 lines (ctrl+o to expand)

⏺ Excellent! I have all the component details. Now I'll import the SSH key "demo-key" with subscriptions to those components.

⏺ si-mcp-server - component-import (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", schemaName: "Microsoft.Compute/sshPublicKeys", resourceId:
                                        "demo-key", attributes: {"/domain/location":{"$source":{"component":"01K8NV36S8E562W0DKGH6WWWBB","path"
                                        :"/domain/location"}},"/domain/subscriptionId":{"$source":{"component":"01K8NV40A0YC31ZVQ5Q8Z54YF2","pa
                                        th":"/domain/SubscriptionId"}},"/domain/resourceGroup":"Paul-Testing0Import-from-AI","/secrets/Azure
                                        Credential":{"$source":{"component":"01K8NV2KBHT935GP0FQSXGYZ36","path":"/secrets/Azure Credential"}}})
  ⎿  Error: <response>{"status":"failure","errorMessage":"Error Status: failed\nError Data: {\"componentId\":\"01K8PEW0JZSV68WW074KENCYRD\",\"co
     mponentName\":\"demo-key\",\"schemaName\":\"Microsoft.Compute/sshPublicKeys\",\"funcRunId\":\"01K8PEW36M7TC4FGFGXJG9PGJS\"}\nMessage:failed
      to import Microsoft.Compute/sshPublicKeys with resourceId demo-key; see funcRunId 01K8PEW36M7TC4FGFGXJG9PGJS with the func-run-get tool
     for more information"}</response>

⏺ The import failed. Let me check the function run logs to see what went wrong.

⏺ si-mcp-server - func-run-get (MCP)(funcRunId: "01K8PEW36M7TC4FGFGXJG9PGJS", changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", logs: true, result:
                                    true)
  ⎿  {
       "status": "success",
       "data": {
     … +14 lines (ctrl+o to expand)

⏺ I see the issue. The URL being constructed is malformed. It looks like the import function needs the full Azure resource ID, not just the
   resource name. Let me try again with the full resource ID path.

⏺ si-mcp-server - component-erase (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", componentId: "01K8PEW0JZSV68WW074KENCYRD")
  ⎿  {
       "status": "success",
       "data": {
     … +3 lines (ctrl+o to expand)

⏺ si-mcp-server - component-import (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", schemaName: "Microsoft.Compute/sshPublicKeys", resourceId:
                                        "/subscriptions/09dc4b7f-17eb-4a3c-8383-b38e805b4ae8/resourceGroups/Paul-Testing0Import-from-AI/provide
                                        rs/Microsoft.Compute/sshPublicKeys/demo-key", attributes:
                                        {"/domain/location":{"$source":{"component":"01K8NV36S8E562W0DKGH6WWWBB","path":"/domain/location"}},"/
                                        domain/subscriptionId":{"$source":{"component":"01K8NV40A0YC31ZVQ5Q8Z54YF2","path":"/domain/Subscriptio
                                        nId"}},"/domain/resourceGroup":"Paul-Testing0Import-from-AI","/secrets/Azure
                                        Credential":{"$source":{"component":"01K8NV2KBHT935GP0FQSXGYZ36","path":"/secrets/Azure Credential"}}})
  ⎿  {
       "status": "success",
       "data": {
     … +7 lines (ctrl+o to expand)

⏺ Great! The import has been initiated. Let me check the function run to verify it completed successfully.

⏺ si-mcp-server - func-run-get (MCP)(funcRunId: "01K8PF3A2CABFN0PE9WFKAHKQH", changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", logs: true, result:
                                    true)
  ⎿  {
       "status": "success",
       "data": {
     … +37 lines (ctrl+o to expand)

⏺ Excellent! The import was successful. Now let me rename the component from the full resource path to just "demo-key" as you requested.

⏺ si-mcp-server - component-update (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", componentId: "01K8PF37K0VQ4VME26NG5ET5GP", attributes:
                                        {"/si/name":"demo-key"})
  ⎿  {
       "status": "success",
       "data": {
     … +3 lines (ctrl+o to expand)

⏺ si-mcp-server - generate-si-url (MCP)(changeSetId: "01K8PED6A1G7HT2XHKVX00SJRV", componentId: "01K8PF37K0VQ4VME26NG5ET5GP")
  ⎿  {
       "status": "success",
       "data": {
     … +3 lines (ctrl+o to expand)

⏺ Perfect! I've successfully completed the import:

  Summary:
  - Created new change set: "Import demo-key SSH Key" (ID: 01K8PED6A1G7HT2XHKVX00SJRV)
  - Imported SSH key "demo-key" from resource group "Paul-Testing0Import-from-AI"
  - Set up subscriptions to:
    - aZ-Location (eastus)
    - engineering-Subscription (09dc4b7f-17eb-4a3c-8383-b38e805b4ae8)
    - aZ-Credential
  - The SSH public key was successfully imported with its public key data
```