### PR TITLE
feat: create overlay qualifications and code gens with luminork

### DIFF
--- a/lib/dal/src/func/authoring.rs
+++ b/lib/dal/src/func/authoring.rs
@@ -400,6 +400,23 @@ impl FuncAuthoringClient {
         Ok(func)
     }
 
+    /// Creates a new Code Gen or Qualification Overlay Func and returns it
+    #[instrument(
+        name = "func.authoring.create_new_leaf_overlay_funcy",
+        level = "info",
+        skip(ctx)
+    )]
+    pub async fn create_new_leaf_overlay_func(
+        ctx: &DalContext,
+        name: Option<String>,
+        leaf_kind: LeafKind,
+        schema_id: SchemaId,
+        inputs: &[LeafInputLocation],
+    ) -> FuncAuthoringResult<Func> {
+        let func =
+            create::create_leaf_overlay_func(ctx, name, leaf_kind, schema_id, inputs).await?;
+        Ok(func)
+    }
     /// Creates a new Code Gen or Qualification Func and returns it
     #[instrument(
         name = "func.authoring.create_new_leaf_func",

--- a/lib/dal/src/schema.rs
+++ b/lib/dal/src/schema.rs
@@ -4,6 +4,10 @@ use std::{
     sync::Arc,
 };
 
