### PR TITLE
fix(conduit): Don't unlock unnecessary schemas or create unnecessary change sets

### DIFF
--- a/bin/si-conduit/.gitignore
+++ b/bin/si-conduit/.gitignore
@@ -1,0 +1,4 @@
+# For devs - Don't add the conduit project folders that get created when you run the commands on this folder.
+schemas/
+.conduitroot
+si-conduit

--- a/bin/si-conduit/src/generators.ts
+++ b/bin/si-conduit/src/generators.ts
@@ -379,7 +379,7 @@ function schemaMetadata(schemaName: string): SchemaMetadata {
     name: schemaName,
     category: "",
     description: "optional",
-    documentation: "optional, should be a link",
+    documentation: null, // "optional, should be a link",
   };
 }
 


### PR DESCRIPTION


<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Change the order in which we did operations on push so we can avoid write unnecessary unlocks and write operations, by checking the filesystem data against head as the first step. 

Extras: 
- Added the link  in schemas when pushing
- Make sure we fail very early if we have duplicated schema names

#### Screenshots:

<img width="1103" height="211" alt="image" src="https://github.com/user-attachments/assets/9f1c3dbc-7a2c-410b-af4d-ebea1d9c7d49" />



## How was it tested?

<!-- Does it have automated tests? What manual tests did you do? -->
<!-- Sometimes it's nice to use this as a mini "test plan" for manual testing, too--write them down and check them
off :)-->

- [X] Manual test: Validated that only having unchanged schemas does not create a changeset
- [X] Manual test: Created a new schema, pulled an 2 existing schemas and modified one. Validated that only the necessary schemas and functions would be unlocked, and also that funcs are being erased. 

