### PR TITLE
fixing two small annoying bugs

### DIFF
--- a/app/web/src/newhotness/ComponentDetails.vue
+++ b/app/web/src/newhotness/ComponentDetails.vue
@@ -873,8 +873,8 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
   // a: used for select all in Explore, not used here
   // b: undefined,
   c: (e) => {
+    if (e.metaKey || e.ctrlKey) return; // copy
     e.preventDefault();
-    if (e.metaKey || e.ctrlKey) return;
     emit("openChangesetModal");
   },
   // d: used for duplicate in Explore, not used here
@@ -885,6 +885,7 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
     }
   },
   f: (e) => {
+    if (e.metaKey || e.ctrlKey) return; // find
     e.preventDefault();
     if (component.value?.toDelete) {
       restoreComponent();
@@ -928,7 +929,10 @@ const shortcuts: { [Key in string]: (e: KeyDetails[Key]) => void } = {
       upgradeComponent();
     }
   },
-  v: () => {
+  v: (e) => {
+    if (e.metaKey || e.ctrlKey) {
+      return;
+    }
     if (featureFlagsStore.VIEWS_BUTTON) {
       openViewsModal();
     }

--- a/app/web/src/newhotness/layout_components/AttributeInput.vue
+++ b/app/web/src/newhotness/layout_components/AttributeInput.vue
@@ -495,7 +495,7 @@
               to select
             </div>
             <div
-              v-if="value"
+              v-if="value && !isMap"
               class="ml-auto pl-sm flex flex-row items-end gap-xs flex-1 min-w-0 max-w-fit"
             >
               <span


### PR DESCRIPTION
## How does this PR change the system?

This PR fixes two small but very annoying bugs -

The first bug is that the keyboard shortcuts in the ComponentDetails screen were blocking the browser shortcuts for copy, paste, and find. The shortcuts have been adjusted to fix the issue.

The second bug is that a "Previous value" was always being shown in the `AttributeInput` for maps as `[object Object]` - the fix is to simply not show a previous value for Maps on the root level, since the only way you can open the input at that level is if the value is empty.

#### Screenshots:

<img width="939" height="246" alt="Screenshot 2025-10-30 at 2 21 33 PM" src="https://github.com/user-attachments/assets/47e90851-2409-4238-b081-ea9256121e18" />

#### Out of Scope:

This PR only fixes these two bugs, nothing more.

## How was it tested?

Both browser shortcuts now work properly and the SI keyboard shortcuts also still work.
I checked every possible `AttributeInput` type for the "Previous value" and found no remaining issues.