### PR TITLE
fix(clover): Ignore the massive schema

### DIFF
--- a/bin/clover/src/pipelines/azure/pipeline-steps/removeUnneededAssets.ts
+++ b/bin/clover/src/pipelines/azure/pipeline-steps/removeUnneededAssets.ts
@@ -1,0 +1,13 @@
+import _logger from "../../../logger.ts";
+import _ from "lodash";
+import { ExpandedPkgSpec } from "../../../spec/pkgs.ts";
+const IGNORED_CATEGORIES = [
+  "Microsoft.RecoveryServices/vaults/replicationRecoveryPlans",
+];
+export function removeUnneededAssets(
+  specs: ExpandedPkgSpec[],
+): ExpandedPkgSpec[] {
+  return specs.filter(({ schemas: [{ variants: [variant] }] }) =>
+    !IGNORED_CATEGORIES.find((c) => variant.superSchema.typeName.startsWith(c))
+  );
+}

--- a/bin/clover/src/pipelines/azure/pipeline.ts
+++ b/bin/clover/src/pipelines/azure/pipeline.ts
@@ -15,6 +15,7 @@ import {
 } from "./schema.ts";
 import { parseAzureSpec } from "./spec.ts";
 import { createSuggestionsForIds } from "./pipeline-steps/createSuggestionsAcrossAssets.ts";
+import { removeUnneededAssets } from "./pipeline-steps/removeUnneededAssets.ts";
 
 export async function generateAzureSpecs(
   options: PipelineOptions,
@@ -25,6 +26,7 @@ export async function generateAzureSpecs(
   let specs = await getLatestAzureSpecs(options);
 
   // Apply pipeline steps
+  specs = removeUnneededAssets(specs);
   specs = addDefaultProps(specs);
   specs = generateDefaultFuncsFromConfig(specs, azureConfig);
   specs = generateIntrinsicFuncs(specs);


### PR DESCRIPTION
This schema Microsoft.RecoveryServices/vaults/replicationRecoveryPlans is over 200MB so is failing to insert to the cached_modules table