### PR TITLE
feat(si-conduit): add authentication function generation support

### DIFF
--- a/bin/si-conduit/src/cli.ts
+++ b/bin/si-conduit/src/cli.ts
@@ -21,6 +21,7 @@ import { callWhoami } from "./command/whoami.ts";
 import { callProjectInit } from "./command/project/init.ts";
 import { callRemoteSchemaPull } from "./command/remote/schema/pull.ts";
 import { callSchemaActionGenerate } from "./command/schema/action/generate.ts";
+import { callSchemaAuthGenerate } from "./command/schema/authentication/generate.ts";
 import { callSchemaCodegenGenerate } from "./command/schema/codegen/generate.ts";
 import { callSchemaManagementGenerate } from "./command/schema/management/generate.ts";
 import { callSchemaQualificationGenerate } from "./command/schema/qualification/generate.ts";
@@ -187,6 +188,7 @@ function buildSchemaCommand() {
       this.showHelp();
     })
     .command("action", buildSchemaActionCommand())
+    .command("authentication", buildSchemaAuthenticationCommand())
     .command("codegen", buildSchemaCodegenCommand())
     .command("management", buildSchemaManagementCommand())
     .command("qualification", buildSchemaQualificationCommand())
@@ -366,6 +368,43 @@ function buildSchemaActionCommand() {
             project,
             finalSchemaName,
             finalActionName,
+          );
+        }),
+    );
+}
+
+/**
+ * Builds the schema authentication subcommands.
+ *
+ * @returns A SubCommand configured for authentication operations
+ * @internal
+ */
+function buildSchemaAuthenticationCommand() {
+  return createSubCommand()
+    .description("Generates authentication functions for schemas")
+    .action(function () {
+      this.showHelp();
+    })
+    .command(
+      "generate",
+      createSubCommand()
+        .description(
+          "Generates authentication functions for credential validation",
+        )
+        .arguments("[SCHEMA_NAME:string] [AUTH_NAME:string]")
+        .action(async ({ root }, schemaName, authName) => {
+          const project = createProject(root);
+          const finalSchemaName = await prompt.schemaNameFromDirNames(
+            schemaName,
+            project,
+          );
+          const finalAuthName = await prompt.authName(authName, project);
+
+          await callSchemaAuthGenerate(
+            Context.instance(),
+            project,
+            finalSchemaName,
+            finalAuthName,
           );
         }),
     );

--- a/bin/si-conduit/src/cli/prompt.ts
+++ b/bin/si-conduit/src/cli/prompt.ts
@@ -42,8 +42,9 @@ const MIN_INPUT_LENGTH = 1 as const;
  *
  * @param message - The prompt message to display to the user
  * @param suggestions - Array of suggestion strings for autocomplete (typically
- *   derived from existing project entities or default naming conventions)
- * @returns Input options configuration object compatible with Cliffy's Input prompt
+ * derived from existing project entities or default naming conventions)
+ * @returns Input options configuration object compatible with Cliffy's Input
+ * prompt
  *
  * @internal
  */
