### PR TITLE
fixed truncation bug in QualificationView

### DIFF
--- a/app/web/src/newhotness/QualificationView.vue
+++ b/app/web/src/newhotness/QualificationView.vue
@@ -1,9 +1,11 @@
 <template>
   <li class="rounded border border-neutral-600 [&>div]:p-xs">
     <div
-      class="border-b border-neutral-600 text-sm flex flex-row items-center justify-between"
+      class="border-b border-neutral-600 text-sm flex flex-row items-center justify-between gap-xs"
     >
-      <span>{{ qualification.name }}</span>
+      <TruncateWithTooltip :lineClamp="3">
+        {{ qualification.name }}
+      </TruncateWithTooltip>
       <NewButton
         v-if="qualification.avId"
         label="Rerun qualification"
@@ -64,7 +66,11 @@
 <script lang="ts" setup>
 import { computed, ref, toRef } from "vue";
 import * as _ from "lodash-es";
-import { LoadingMessage, NewButton } from "@si/vue-lib/design-system";
+import {
+  LoadingMessage,
+  NewButton,
+  TruncateWithTooltip,
+} from "@si/vue-lib/design-system";
 import StatusMessageBox from "@/newhotness/layout_components/StatusMessageBox.vue";
 import CodeViewer from "@/components/CodeViewer.vue";
 import {


### PR DESCRIPTION
## How does this PR change the system?

A small truncation bug fix to the `QualificationView` component. Thank you @aaron-dernley for finding this one!

#### Screenshots:

Before the fix - long qualification names took up too much space and could break the UI -
<img width="376" height="550" alt="Screenshot 2025-10-31 at 1 36 15 PM" src="https://github.com/user-attachments/assets/97df2b07-85c9-46df-8f0c-0c68adfc66a4" />

After the fix - qualification names are truncated with a tooltip after three lines -
<img width="377" height="356" alt="Screenshot 2025-10-31 at 1 35 53 PM" src="https://github.com/user-attachments/assets/aef959c7-cb42-4edc-a2da-6ba8924eb218" />