### PR TITLE
feat: Create subresource schemas for Azure

### DIFF
--- a/bin/clover/src/pipelines/azure/funcs/actions/delete.ts
+++ b/bin/clover/src/pipelines/azure/funcs/actions/delete.ts
@@ -33,6 +33,7 @@ async function main(component: Input): Promise<Output> {
   const url =
     `https://management.azure.com${resourceId}?api-version=${apiVersion}`;
 
+  console.log(`DELETE ${url}`);
   const response = await fetch(url, {
     method: "DELETE",
     headers: {

--- a/bin/clover/src/pipelines/azure/funcs/actions/refresh.ts
+++ b/bin/clover/src/pipelines/azure/funcs/actions/refresh.ts
@@ -41,6 +41,7 @@ async function main(component: Input): Promise<Output> {
   const url =
     `https://management.azure.com${resourceId}?api-version=${apiVersion}`;
 
+  console.log(`GET ${url}`);
   const response = await fetch(url, {
     method: "GET",
     headers: {

--- a/bin/clover/src/pipelines/azure/funcs/actions/update.ts
+++ b/bin/clover/src/pipelines/azure/funcs/actions/update.ts
@@ -34,6 +34,7 @@ async function main(component: Input): Promise<Output> {
     `https://management.azure.com${resourceId}?api-version=${apiVersion}`;
 
   // First, GET the current resource state
+  console.log(`GET ${url}`);
   const getCurrentResponse = await fetch(url, {
     method: "GET",
     headers: {
@@ -55,6 +56,7 @@ async function main(component: Input): Promise<Output> {
   const mergedPayload = _.merge({}, currentResource, updatePayload);
 
   // PUT the complete merged resource definition
+  console.log(`PUT ${url} with payload:\n${JSON.stringify(mergedPayload, null, 2)}`);
   const response = await fetch(url, {
     method: "PUT",
     headers: {
@@ -92,9 +94,12 @@ function cleanPayload(domain) {
   const payload = _.cloneDeep(domain);
 
   // Remove metadata fields that are used for URL construction only
-  delete payload.subscriptionId;
-  delete payload.resourceGroup;
-  delete payload.name;
+  if (domain.extra?.resourceId) {
+    for (const key of domain.extra.resourceId.matchAll(/{([^}]+)}/g)) {
+      const paramName = key[1];
+      delete payload[paramName];
+    }
+  }
   delete payload.extra;
 
   // Merge discriminator subtypes into parent

--- a/bin/clover/src/pipelines/azure/pipeline-steps/addDefaultProps.ts
+++ b/bin/clover/src/pipelines/azure/pipeline-steps/addDefaultProps.ts
@@ -33,62 +33,28 @@ export function addDefaultProps(
     const [schemaVariant] = schema.variants;
     const { domain } = schemaVariant;
 
-    // add name prop if not exists
-    if (!findPropByName(domain, "name")) {
-      const nameProp = createScalarProp(
-        "name",
-        "string",
-        domain.metadata.propPath,
-        true,
-      );
-
-      nameProp.data.documentation = "The name of the Azure resource";
-      nameProp.metadata.createOnly = true;
-
-      domain.entries.push(nameProp);
-    } else {
-      // Mark existing name prop as createOnly
-      const nameProp = findPropByName(domain, "name");
-      if (nameProp) {
-        nameProp.metadata.createOnly = true;
-      }
-    }
-
-    // add resource group prop if not exists
-    if (!findPropByName(domain, "resourceGroup")) {
-      const resourceGroupProp = createScalarProp(
-        "resourceGroup",
-        "string",
-        domain.metadata.propPath,
-        false,
-      );
-
-      resourceGroupProp.data.documentation =
+    // Add suggestions to resourceGroupName
+    // TODO if resourceGroupName prop exists with a different name, support that
+    const resourceGroupNameProp = findPropByName(domain, "resourceGroupName");
+    if (resourceGroupNameProp) {
+      resourceGroupNameProp.data.documentation ??=
         "The name of the resource group where this resource will be created";
-      resourceGroupProp.data.docLink =
+      resourceGroupNameProp.data.docLink ??=
         "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal";
-      resourceGroupProp.metadata.createOnly = true;
+      resourceGroupNameProp.metadata.createOnly = true;
 
-      addPropSuggestSource(resourceGroupProp, {
+      addPropSuggestSource(resourceGroupNameProp, {
         schema: "Azure Resource Group",
         prop: "/domain/Name",
       });
-
-      domain.entries.push(resourceGroupProp);
     }
 
-    // add subscription id prop if not exists
-    if (!findPropByName(domain, "subscriptionId")) {
-      const subscriptionIdProp = createScalarProp(
-        "subscriptionId",
-        "string",
-        domain.metadata.propPath,
-        true,
-      );
-
-      subscriptionIdProp.data.documentation =
+    // Add suggestions to subscriptionId
+    const subscriptionIdProp = findPropByName(domain, "subscriptionId");
+    if (subscriptionIdProp) {
+      subscriptionIdProp.data.documentation ??=
         "The Azure subscription ID where this resource will be created";
-      subscriptionIdProp.data.docLink =
+      subscriptionIdProp.data.docLink ??=
         "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-subscription";
       subscriptionIdProp.metadata.createOnly = true;
 
@@ -96,8 +62,6 @@ export function addDefaultProps(
         schema: "Azure Subscription",
         prop: "/domain/SubscriptionId",
       });
-
-      domain.entries.push(subscriptionIdProp);
     }
 
     // Extra prop
@@ -111,6 +75,7 @@ export function addDefaultProps(
     extraProp.data.hidden = true;
 
     // Create AzureResourceType prop
+    // TODO remove this; kept because a few functions reference it right now
     {
       const resourceTypeProp = createScalarProp(
         "AzureResourceType",
@@ -123,6 +88,22 @@ export function addDefaultProps(
       resourceTypeProp.data.hidden = true;
 
       extraProp.entries.push(resourceTypeProp);
+    }
+
+    // Create AzureResourceType prop
+    {
+      const resourceIdProp = createScalarProp(
+        "resourceId",
+        "string",
+        extraProp.metadata.propPath,
+        false,
+      );
+
+      const { resourceId } = schemaVariant.superSchema as AzureSchema;
+      resourceIdProp.data.defaultValue = resourceId;
+      resourceIdProp.data.hidden = true;
+
+      extraProp.entries.push(resourceIdProp);
     }
 
     // Create apiVersion prop

--- a/bin/hoist/src/main.rs
+++ b/bin/hoist/src/main.rs
@@ -488,12 +488,16 @@ async fn diff_summaries_with_module_index(
             println!("```");
 
             if let Some(modules) = new {
+                let mut modules = modules.clone();
+                modules.sort();
                 for module in modules {
                     println!("{module}");
                 }
             }
 
             if let Some(modules) = changed {
+                let mut modules = modules.clone();
+                modules.sort();
                 for module in modules {
                     println!("{module}");
                 }
@@ -506,11 +510,15 @@ async fn diff_summaries_with_module_index(
         // Print plain text output organized by provider
         for provider in providers {
             if let Some(modules) = new_modules.get(provider) {
+                let mut modules = modules.clone();
+                modules.sort();
                 for module in modules {
                     println!("{module}");
                 }
             }
             if let Some(modules) = changed_modules.get(provider) {
+                let mut modules = modules.clone();
+                modules.sort();
                 for module in modules {
                     println!("{module}");
                 }

--- a/lib/jsr-systeminit/cf-db/cfDb.ts
+++ b/lib/jsr-systeminit/cf-db/cfDb.ts
@@ -8,6 +8,7 @@
  * @module cfDb
  */
 
+import util from "node:util";
 import type {
   JSONSchema,
 } from "./draft_07.ts";
@@ -134,7 +135,7 @@ function normalizeAnyOfAndOneOfTypes(
 
     for (let ofMember of prop.oneOf) {
       if (!mergedProp.properties) {
-        throw new Error("unexpected oneOf");
+        throw new Error(`unexpected oneOf: ${util.inspect(prop, { depth: 3 })}`);
       }
 
       ofMember = normalizePropertyType(ofMember);
@@ -145,7 +146,7 @@ function normalizeAnyOfAndOneOfTypes(
         }
       } else if (ofMember.type === "array" && ofMember.items) {
         const title = ofMember.title ?? prop.title;
-        if (!title) { throw new Error("oneOf array without title"); }
+        if (!title) { throw new Error(`oneOf array without title: ${util.inspect(prop, { depth: 3 })}`); }
 
         // we don't support this yet; throw an exception if it happens so we can decide
         if (Array.isArray(ofMember.items)) throw new Error("unexpected array as item type");
@@ -166,9 +167,8 @@ function normalizeAnyOfAndOneOfTypes(
           type: "string",
         }
       } else {
-        console.log(ofMember);
         throw new Error(
-          `attempted to process oneOf as not an object or array: ${ofMember}`,
+          `attempted to process oneOf as not an object or array: ${util.inspect(prop, { depth: 3 })}`,
         );
       }
     }
@@ -195,8 +195,7 @@ function normalizeAnyOfAndOneOfTypes(
       isObject = true;
 
       if (!ofMember.title) {
-        console.log(prop);
-        throw new Error("anyOf of objects without title");
+        throw new Error(`anyOf of objects without title: ${util.inspect(prop, { depth: 3 })}`);
       }
 
       if (ofMember.properties) {
@@ -209,8 +208,7 @@ function normalizeAnyOfAndOneOfTypes(
         isObject = true;
 
         if (!ofMember.title) {
-          console.log(prop);
-          throw new Error("anyOf of objects without title");
+          throw new Error(`anyOf of objects without title: ${util.inspect(prop, { depth: 3 })}`);
         }
 
         properties[ofMember.title] = ofMember;


### PR DESCRIPTION
VM extensions are only identifiable as *sub-resources*--`/providers/Microsoft.Compute/virtualMachines/myMachine/extensions/myExtension`.

This PR:
* Adds two-level subresources like extensions
* Supports arbitrary depth subresources in create/update/refresh/delete using a new `resourceId` domain prop that mirrors the path (i.e. `/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}`)
* Uses the parameter name in the schema for subscriptionId, resourceGroupName, and name
* Merges the parameters from the schema, and uses the parameter *name* in the schema (generally means `name` and `resourceGroup` are now things like `vmName` and `resourceGroupName`).

## How was it tested?

- [X] Integration tests pass
- [X] Manual test: extensions is created, CRUD works

## In short: [:link:](https://giphy.com/)

<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlZ2EwcXR6dXM0ZWxxeGoyOWZlbXl6NXhnZm8zazc3bnFsa3Bua2E1eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/U26Aj5j5Yv3Hy/giphy.gif"/>