### PR TITLE
Views button on ComponentDetails + bug fixes

### DIFF
--- a/app/web/src/newhotness/ComponentViewsModal.vue
+++ b/app/web/src/newhotness/ComponentViewsModal.vue
@@ -1,0 +1,82 @@
+<template>
+  <Modal
+    ref="modalRef"
+    :title="`Adjust Views For &quot;${componentName}&quot;`"
+    :capitalizeTitle="false"
+  >
+    <div class="max-h-[70vh] scrollable flex flex-col gap-xs">
+      <div class="text-lg">Currently in the following views -</div>
+      <div
+        v-for="view in availableViewListOptions.removeFromView"
+        :key="view.value"
+        class="flex flex-row items-center gap-xs"
+      >
+        <NewButton
+          v-tooltip="
+            onlyInOneView ? `Can't remove from last view` : `Remove from view`
+          "
+          icon="trash"
+          tone="destructive"
+          :disabled="onlyInOneView"
+          @click="() => removeFromView(view.value)"
+        />
+        <div>{{ view.label }}</div>
+      </div>
+      <div class="text-lg">Can be added to the following views -</div>
+      <div
+        v-for="view in availableViewListOptions.addToView"
+        :key="view.value"
+        class="flex flex-row items-center gap-xs"
+      >
+        <NewButton
+          v-tooltip="`Add to view`"
+          icon="plus"
+          tone="action"
+          @click="() => addToView(view.value)"
+        />
+        <div>{{ view.label }}</div>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { Modal, NewButton, useModal } from "@si/vue-lib/design-system";
+import { AvailableViewListOptions } from "./logic_composables/view";
+import { useApi, routes } from "./api_composables";
+
+const modalRef = ref<InstanceType<typeof Modal>>();
+const { open, close } = useModal(modalRef);
+
+const props = defineProps<{
+  componentName: string;
+  componentId: string;
+  availableViewListOptions: AvailableViewListOptions;
+}>();
+
+const onlyInOneView = computed(
+  () => props.availableViewListOptions.removeFromView.length < 2,
+);
+
+const addToViewApi = useApi();
+const removeFromViewApi = useApi();
+const addToView = async (viewId: string) => {
+  const call = addToViewApi.endpoint(routes.ViewAddComponents, {
+    viewId,
+  });
+  await call.post({
+    componentIds: [props.componentId],
+  });
+};
+const removeFromView = async (viewId: string) => {
+  const call = removeFromViewApi.endpoint(routes.ViewEraseComponents, {
+    viewId,
+  });
+  await call.delete({
+    componentIds: [props.componentId],
+  });
+};
+
+defineExpose({ open, close });
+</script>

--- a/app/web/src/newhotness/Explore.vue
+++ b/app/web/src/newhotness/Explore.vue
@@ -37,7 +37,7 @@
         <div class="flex-none flex flex-row items-start gap-xs">
           <DropdownMenuButton
             ref="viewsDropdownRef"
-            class="rounded min-w-[128px] h-[2.5rem]"
+            class="rounded min-w-[128px] h-[38px] pl-xs"
             :options="filteredViewListOptions"
             :search="viewListOptions.length > DEFAULT_DROPDOWN_SEARCH_THRESHOLD"
             :modelValue="selectedViewId"
@@ -527,6 +527,7 @@
     <!-- For the edit view modals, upon delete, change back to "All Views" -->
     <EditViewModal
       ref="editViewModalRef"
+      :views="viewListQuery.data.value ?? []"
       @deleted="() => (selectedViewId = '')"
     />
     <ComponentContextMenu
@@ -2432,7 +2433,7 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
       mapRef.value?.onU(e);
     }
   },
-  // v: undefined,
+  // v: undefined, - USED FOR VIEWS BUTTON IN ComponentDetails
   // w: undefined,
   // x: undefined,
   // y: undefined,

