### PR TITLE
Filter possible connections by schema and component

### DIFF
--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -608,7 +608,13 @@
                     :virtualItemIndex="virtualItem.index"
                     :virtualItemSize="virtualItem.size"
                     :virtualItemStart="virtualItem.start"
+                    :filteredSchemaName="filteredSchemaName"
+                    :filteredComponentName="filteredComponentName"
                     @selectConnection="(index) => selectConnection(index)"
+                    @filter-component="(name) => (filteredComponentName = name)"
+                    @clear-component="() => (filteredComponentName = '')"
+                    @filter-schema="(name) => (filteredSchemaName = name)"
+                    @clear-schema="() => (filteredSchemaName = '')"
                   />
                   <div
                     v-else
@@ -1554,6 +1560,8 @@ const categorizedPossibleConn = computed(() => {
   return categories;
 });
 
+const filteredSchemaName = ref("");
+const filteredComponentName = ref("");
 const filteredConnections = computed(() => {
   const output: UIConnectionRow[] = [];
 
@@ -1562,6 +1570,18 @@ const filteredConnections = computed(() => {
       matches: PossibleConnection[],
       array: UIConnectionRow[],
     ) => {
+      if (filteredSchemaName.value) {
+        matches = matches.filter(
+          (m) => m.schemaName === filteredSchemaName.value,
+        );
+      }
+
+      if (filteredComponentName.value) {
+        matches = matches.filter(
+          (m) => m.componentName === filteredComponentName.value,
+        );
+      }
+
       // Node(victor): We know that secret props on secret defining schemas live on /secrets/kind name
       // This MAY match other secret props on random schemas, but we check the types match. Ideally the MVs at some
       // point should tells us what props are the secret props on the secret defining schemas. But this solves

--- a/app/web/src/newhotness/layout_components/AttributeInputPossibleConnection.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInputPossibleConnection.vue
@@ -26,21 +26,31 @@
     >
       <TruncateWithTooltip
         :class="
-          themeClasses(
-            'text-newhotness-greenlight',
-            'text-newhotness-greendark',
+          clsx(
+            themeClasses(
+              'text-newhotness-greenlight',
+              'text-newhotness-greendark',
+            ),
+            filteredSchemaName === connection.schemaName ? 'underline' : '',
           )
         "
+        @click.right.stop.prevent="onSchema"
       >
         {{ connection.schemaName }}
       </TruncateWithTooltip>
       <TruncateWithTooltip
         :class="
-          themeClasses(
-            'text-newhotness-purplelight',
-            'text-newhotness-purpledark',
+          clsx(
+            themeClasses(
+              'text-newhotness-purplelight',
+              'text-newhotness-purpledark',
+            ),
+            filteredComponentName === connection.componentName
+              ? 'underline'
+              : '',
           )
         "
+        @click.right.stop.prevent="onComponent"
       >
         {{ connection.componentName }}
       </TruncateWithTooltip>
@@ -87,16 +97,36 @@ import { themeClasses, TruncateWithTooltip } from "@si/vue-lib/design-system";
 import clsx from "clsx";
 import { UIPotentialConnection } from "./AttributeInput.vue";
 
-defineProps<{
+const props = defineProps<{
   connection?: UIPotentialConnection;
   isConnectionSelected: boolean;
   virtualItemSize: number;
   virtualItemIndex: number;
   virtualItemStart: number;
+  filteredSchemaName?: string;
+  filteredComponentName?: string;
 }>();
+
+const onSchema = () => {
+  if (!props.connection) return;
+  if (props.filteredSchemaName !== props.connection.schemaName)
+    emit("filterSchema", props.connection.schemaName);
+  else emit("clearSchema");
+};
+
+const onComponent = () => {
+  if (!props.connection) return;
+  if (props.filteredComponentName !== props.connection.componentName)
+    emit("filterComponent", props.connection.componentName);
+  else emit("clearComponent");
+};
 
 const emit = defineEmits<{
   (e: "selectConnection", index: number): void;
+  (e: "filterSchema", name: string): void;
+  (e: "clearSchema"): void;
+  (e: "filterComponent", name: string): void;
+  (e: "clearComponent"): void;
 }>();
 </script>
 


### PR DESCRIPTION
## How does this PR change the system?

Right click on either the schema name or the component name to filter the connections to only that schema or component name! Right click again to remove. Underline shows when its being filtered

While modeling out Azure there are lots of components with similar prop names and structures. Fuzzy search is less useful in these cases to find what you're looking for since many things come up. Prop suggestions will help us here! But I think there will be many cases where we don't have some suggestions based on the interior nested Azure structure.

Also, when using String Templates—you don't get any suggestions!

#### Screenshots:

First: <img width="845" height="365" alt="image" src="https://github.com/user-attachments/assets/16053176-a760-41b4-89b7-fd9a1ae18e4a" />

Second: 
<img width="844" height="357" alt="image" src="https://github.com/user-attachments/assets/1013be79-8700-4d59-ae42-ed20160858e8" />

Third:
<img width="846" height="363" alt="image" src="https://github.com/user-attachments/assets/fee7ab0e-8b91-44f9-b254-469788115ec2" />


## How was it tested?

Right click!

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbjh6am40YzJta3R6cXRncmdmeG5hNzN5Z3YyamMwbmRxZ256OGpqbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/wvU7PlKnaofw4/giphy.gif"/>