### PR TITLE
fix(web): Preserve view context when navigating to/from component details

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -490,6 +490,7 @@ import { useComponentDeletion } from "./composables/useComponentDeletion";
 import { useComponentUpgrade } from "./composables/useComponentUpgrade";
 import { useManagementFuncJobState } from "./logic_composables/management";
 import { useComponentActions } from "./logic_composables/component_actions";
+import { prevPage } from "./logic_composables/navigation_stack";
 import { openWorkspaceMigrationDocumentation } from "./util";
 import { useContext } from "./logic_composables/context";
 
@@ -622,13 +623,25 @@ const mgmtRef = ref<typeof CollapsingFlexItem>();
 const router = useRouter();
 
 const close = () => {
-  const params = router.currentRoute?.value.params ?? {};
-  delete params.componentId;
-  router.push({
-    name: "new-hotness",
-    params,
-    query: { retainSessionState: 1 },
-  });
+  const lastPage = prevPage();
+
+  // If we have a previous page and it's the explore view, go back to it with full context
+  if (lastPage && lastPage.name === "new-hotness") {
+    router.push({
+      name: lastPage.name,
+      params: lastPage.params,
+      query: lastPage.query,
+    });
+  } else {
+    // Fallback to default navigation if no history
+    const params = router.currentRoute?.value.params ?? {};
+    delete params.componentId;
+    router.push({
+      name: "new-hotness",
+      params,
+      query: { retainSessionState: 1 },
+    });
+  }
 };
 
 const navigateToMap = () => {


### PR DESCRIPTION
Fixes: BUG-1110

When a user is in a specific view and navigates to a component's details page, clicking the X button to close the component details takes them back to the default view instead of the view they were originally in. All other context (grid/map mode, sorting, filters, etc.) was also lost.

The close() function in ComponentDetails.vue was replacing all query parameters with just { retainSessionState: 1 }, which discarded the viewId and other state information stored in the URL query string.

This solution follows the same pattern already used in FuncRunDetailsLayout.vue for navigating back from function run details.