### PR TITLE
Add prop suggestions for Azure pluralized matches

### DIFF
--- a/bin/clover/src/pipelines/azure/pipeline-steps/createSuggestionsAcrossAssets.ts
+++ b/bin/clover/src/pipelines/azure/pipeline-steps/createSuggestionsAcrossAssets.ts
@@ -1,0 +1,64 @@
+import _ from "lodash";
+
+import { bfsPropTree } from "../../../spec/props.ts";
+import pluralize from "npm:pluralize@^8.0.0";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+import { addPropSuggestSource } from "../../../spec/props.ts";
+import _logger from "../../../logger.ts";
+const logger = _logger.ns("test").seal();
+
+export function createSuggestionsForIds(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  const schemasByResourceTypeName = new Map<string, Set<string>>();
+
+  // Go through all the specs and get all the things that we may possibly want to reference.
+  for (const spec of specs) {
+    const resourceTypeName = spec.name.split("/").pop();
+    if (!resourceTypeName) continue;
+    const schemas = schemasByResourceTypeName.get(resourceTypeName) ?? new Set();
+    schemas.add(spec.name);
+    schemasByResourceTypeName.set(resourceTypeName, schemas);
+  }
+
+  // Iterate over all specs again and find matches for "<pluralized-schema-name>/id" props and
+  // "/resource_value/id" props.
+  for (const spec of specs) {
+    const [schema] = spec.schemas;
+    const [schemaVariant] = schema.variants;
+    const domain = schemaVariant.domain;
+
+    // TODO(nick,jkeiser): this is a bit "brute force" right now, but we need to handle suffixes
+    // and prefixes. For example "pool/id" might actually need to correspond it to the
+    // "Microsoft.Network/networkManagers/{networkManagerName}/ipamPools" resource. Another example
+    // is "gatewayLoadBalancers" vs. "loadBalancers".
+    //
+    // Another issue is that this doesn't handle an array of references. We aren't stripping the
+    // word "Item" from the prop name like we do for AWS assets yet.
+    bfsPropTree(
+      domain,
+      (prop) => {
+        // We will only process object props that are not "/root/domain".
+        if (prop.kind !== "object" || prop.metadata.propPath.length < 3) return;
+
+        const idProp = prop.entries.find((p) => p.name === "id");
+        if (!idProp) return;
+        const objectPropNamePluralized = pluralize(prop.name);
+
+        const schemas = schemasByResourceTypeName.get(objectPropNamePluralized);
+        if (!schemas) return;
+
+        for (const schema of schemas) {
+          logger.debug(
+            `suggest {schema:${schema}, prop:/resource_value/id for prop ${idProp.metadata.propPath.join('/')} on ${spec.name}`,
+          );
+          addPropSuggestSource(idProp, {
+            schema,
+            prop: "/resource_value/id",
+          });
+        }
+      }
+    );
+  }
+  return specs;
+}

--- a/bin/clover/src/pipelines/azure/pipeline.ts
+++ b/bin/clover/src/pipelines/azure/pipeline.ts
@@ -3,7 +3,6 @@ import { PipelineOptions } from "../types.ts";
 import { generateDefaultFuncsFromConfig } from "../generic/index.ts";
 import { getExistingSpecs } from "../../specUpdates.ts";
 import { generateIntrinsicFuncs } from "../generic/generateIntrinsicFuncs.ts";
-// import { createSuggestionsForPrimaryIdentifiers } from "../generic/createSuggestionsAcrossAssets.ts";
 import { reorderProps } from "../generic/reorderProps.ts";
 import { updateSchemaIdsForExistingSpecs } from "../generic/updateSchemaIdsForExistingSpecs.ts";
 import { generateAssetFuncs } from "../generic/generateAssetFuncs.ts";
@@ -15,6 +14,7 @@ import {
   readAzureSwaggerSpec,
 } from "./schema.ts";
 import { parseAzureSpec } from "./spec.ts";
+import { createSuggestionsForIds } from "./pipeline-steps/createSuggestionsAcrossAssets.ts";
 
 export async function generateAzureSpecs(
   options: PipelineOptions,
@@ -28,7 +28,7 @@ export async function generateAzureSpecs(
   specs = addDefaultProps(specs);
   specs = generateDefaultFuncsFromConfig(specs, azureConfig);
   specs = generateIntrinsicFuncs(specs);
-  // specs = createSuggestionsForPrimaryIdentifiers(specs);
+  specs = createSuggestionsForIds(specs);
 
   // Apply provider-specific overrides
   specs = applyAssetOverrides(specs, azureConfig);

--- a/bin/clover/src/pipelines/azure/provider.ts
+++ b/bin/clover/src/pipelines/azure/provider.ts
@@ -63,21 +63,15 @@ function azureIsChildRequired(
   return schema.requiredProperties.has(childName);
 }
 
-// TODO(nick): move to file.
-// {
-//   "schemaName": {
-//     "propPath": ["list", "of", "override"],
-//     "propPath": "singleOverride"
+// NOTE(nick,jkeiser): here is an example of what overrides look like...
+// const AZURE_PROP_OVERRIDES: Record<
+//   string,
+//   Record<string, PropOverrideFn | PropOverrideFn[]>
+// > = {
+//   "Microsoft.Network/loadBalancers": {
+//     "properties/frontendIPConfigurations/frontendIPConfigurationsItem/properties/publicIPAddress/id": suggest("Microsoft.Network/publicIPAddresses", "id"),
 //   }
-// }
-const AZURE_PROP_OVERRIDES: Record<
-  string,
-  Record<string, PropOverrideFn | PropOverrideFn[]>
-> = {
-  "Microsoft.Network/loadBalancers": {
-    "properties/frontendIPConfigurations/frontendIPConfigurationsItem/properties/publicIPAddress/id": suggest("Microsoft.Network/publicIPAddresses", "id"),
-  }
-};
+// };
 
 export const AZURE_PROVIDER_CONFIG: ProviderConfig = {
   name: "azure",
@@ -98,7 +92,7 @@ export const AZURE_PROVIDER_CONFIG: ProviderConfig = {
   normalizeProperty: (prop: JSONSchema) => prop as AzureProperty,
   isChildRequired: azureIsChildRequired,
   overrides: {
-    propOverrides: AZURE_PROP_OVERRIDES,
+    propOverrides: {},
     schemaOverrides: new Map(),
   },
   metadata: {


### PR DESCRIPTION
## Description

This change adds prop suggestions for all Azure assets where the parent prop of an "id" prop matches the pluralized name of another Azure asset.

An example: say you have a "Microsoft.Network/todds" asset and a "Microsoft.Network/howards" asset. The "todds" asset has a deeply nested prop called "id" where its parent is "howard" (pluralized). By convention, this implies that the "id" expected corresponds to a resource ID for the "howard" asset.

That being said, this change does not cover every scenario. For example, if the parent of the "id" prop is "pools", but an "ipamPool" ID is expected, it will not suggested. That is for a future iteration.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaGdweGNrcjdobG55ZzA1em96dWR5NnN4azBlMXdvNmJzeTBiYXQxcCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/FYVDcLexsVRrH0YCWr/giphy.gif"/>