--- a/app/web/src/newhotness/logic_composables/view.ts
+++ b/app/web/src/newhotness/logic_composables/view.ts
@@ -1,4 +1,4 @@
-import { computed } from "vue";
+import { computed, ComputedRef } from "vue";
 import { useQuery } from "@tanstack/vue-query";
 import {
   getComponentsInViews,
@@ -9,6 +9,11 @@ import { EntityKind } from "@/workers/types/entity_kind_types";
 import { ViewId } from "@/api/sdf/dal/views";
 import { ComponentId } from "@/api/sdf/dal/component";
 import { useContext } from "./context";
+
+type UseComponentsAndViews = {
+  componentsInViews: ComputedRef<Record<string, Set<string>>>;
+  componentsInOnlyOneView: ComputedRef<Record<string, string>>;
+};
 
 export const useComponentsAndViews = () => {
   const ctx = useContext();
@@ -33,4 +38,85 @@ export const useComponentsAndViews = () => {
       () => componentsInOnlyOneViewQuery.data.value ?? {},
     ),
   };
+};
+
+export interface AvailableViewListOptions {
+  addToView: { label: string; value: string }[];
+  removeFromView: { label: string; value: string }[];
+}
+
+export const availableViewListOptionsForComponentIds = (
+  componentIds: ComponentId[],
+  viewListOptions: { label: string; value: string }[],
+  componentsAndViews: UseComponentsAndViews,
+  showInvalidOptions = false,
+) => {
+  const unprocessedOptions = viewListOptions;
+  unprocessedOptions.sort((a, b) =>
+    a.label.toLowerCase().localeCompare(b.label.toLowerCase()),
+  );
+  const options: AvailableViewListOptions = {
+    addToView: [],
+    removeFromView: [],
+  };
+  for (const unprocessedOption of unprocessedOptions) {
+    const viewId = unprocessedOption.value;
+    const componentsInView =
+      componentsAndViews.componentsInViews.value[viewId] ?? new Set();
+    if (showViewInAddToViewMenuOptions(componentsInView, componentIds))
+      options.addToView.push(unprocessedOption);
+    if (
+      showViewInRemoveFromViewMenuOptions(
+        componentsInView,
+        viewId,
+        componentIds,
+        componentsAndViews,
+        showInvalidOptions,
+      )
+    )
+      options.removeFromView.push(unprocessedOption);
+  }
+  return options;
+};
+const showViewInAddToViewMenuOptions = (
+  componentIdsInView: Set<ComponentId>,
+  componentIds: Array<ComponentId>,
+) => {
+  // If there's nothing in the view, you always add to it.
+  if (componentIdsInView.size < 1) return true;
+
+  // For the selected components, if at least one of them is not in the view, we can add to it.
+  for (const componentId of componentIds) {
+    if (!componentIdsInView.has(componentId)) {
+      return true;
+    }
+  }
+
+  // If all of the components are in the view, we cannot add any of them to it.
+  return false;
+};
+const showViewInRemoveFromViewMenuOptions = (
+  componentIdsInView: Set<ComponentId>,
+  viewId: ViewId,
+  componentIds: Array<ComponentId>,
+  componentsAndViews: UseComponentsAndViews,
+  showInvalidOptions: boolean,
+) => {
+  // If there's nothing in the view, there's nothing to remove from it.
+  if (componentIdsInView.size < 1) return false;
+
+  // For the selected components, only show the option if all of them are in the view and that view
+  // isn't the final view for any of the components.
+  for (const componentId of componentIds) {
+    const soleViewIdForCurrentComponent =
+      componentsAndViews.componentsInOnlyOneView.value[componentId];
+    if (
+      !componentIdsInView.has(componentId) ||
+      (soleViewIdForCurrentComponent === viewId && !showInvalidOptions)
+    )
+      return false;
+  }
+
+  // If we don't hit the exit clause, then we are good to include this option.
+  return true;
 };

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -29,6 +29,7 @@ const USER_FLAG_MAPPING = {
   COMPONENT_HISTORY_FUNCS: "component-history-funcs",
   REVERSE_TRUNCATION: "reverse-truncation",
   AZURE_SCHEMAS: "ms-azure-schemas",
+  VIEWS_BUTTON: "views-button-component-details",
 } as const;
 const WORKSPACE_FLAG_MAPPING = {
   FRONTEND_ARCH_VIEWS: "workspace-frontend-arch-views",


### PR DESCRIPTION
## How does this PR change the system?

This PR refactors and fixes bugs around views and also adds a feature flagged Views button to the ComponentDetails page.

#### Screenshots:

<img width="488" height="463" alt="Screenshot 2025-10-29 at 4 31 46 PM" src="https://github.com/user-attachments/assets/07293fee-059e-4bd2-8bdc-7a788985fb1b" />

<img width="1347" height="534" alt="Screenshot 2025-10-29 at 4 58 58 PM" src="https://github.com/user-attachments/assets/988d1486-ceda-4e9d-aa84-03537f985814" />

#### Out of Scope:

The UI/UX for adjusting views on ComponentDetails is not ideal but was just quick to put together! We'll want to make sure we like the UI/UX before turning the feature on for all users.

## How was it tested?

Plenty of manual testing, confirming forms reset and validate properly.
