### PR TITLE
fix(dal): ensure deletes and upgrades cannot break components with subs

### DIFF
--- a/lib/dal/src/attribute/value.rs
+++ b/lib/dal/src/attribute/value.rs
@@ -252,6 +252,8 @@ pub enum AttributeValueError {
     NotFoundForComponentAndInputSocket(ComponentId, InputSocketId),
     #[error("attribute value {0} has no outgoing edge to a prop or socket")]
     OrphanedAttributeValue(AttributeValueId),
+    #[error("attribute value {0} could not be linked to a component")]
+    OrphanedAttributeValueNoComponent(AttributeValueId),
     #[error("output socket error: {0}")]
     OutputSocketError(#[from] Box<OutputSocketError>),
     #[error("parent prop of map or array not found: {0}")]
@@ -997,7 +999,7 @@ impl AttributeValue {
                 .await?
                 .first()
                 .copied()
-                .ok_or(AttributeValueError::OrphanedAttributeValue(
+                .ok_or(AttributeValueError::OrphanedAttributeValueNoComponent(
                     current_attribute_value_id,
                 ))?,
         };


### PR DESCRIPTION
Suppose you have a component A on HEAD. And, in another change set, you have B, which has an outgoing ValueSubscription edge to the root attribute value of A (subscribe a value on B to a value on A). If you either: upgrade A to a new schema variant and apply to HEAD, or delete A and apply to HEAD, we will not remove the root attribute value or the incoming ValueSubscription edges for that deleted component without this correction. The result is that the component B will be broken in the change set.

This correction ensures that any time we either delete a component, or detect that its schema variant is being upgraded, we esnure the root attribute value is removed and we ensure that the attribute prototype arguments that are the source for the ValueSubscription edges are also removed, so that the subscribing (destination) component does not have broken attribute values.

Should close BUG-1123.

This one deserves manual testing, first just deleting and appying and seeing how it goes. Second, replicate the scenario in the description above and ensure that the change sets remain in a good state.