### PR TITLE
fix Apply button becoming not disabled while still loading

### DIFF
--- a/app/web/src/newhotness/ApplyChangeSetModal.vue
+++ b/app/web/src/newhotness/ApplyChangeSetModal.vue
@@ -87,6 +87,7 @@
             loadingText="Applying Changes"
             :loading="applyInFlight"
             :disabled="!allowedToApplyWithApprovalsDisabled"
+            disabledWhileLoading
             pill="Cmd + Enter"
             @click="debouncedApply"
           />

--- a/lib/vue-lib/src/design-system/general/NewButton.vue
+++ b/lib/vue-lib/src/design-system/general/NewButton.vue
@@ -20,7 +20,7 @@
           tone !== 'empty' && 'border',
           computedTextSize,
           truncateText && 'min-w-0',
-          disabled
+          disabled || (disabledWhileLoading && computedLoading)
             ? [
                 'cursor-not-allowed',
                 themeClasses(
@@ -169,6 +169,7 @@ const props = defineProps({
   linkTo: [String, Object],
   target: String,
   disabled: Boolean,
+  disabledWhileLoading: Boolean,
   loading: Boolean,
   loadingText: { type: String, default: "Loading..." },
   loadingIcon: { type: String as PropType<IconNames>, default: "loader" },


### PR DESCRIPTION
## How does this PR change the system?

This PR fixes a rather infrequent bug where the Apply Change Set button on the `ApplyChangeSetModal` would, after being clicked, change from its disabled state back to enabled while still in the loading state. This change is purely visual since the loading state still prevents the button from being fired again, but it looks confusing/bad to the user.

#### Screenshots:

the bug looks like this -
<img width="477" height="360" alt="Screenshot 2025-10-30 at 4 37 17 PM" src="https://github.com/user-attachments/assets/423f6e32-157d-439b-a56c-c551c8f29bd4" />

now it looks like this -
<img width="486" height="360" alt="Screenshot 2025-10-30 at 4 38 27 PM" src="https://github.com/user-attachments/assets/3eb02868-7763-4b35-bab2-57667e383efd" />

## How was it tested?

Ran a forced scenario that caused the bug before the fix (forced indefinite loading) and the bug does not happen with the fix.