@@ -59,7 +60,8 @@ function createPromptOptions(
 }
 
 /**
- * Generic prompt helper that handles the common pattern of prompting for a name.
+ * Generic prompt helper that handles the common pattern of prompting for a
+ * name.
  *
  * This internal helper reduces code duplication across all prompt functions by
  * implementing the flexible input strategy: if a value is provided, return it
@@ -67,7 +69,8 @@ function createPromptOptions(
  *
  * @param value - Optional value from command arguments
  * @param promptMessage - The message to display in the prompt
- * @param getSuggestions - Function that returns suggestions (can be sync or async)
+ * @param getSuggestions - Function that returns suggestions (can be sync or
+ * async)
  * @returns A promise resolving to the value (either provided or prompted)
  *
  * @internal
@@ -182,12 +185,12 @@ export async function actionName(
  * prompt with autocomplete suggestions based on default codegen function
  * naming conventions.
  *
- * @param codegenName - Optional codegen name from command arguments. If provided,
- *   this value is returned as-is without prompting the user
+ * @param codegenName - Optional codegen name from command arguments. If
+ * provided, this value is returned as-is without prompting the user
  * @param project - Project instance used to retrieve default codegen function
- *   names for autocomplete suggestions
+ * names for autocomplete suggestions
  * @returns A promise resolving to the codegen name (either the provided value
- *   or the user's prompted input)
+ * or the user's prompted input)
  *
  * @example
  * ```ts
@@ -222,11 +225,11 @@ export async function codegenName(
  * naming conventions.
  *
  * @param managementName - Optional management name from command arguments. If
- *   provided, this value is returned as-is without prompting the user
- * @param project - Project instance used to retrieve default management function
- *   names for autocomplete suggestions
- * @returns A promise resolving to the management name (either the provided value
- *   or the user's prompted input)
+ * provided, this value is returned as-is without prompting the user
+ * @param project - Project instance used to retrieve default management
+ * function names for autocomplete suggestions
+ * @returns A promise resolving to the management name (either the provided
+ * value or the user's prompted input)
  *
  * @example
  * ```ts
@@ -255,17 +258,18 @@ export async function managementName(
 /**
  * Prompts the user for a qualification name if not provided.
  *
- * This function implements a flexible input strategy: if a qualification name is
- * provided, it returns immediately. Otherwise, it presents an interactive
+ * This function implements a flexible input strategy: if a qualification name
+ * is provided, it returns immediately. Otherwise, it presents an interactive
  * prompt with autocomplete suggestions based on default qualification function
  * naming conventions.
  *
- * @param qualificationName - Optional qualification name from command arguments.
- *   If provided, this value is returned as-is without prompting the user
- * @param project - Project instance used to retrieve default qualification function
- *   names for autocomplete suggestions
- * @returns A promise resolving to the qualification name (either the provided value
- *   or the user's prompted input)
+ * @param qualificationName - Optional qualification name from command
+ * arguments. If provided, this value is returned as-is without prompting the
+ * user
+ * @param project - Project instance used to retrieve default qualification
+ * function names for autocomplete suggestions
+ * @returns A promise resolving to the qualification name (either the provided
+ * value or the user's prompted input)
  *
  * @example
  * ```ts
@@ -288,5 +292,40 @@ export async function qualificationName(
     qualificationName,
     "Qualification Function Name",
     () => Project.DEFAULT_QUALIFICATION_NAMES,
+  );
+}
+
+/**
+ * Prompts the user for an authentication name if not provided.
+ *
+ * This function implements a flexible input strategy: if an authentication name
+ * is provided, it returns immediately. Otherwise, it presents an interactive
+ * prompt for the authentication function name.
+ *
+ * @param authName - Optional authentication name from command arguments.
+ *   If provided, this value is returned as-is without prompting the user
+ * @param project - Project instance
+ * @returns A promise resolving to the authentication name (either the provided
+ *   value or the user's prompted input)
+ *
+ * @example
+ * ```ts
+ * // With argument - no prompt shown
+ * const name1 = await authName("oauth", project);
+ * // Returns: "oauth"
+ *
+ * // Without argument - interactive prompt
+ * const name2 = await authName(undefined, project);
+ * // User sees: "Authentication Function Name: _"
+ * ```
+ */
+export async function authName(
+  authName: string | undefined,
+  _project: Project,
+): Promise<string> {
+  return await promptForName(
+    authName,
+    "Authentication Function Name",
+    () => [],
   );
 }

--- a/bin/si-conduit/src/command/schema/authentication/generate.ts
+++ b/bin/si-conduit/src/command/schema/authentication/generate.ts
@@ -1,0 +1,50 @@
+import { Context } from "../../../context.ts";
+import * as generator from "../../../generators.ts";
+import { getLogger } from "../../../logger.ts";
+import { Project } from "../../../project.ts";
+import type { AbsoluteFilePath } from "../../../project.ts";
+
+const logger = getLogger();
+
+export async function callSchemaAuthGenerate(
+  ctx: Context,
+  project: Project,
+  schemaName: string,
+  name: string,
+): Promise<GeneratorResult> {
+  logger.info(
+    "Generating authentication function {name} for schema {schemaName}",
+    {
+      schemaName,
+      name,
+    },
+  );
+  logger.info("---");
+  logger.info("");
+
+  await generator.generateSchemaAuthBase(project, schemaName);
+
+  const paths = await generator.generateSchemaAuth(project, schemaName, name);
+
+  logger.info("");
+  logger.info("---");
+  logger.info(
+    "Successfully generated authentication function for schema {schemaName}",
+    {
+      schemaName,
+    },
+  );
+  logger.info(`  - ${name}`);
+
+  ctx.analytics.trackEvent("schema_authentication_generate", {
+    schemaName: schemaName,
+    authName: name,
+  });
+
+  return paths;
+}
+
+export interface GeneratorResult {
+  metadataPath: AbsoluteFilePath;
+  codePath: AbsoluteFilePath;
+}


### PR DESCRIPTION
This change introduces the ability to generate authentication functions
for schemas in the si-conduit CLI tool. Prior to this change, the tool
supported generating action, codegen, management, and qualification
functions, but had no command for creating authentication functions.
This created an asymmetry in the developer experience and forced
developers to manually create authentication function files when
building schemas that require credential validation.

With this change, developers can now use `si-conduit schema
authentication generate` to scaffold new authentication functions
following the same patterns established for other function types. The
implementation mirrors the existing function generation commands,
providing a consistent interface and code structure.

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZDQ0cGpqbWQ5OGFjYmE2M29xNXRwZ3ZnOHV3emVscWJrZXZleHJvOCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/oDyDSmr7StLCBKucHM/giphy.gif"/>