### PR TITLE
fix(web): Fix missing refresh button on component resource panel when viewing components on HEAD

### DIFF
--- a/app/web/src/newhotness/logic_composables/component_actions.ts
+++ b/app/web/src/newhotness/logic_composables/component_actions.ts
@@ -149,7 +149,7 @@ export const useComponentActions = (
       !!(
         refreshActionPrototype.value &&
         component.value?.hasResource &&
-        componentExistsOnHead.value
+        (ctx.onHead.value || componentExistsOnHead.value)
       ),
   );
 


### PR DESCRIPTION
Fixes BUG-1119


The refresh button was not appearing on the resource panel when viewing components on HEAD, even when those components had resources and refresh action prototypes defined. The button only appeared when viewing components from a change set that had been previously applied to HEAD

<img width="658" height="396" alt="Screenshot 2025-10-30 at 16 42 14" src="https://github.com/user-attachments/assets/be7bf5d2-cf44-4df4-8eac-de2e8d1f9064" />
