### PR TITLE
Show previous attribute input value, and highlight subscription on focus

### DIFF
--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -145,6 +145,7 @@
         "
         @add="add"
         @set-key="setKey"
+        @focused="(path) => emit('focused', path)"
       />
     </AttributeChildLayout>
     <AttributeChildLayout v-if="secrets && secrets.children.length > 0">
@@ -832,6 +833,10 @@ const nameForm = wForm.newForm({
   },
   watchFn: () => props.component.name,
 });
+
+const emit = defineEmits<{
+  (e: "focused", path: string): void;
+}>();
 
 defineExpose({
   focusSearch,

--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -263,6 +263,7 @@
                 ? specialCaseManagementFuncRun
                 : undefined
             "
+            @focused="(path) => focused(path)"
           />
         </CollapsingFlexItem>
         <CollapsingFlexItem
@@ -335,7 +336,7 @@
             :attributeTree="attributeTree"
           />
         </CollapsingFlexItem>
-        <CollapsingFlexItem expandable>
+        <CollapsingFlexItem ref="connectionsFlex" expandable>
           <template #header
             ><span class="text-sm">Subscriptions</span></template
           >
@@ -348,6 +349,7 @@
           </template>
           <ConnectionsPanel
             v-if="componentConnections && component"
+            ref="connectionsPanel"
             :component="component"
             :connections="componentConnections ?? undefined"
           />
@@ -458,7 +460,16 @@ import {
   TruncateWithTooltip,
   NewButton,
 } from "@si/vue-lib/design-system";
-import { computed, ref, onMounted, onBeforeUnmount, inject, watch } from "vue";
+import {
+  computed,
+  ref,
+  onMounted,
+  onBeforeUnmount,
+  inject,
+  watch,
+  useTemplateRef,
+  nextTick,
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 import clsx from "clsx";
 import {
@@ -627,6 +638,16 @@ const componentConnectionsQuery = useQuery<IncomingConnections | null>({
 const componentConnections = computed(
   () => componentConnectionsQuery.data.value,
 );
+
+const connectionsPanel =
+  useTemplateRef<typeof ConnectionsPanel>("connectionsPanel");
+const connectionsFlex =
+  useTemplateRef<typeof CollapsingFlexItem>("connectionsFlex");
+const focused = async (path: string) => {
+  if (connectionsFlex.value) connectionsFlex.value.openState.open.value = true;
+  await nextTick();
+  connectionsPanel.value?.highlight(path);
+};
 
 const docs = ref("");
 const docLink = ref("");

--- a/app/web/src/newhotness/ConnectionsPanel.vue
+++ b/app/web/src/newhotness/ConnectionsPanel.vue
@@ -12,7 +12,11 @@
     "
   >
     <template v-if="incoming.length">
-      <ConnectionLayout label="Incoming" :connections="incoming" />
+      <ConnectionLayout
+        label="Incoming"
+        :connections="incoming"
+        :highlightedPath="highlightedPath"
+      />
     </template>
     <template v-if="outgoing.length">
       <ConnectionLayout label="Outgoing" :connections="outgoing" />
@@ -26,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import clsx from "clsx";
 import { themeClasses } from "@si/vue-lib/design-system";
 import {
@@ -50,4 +54,13 @@ const connections = computed(
 );
 const incoming = computed(() => connections.value.incoming);
 const outgoing = computed(() => connections.value.outgoing);
+
+const highlightedPath = ref("");
+const highlight = (selfPath: string) => {
+  highlightedPath.value = selfPath;
+};
+
+defineExpose({
+  highlight,
+});
 </script>

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -434,7 +434,7 @@
             v-if="!isSecret"
             :class="
               clsx(
-                'flex flex-row items-center border border-transparent',
+                'flex flex-row gap-sm items-center border border-transparent',
                 'px-xs py-2xs h-[30px]',
                 // Don't show cursor pointer or hover effects for connected arrays/maps
                 (props.isArray || props.isMap) && isSetByConnection
@@ -458,7 +458,7 @@
             <TruncateWithTooltip
               :class="
                 clsx(
-                  'grow font-mono',
+                  'flex-1 min-w-0 max-w-fit font-mono',
                   !field.state.value &&
                     !isArray && [
                       'italic',
@@ -487,11 +487,40 @@
                 clsx(
                   'text-xs flex-none',
                   themeClasses('text-neutral-900', 'text-neutral-200'),
+                  !value && 'ml-auto',
                 )
               "
             >
               <TextPill variant="key2">{{ selectKeyString }}</TextPill>
               to select
+            </div>
+            <div
+              v-if="value"
+              class="ml-auto pl-sm flex flex-row items-end gap-xs flex-1 min-w-0 max-w-fit"
+            >
+              <span
+                :class="
+                  clsx(
+                    'font-bold whitespace-nowrap flex-none',
+                    themeClasses('text-neutral-600', 'text-neutral-400'),
+                  )
+                "
+              >
+                Previous value:
+              </span>
+              <TruncateWithTooltip
+                :class="
+                  clsx(
+                    'flex-1 font-mono',
+                    !value &&
+                      !isArray && [
+                        'italic',
+                        themeClasses('text-neutral-600', 'text-neutral-400'),
+                      ],
+                  )
+                "
+                >{{ value }}
+              </TruncateWithTooltip>
             </div>
           </div>
 
@@ -1271,8 +1300,8 @@ const resetEverything = () => {
 const openInput = () => {
   if (readOnly.value || inputOpen.value) return;
 
+  emit("selected");
   if (props.disableInputWindow) {
-    emit("selected");
     return;
   }
 

--- a/app/web/src/newhotness/layout_components/ComponentAttribute.vue
+++ b/app/web/src/newhotness/layout_components/ComponentAttribute.vue
@@ -17,6 +17,7 @@
     :isDefaultSource="false"
     :forceReadOnly="false"
     :hasSocketConnection="hasSocketConnections"
+    @selected="focused"
     @close="closeSubscriptionInput"
     @save="(...args) => emit('save', ...args)"
     @handleTab="handleTab"
@@ -210,6 +211,7 @@
             "
             @add="(...args) => emit('add', ...args)"
             @set-key="(...args) => emit('setKey', ...args)"
+            @focused="(path) => focused(path)"
           />
         </ul>
         <div
@@ -323,6 +325,7 @@
         :forceReadOnly="props.forceReadOnly || parentHasExternalSources"
         :hasSocketConnection="hasSocketConnections"
         :isDefaultSource="attributeTree.attributeValue.isDefaultSource"
+        @selected="focused"
         @save="(...args) => emit('save', ...args)"
         @delete="(...args) => emit('delete', ...args)"
         @set-default-subscription-source="
@@ -554,6 +557,11 @@ const possibleConnectionsQuery = useQuery({
   },
 });
 
+const focused = (path?: string) => {
+  if (!path) path = props.attributeTree.attributeValue.path;
+  emit("focused", path);
+};
+
 const createSubscription = (event: Event) => {
   // Prevent any event propagation that might close the input
   event.stopPropagation();
@@ -565,6 +573,7 @@ const createSubscription = (event: Event) => {
   nextTick(() => {
     setTimeout(() => {
       subscriptionInputRef.value?.openInput();
+      focused();
     }, 50);
   });
 };
@@ -627,6 +636,7 @@ const emit = defineEmits<{
     key: string,
     value: NewChildValue,
   ): void;
+  (e: "focused", path: string): void;
 }>();
 
 const showingChildren = computed(

--- a/app/web/src/newhotness/layout_components/ConnectionLayout.vue
+++ b/app/web/src/newhotness/layout_components/ConnectionLayout.vue
@@ -9,6 +9,12 @@
         clsx(
           'py-xs pr-xs border rounded-sm',
           themeClasses('border-neutral-300', 'border-neutral-600'),
+          props.label === 'Incoming' &&
+            highlightedPath === conn.self &&
+            themeClasses(
+              'border-neutral-500 bg-neutral-300',
+              'border-neutral-400 bg-neutral-700',
+            ),
         )
       "
     >
@@ -222,6 +228,7 @@ const ctx = useContext();
 const props = defineProps<{
   label: string;
   connections: SimpleConnection[];
+  highlightedPath?: string;
 }>();
 
 const router = useRouter();


### PR DESCRIPTION
More Quality of Life!! When you focus on an attribute input, the incoming subscription will open and highlight itself for ease of navigation!

#### Screenshots:

<img width="837" height="261" alt="image" src="https://github.com/user-attachments/assets/8fc9c5f9-ea11-4746-9c16-73a8ba09489f" />

<img width="452" height="298" alt="image" src="https://github.com/user-attachments/assets/aaf942bf-7699-43d1-9b27-89dbbd5935dd" />

## How was it tested?

Click around!

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlbXhmNGk0NGR0dm44MXVqMjM4NTJxazJlMDl4ejliN2k4cmxncml5dyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mC6mEijj7pQBpM7Zvu/giphy.gif"/>