### PR TITLE
fix: add prop suggestion for ou parentid

### DIFF
--- a/bin/clover/src/pipelines/aws/overrides.ts
+++ b/bin/clover/src/pipelines/aws/overrides.ts
@@ -77,6 +77,14 @@ export const AWS_PROP_OVERRIDES: Record<
     DataProtectionPolicy: policyDocumentProp,
   },
 
+  // AWS::Organizations
+  "AWS::Organizations::OrganizationalUnit": {
+    ParentId: [
+      suggest("AWS::Organizations::Organization", "RootId"),
+      suggest("AWS::Organizations::OrganizationalUnit", "/resource_value/Id"),
+    ],
+  },
+
   // Props that exist on resources across all of AWS
   ".*": {
     // Policy document props
@@ -242,7 +250,7 @@ export const AWS_SCHEMA_OVERRIDES = new Map<string, SchemaOverrideFn>([
         );
       spec.funcs.push(importFunc);
       variant.managementFuncs.push(importFuncSpec);
-      
+
       const { func: createDeploymentFunc, actionFuncSpec: createActionFuncSpec } =
         attachExtraActionFunction(
           "./src/pipelines/aws/funcs/overrides/AWS::Route53::RecordSet/actions/create.ts",
@@ -252,7 +260,7 @@ export const AWS_SCHEMA_OVERRIDES = new Map<string, SchemaOverrideFn>([
         );
       spec.funcs.push(createDeploymentFunc);
       variant.actionFuncs.push(createActionFuncSpec);
-      
+
       const { func: refreshDeploymentFunc, actionFuncSpec: refreshActionFuncSpec } =
         attachExtraActionFunction(
           "./src/pipelines/aws/funcs/overrides/AWS::Route53::RecordSet/actions/refresh.ts",
@@ -268,7 +276,7 @@ export const AWS_SCHEMA_OVERRIDES = new Map<string, SchemaOverrideFn>([
     "AWS::CertificateManager::Certificate",
     (spec: ExpandedPkgSpec) => {
       const variant = spec.schemas[0].variants[0];
-      
+
       const { func: createDeploymentFunc, actionFuncSpec: createActionFuncSpec } =
         attachExtraActionFunction(
           "./src/pipelines/aws/funcs/overrides/AWS::CertificateManager::Certificate/actions/create.ts",
@@ -278,7 +286,7 @@ export const AWS_SCHEMA_OVERRIDES = new Map<string, SchemaOverrideFn>([
         );
       spec.funcs.push(createDeploymentFunc);
       variant.actionFuncs.push(createActionFuncSpec);
-      
+
       const { func: refreshDeploymentFunc, actionFuncSpec: refreshActionFuncSpec } =
         attachExtraActionFunction(
           "./src/pipelines/aws/funcs/overrides/AWS::CertificateManager::Certificate/actions/refresh.ts",


### PR DESCRIPTION
Adds a prop suggestion to the ParentId prop on the AWS::Organization::OrganizationalUnit Schema.

#### Screenshots:

<img width="1242" height="759" alt="Screenshot 2025-10-30 at 22 27 11" src="https://github.com/user-attachments/assets/57a60916-2af5-4a65-b08a-b07cba696714" />

## How was it tested?

- [X] Manual test: added suggestion to Component via the UI to test before implementing here.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNnRsNmM5emNmczM4ODliY216b2ZmZHV2aHN3bG9rM2syYmQ1MGQwbCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QYj1X68kn2Xlu/giphy.gif"/>
