### PR TITLE
feat(web): Filter actions by originating change set in actions view list

### DIFF
--- a/app/web/src/newhotness/logic_composables/component_actions.ts
+++ b/app/web/src/newhotness/logic_composables/component_actions.ts
@@ -104,6 +104,13 @@ export const useComponentActions = (
     const result: Record<ActionPrototypeId, ActionProposedView> = {};
     for (const action of actionViewList.data.value.actions) {
       if (action.componentId === component.value.id) {
+        // When in a change set (not HEAD), only show actions that originated in the current change set
+        if (
+          !ctx.onHead.value &&
+          action.originatingChangeSetId !== ctx.changeSetId.value
+        ) {
+          continue;
+        }
         // NOTE(nick): this assumes that there can be one action for a given prototype and component.
         // As of the time of writing, this is true, but multiple actions per prototype and component
         // aren't disallowed from the underlying graph's perspective. Theorhetically, you could


### PR DESCRIPTION
When viewing a change set, only show actions that originated in that specific change set. Previously, all actions were displayed regardless of which change set they originated from, which could be confusing for users working in different change sets.

Why filter this in the front end, currently the MV reads the data from the graph so the graph has all of the actions from HEAD that are replayed to the change set. Changing the graph here is way more risky, we can always remove the filter at a later date if we decide to do this a different way

Added 4 new test cases covering change set filtering scenarios:
- HEAD shows all actions regardless of origin
- Change sets only show actions from current change set
- No actions shown when all are from different change sets
- Correct filtering with multiple components and change sets