### PR TITLE
feat(clover): support read-only azure assets

### DIFF
--- a/bin/clover/src/pipelines/azure/schema.ts
+++ b/bin/clover/src/pipelines/azure/schema.ts
@@ -141,7 +141,11 @@ function extractApiVersion(filePath: string): string | null {
   if (!versionMatch) return null;
 
   const [, versionType, versionDate] = versionMatch;
-  return versionType === "preview" ? `${versionDate}-preview` : versionDate;
+  // If it's a preview version and doesn't already end with -preview, append it
+  if (versionType === "preview" && !versionDate.endsWith("-preview")) {
+    return `${versionDate}-preview`;
+  }
+  return versionDate;
 }
 
 const EXCLUDE_SPECS = [


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Allows us to gather read-only assets (lacking put endpoints, but with gets).

* Ignoring `Microsoft.DataProtection/operationStatus` as it's basically just self-referential
* skip stubbing resources for readOnly as we only build the resource_value anyways
* remove the id checks as we don't necessarily need to block on these


#### Out of Scope:

Also fixes a bug where we were generating the wrong api versions, e.g. `2025-preview-preview`. This accounts for the 125 changes here.

Note that we need endpoint parsing changes to bring in subscription and friends, but this should get us part of the way there

## How was it tested?


- [X] Integration tests pass
- [X] Manual test: new functionality works in UI

## In short: [:link:](https://giphy.com/)

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlMHNjczF2YTN3YjN6bDAyOXQ4OWw2aTVzajdvazByYWZ0N3FyeWxzNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Zdg7kl9bnyqXrPH2jq/giphy.gif"/>