+use leaf::{
+    LeafPrototype,
+    LeafPrototypeError,
+};
 use petgraph::Outgoing;
 use serde::{
     Deserialize,
@@ -99,6 +103,8 @@ pub enum SchemaError {
     Helper(#[from] HelperError),
     #[error("layer db error: {0}")]
     LayerDb(#[from] LayerDbError),
+    #[error("leaf prototype error: {0}")]
+    LeafPrototype(#[from] Box<LeafPrototypeError>),
     #[error("management prototype error: {0}")]
     ManagementPrototype(#[from] Box<ManagementPrototypeError>),
     #[error("No default schema variant exists for {0}")]
@@ -286,6 +292,16 @@ impl Schema {
             .map_err(Box::new)?;
         for management_proto in management_prototypes {
             let func_id = ManagementPrototype::func_id(ctx, management_proto.id())
+                .await
+                .map_err(Box::new)?;
+            func_ids.push(func_id);
+        }
+
+        let leaf_prototypes = LeafPrototype::for_schema(ctx, schema_id)
+            .await
+            .map_err(Box::new)?;
+        for leaf_proto in leaf_prototypes {
+            let func_id = LeafPrototype::func_id(ctx, leaf_proto.id())
                 .await
                 .map_err(Box::new)?;
             func_ids.push(func_id);

--- a/lib/dal/tests/integration_test/func/authoring/binding.rs
+++ b/lib/dal/tests/integration_test/func/authoring/binding.rs
@@ -182,7 +182,7 @@ async fn for_qualification(ctx: &mut DalContext) -> Result<()> {
     assert_eq!(
         LeafBinding {
             func_id,
-            attribute_prototype_id: binding.attribute_prototype_id,
+            leaf_binding_prototype: binding.leaf_binding_prototype,
             eventual_parent: EventualParent::SchemaVariant(schema_variant_id),
             inputs: vec![LeafInputLocation::Secrets],
             leaf_kind: LeafKind::Qualification
@@ -205,7 +205,7 @@ async fn for_code_generation(ctx: &mut DalContext) -> Result<()> {
     assert_eq!(
         LeafBinding {
             func_id,
-            attribute_prototype_id: binding.attribute_prototype_id,
+            leaf_binding_prototype: binding.leaf_binding_prototype,
             eventual_parent: EventualParent::SchemaVariant(schema_variant_id),
             inputs: vec![LeafInputLocation::Domain],
             leaf_kind: LeafKind::CodeGeneration
@@ -627,7 +627,7 @@ async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) -> Result<()> {
     assert_eq!(
         LeafBinding {
             func_id,
-            attribute_prototype_id: binding.attribute_prototype_id,
+            leaf_binding_prototype: binding.leaf_binding_prototype,
             eventual_parent: EventualParent::SchemaVariant(schema_variant_id),
             inputs: vec![LeafInputLocation::Domain],
             leaf_kind: LeafKind::CodeGeneration
@@ -637,7 +637,7 @@ async fn code_gen_cannot_create_cycle(ctx: &mut DalContext) -> Result<()> {
     let _cycle_check_guard = ctx.workspace_snapshot()?.enable_cycle_check().await;
     let result = LeafBinding::update_leaf_func_binding(
         ctx,
-        binding.attribute_prototype_id,
+        binding.leaf_binding_prototype,
         &[LeafInputLocation::Domain, LeafInputLocation::Code],
     )
     .await;
@@ -917,6 +917,7 @@ async fn return_the_right_bindings(ctx: &mut DalContext, nw: &WorkspaceSignup) -
                     inputs,
                     func_id,
                     attribute_prototype_id,
+                    ..
                 } => {
                     assert!(schema_variant_id.is_some());
                     assert!(component_id.is_none());

--- a/lib/dal/tests/integration_test/schema/leaf.rs
+++ b/lib/dal/tests/integration_test/schema/leaf.rs
@@ -59,7 +59,7 @@ async fn leaf_prototype_rerun(ctx: &mut DalContext) -> Result<()> {
         ctx,
         schema.id(),
         LeafKind::Qualification,
-        inputs.clone(),
+        &inputs,
         leaf_qual_func.id,
     )
     .await?;
@@ -162,7 +162,7 @@ async fn leaf_prototype_tests(ctx: &mut DalContext) -> Result<()> {
         ctx,
         schema.id(),
         LeafKind::Qualification,
-        inputs.clone(),
+        &inputs,
         leaf_qual_func.id,
     )
     .await?;

--- a/lib/dal/tests/integration_test/secret/with_schema_variant_authoring.rs
+++ b/lib/dal/tests/integration_test/secret/with_schema_variant_authoring.rs
@@ -76,7 +76,7 @@ async fn existing_code_gen_func_using_secrets_for_new_schema_variant(ctx: &mut D
     // Add the secrets input and commit.
     inputs.push(LeafInputLocation::Secrets);
     // can't update leaf bindings without unlocking all attached things!! because this changes the func args AND the prototype args :facepalm:
-    LeafBinding::update_leaf_func_binding(ctx, bindings.attribute_prototype_id, inputs.as_slice())
+    LeafBinding::update_leaf_func_binding(ctx, bindings.leaf_binding_prototype, inputs.as_slice())
         .await
         .expect("could not update leaf binding");
 

--- a/lib/luminork-server/src/service/v1/schemas/create_qualification.rs
+++ b/lib/luminork-server/src/service/v1/schemas/create_qualification.rs
@@ -5,6 +5,7 @@ use axum::{
 use dal::{
     FuncId,
     SchemaVariant,
+    cached_module::CachedModule,
     func::{
         authoring::FuncAuthoringClient,
         binding::EventualParent,
@@ -58,7 +59,7 @@ pub async fn create_variant_qualification(
     ChangeSetDalContext(ref ctx): ChangeSetDalContext,
     tracker: PosthogEventTracker,
     Path(SchemaVariantV1RequestPath {
-        schema_id: _,
+        schema_id,
         schema_variant_id,
     }): Path<SchemaVariantV1RequestPath>,
     payload: Result<
@@ -72,9 +73,13 @@ pub async fn create_variant_qualification(
         return Err(SchemaError::NotPermittedOnHead);
     }
 
-    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
-    if schema_variant.is_locked() {
-        return Err(SchemaError::LockedVariant(schema_variant_id));
+    let schema_id_for_variant: dal::SchemaId =
+        SchemaVariant::schema_id(ctx, schema_variant_id).await?;
+    if schema_id != schema_id_for_variant {
+        return Err(SchemaError::SchemaVariantNotMemberOfSchema(
+            schema_id,
+            schema_variant_id,
+        ));
     }
 
     let locations: Vec<LeafInputLocation> = vec![
@@ -84,14 +89,35 @@ pub async fn create_variant_qualification(
         LeafInputLocation::Secrets,
     ];
 
-    let func = FuncAuthoringClient::create_new_leaf_func(
-        ctx,
-        Some(payload.name),
-        LeafKind::Qualification,
-        EventualParent::SchemaVariant(schema_variant_id),
-        &locations,
-    )
-    .await?;
+    let is_builtin = CachedModule::find_latest_for_schema_id(ctx, schema_id)
+        .await?
+        .is_some();
+
+    let schema_variant = SchemaVariant::get_by_id(ctx, schema_variant_id).await?;
+
+    let func = if is_builtin {
+        FuncAuthoringClient::create_new_leaf_overlay_func(
+            ctx,
+            Some(payload.name),
+            LeafKind::Qualification,
+            schema_id,
+            &locations,
+        )
+        .await?
+    } else {
+        if schema_variant.is_locked() {
+            return Err(SchemaError::LockedVariant(schema_variant_id));
+        }
+
+        FuncAuthoringClient::create_new_leaf_func(
+            ctx,
+            Some(payload.name),
+            LeafKind::Qualification,
+            EventualParent::SchemaVariant(schema_variant_id),
+            &locations,
+        )
+        .await?
+    };
 
     FuncAuthoringClient::update_func(ctx, func.id, payload.display_name, payload.description)
         .await?;

--- a/lib/luminork-server/src/service/v1/schemas/detach_codegen_binding.rs
+++ b/lib/luminork-server/src/service/v1/schemas/detach_codegen_binding.rs
@@ -18,6 +18,7 @@ use sdf_extract::{
     change_set::ChangeSetDalContext,
 };
 use si_events::audit_log::AuditLogKind;
+use si_frontend_types::LeafBindingPrototype;
 use utoipa::{
     self,
 };
@@ -71,7 +72,15 @@ pub async fn detach_codegen_func_binding(
     for binding in bindings {
         if let FuncBinding::CodeGeneration(codegen) = binding {
             if codegen.leaf_kind == LeafKind::CodeGeneration {
-                LeafBinding::delete_leaf_func_binding(ctx, codegen.attribute_prototype_id).await?;
+                match codegen.leaf_binding_prototype {
+                    LeafBindingPrototype::Attribute(attribute_prototype_id) => {
+                        LeafBinding::delete_leaf_func_binding(ctx, attribute_prototype_id).await?;
+                    }
+                    LeafBindingPrototype::Overlay(leaf_prototype_id) => {
+                        LeafBinding::delete_leaf_overlay_func_binding(ctx, leaf_prototype_id)
+                            .await?;
+                    }
+                }
 
                 tracker.track(
                     ctx,
@@ -79,7 +88,7 @@ pub async fn detach_codegen_func_binding(
                     serde_json::json!({
                         "func_id": func.id,
                         "schema_variant_id": schema_variant_id,
-                        "attribute_prototype_id": codegen.attribute_prototype_id,
+                        "leaf_binding_prototype": codegen.leaf_binding_prototype,
                     }),
                 );
 

--- a/lib/sdf-server/src/service/v2/func.rs
+++ b/lib/sdf-server/src/service/v2/func.rs
@@ -96,6 +96,8 @@ pub enum FuncAPIError {
     MissingFuncId,
     #[error("no input location given")]
     MissingInputLocationForAttributeFunc,
+    #[error("no input locations given for leaf func")]
+    MissingInputLocationForLeafFunc,
     #[error("no output location given")]
     MissingOutputLocationForAttributeFunc,
     #[error("missing prototype id")]

--- a/lib/si-frontend-types-rs/src/lib.rs
+++ b/lib/si-frontend-types-rs/src/lib.rs
@@ -48,6 +48,7 @@ pub use crate::{
         FuncCode,
         FuncKind,
         FuncSummary,
+        LeafBindingPrototype,
         LeafInputLocation,
     },
     index::FrontEndObjectRequest,


### PR DESCRIPTION
The create qualification and create codegen endpoints in luminork will
now default to creating overlay functions if the schema is a builtin.

Tested by creating a qualification and codegen in luminork for a security group. Then creating a working workspace (cred + region and some vpcs imported) and creating security groups. Ensuring DVU dependent features (actions and quals/code gens) still worked correctly. Ensured qualification overlays re-run when button clicked on component.