### PR TITLE
Virtualize the component creation modal

### DIFF
--- a/app/web/src/newhotness/AddComponentModalListRow.vue
+++ b/app/web/src/newhotness/AddComponentModalListRow.vue
@@ -1,0 +1,110 @@
+<template>
+  <div
+    :style="{ 'border-left-color': rowData.color }"
+    :class="
+      clsx(
+        'absolute top-0 left-0 w-full flex flex-row items-center px-xs gap-2xs border-l-[3px] cursor-pointer',
+        category && themeClasses('bg-neutral-200', 'bg-neutral-700'),
+        category &&
+          themeClasses('hover:text-action-500', 'hover:text-action-300'),
+        schema &&
+          'hover:outline hover:z-10 hover:-outline-offset-1 hover:outline-1',
+        themeClasses(
+          'bg-shade-0 hover:outline-action-500',
+          'bg-neutral-800 hover:outline-action-300',
+        ),
+        selected && [
+          'add-component-selected-item',
+          themeClasses(
+            'outline-action-500 bg-action-200',
+            'outline-action-300 bg-action-900',
+          ),
+        ],
+      )
+    "
+  >
+    <Icon
+      v-if="category"
+      size="lg"
+      :name="open ? 'chevron--down' : 'chevron--right'"
+    />
+
+    <Icon
+      v-if="category && category.icon"
+      size="md"
+      :name="category.icon"
+      class="mr-xs"
+    />
+    <div class="flex flex-row items-center gap-xs">
+      <TruncateWithTooltip>
+        {{ rowData.name }}
+      </TruncateWithTooltip>
+      <EditingPill
+        v-if="'editing' in rowData && rowData.editing"
+        :color="rowData.color"
+      />
+    </div>
+    <div class="ml-auto flex flex-none">
+      <Icon v-if="submitted" name="loader" size="sm" />
+      <div
+        v-else-if="selected"
+        :class="
+          clsx('text-xs', themeClasses('text-neutral-900', 'text-neutral-200'))
+        "
+      >
+        <TextPill tighter variant="key2">Enter</TextPill> to add
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import clsx from "clsx";
+import {
+  Icon,
+  IconNames,
+  themeClasses,
+  TruncateWithTooltip,
+  TextPill,
+} from "@si/vue-lib/design-system";
+import { computed } from "vue";
+import EditingPill from "@/components/EditingPill.vue";
+import { UISchemaKey } from "./AddComponentModal.vue";
+
+const props = defineProps<{
+  rowData: AddComponentRowData;
+  open?: boolean;
+  selected: boolean;
+  submitted: boolean;
+  idx: number;
+}>();
+
+const category = computed<CategoryRow | undefined>(() => {
+  if (props.rowData.type === "category") return props.rowData;
+  return undefined;
+});
+
+const schema = computed<SchemaRow | undefined>(() => {
+  if (props.rowData.type === "schema") return props.rowData;
+  return undefined;
+});
+</script>
+
+<script lang="ts">
+interface AddComponentBaseRowData {
+  color: string;
+  name: string;
+}
+
+export type SchemaRow = AddComponentBaseRowData & {
+  type: "schema";
+  editing: boolean;
+  key: UISchemaKey;
+};
+export type CategoryRow = AddComponentBaseRowData & {
+  type: "category";
+  icon?: IconNames;
+};
+
+export type AddComponentRowData = SchemaRow | CategoryRow;
+</script>

--- a/app/web/src/newhotness/explore_grid/ExploreGrid.vue
+++ b/app/web/src/newhotness/explore_grid/ExploreGrid.vue
@@ -157,7 +157,7 @@ const virtualListHeight = computed(() => virtualList.value.getTotalSize());
 // Got through all the rows, save the id of the latest contentRow.
 // If it's initialId is bigger than the id we're looking for, the previous one was the target row,
 // otherwise, contentRow idx is the target.
-// This is extra  complicated sinc ewe need to skip headers and footerss
+// This is extra complicated since we need to skip headers and footers
 const getRowIndexByGridTileIndex = (idx: number) => {
   let lastValidRowIndex = 0;
 

--- a/lib/vue-lib/src/design-system/utils/color_utils.ts
+++ b/lib/vue-lib/src/design-system/utils/color_utils.ts
@@ -10,6 +10,7 @@ export const BRAND_COLOR_FILTER_HEX_CODES = {
   "Google Cloud": "#EF6255",
   "Open AI": "#FFBE19",
   AWS: "#FF9900",
+  MS: "rgb(0, 120, 212)",
   Azure: "#104581",
   CoreOS: "#E9659C",
   Custom: "#E5E5E5",


### PR DESCRIPTION
Thank you Victor for getting this started!!

## How does this PR change the system?

Virtualize the list of thousands of assets in the add component modal.

This means no longer using the `<Treeform>` components because it creates a nested hierarchy that won't work with the virtual approach because it needs a flat list.

## How was it tested?

- [X] typing doesn't suck!!!
- [X] Integration tests pass
- [X] Manual test: new functionality works in UI (all the keyboard controls, scrolling, etc etc)
- [X] Manual test: (regression check) creating a component still works with click and enter
- [X] Manual test: unlock an asset, ensure you see `editing` as well as the default in the list
- [X] Here is a fun one:
- open the modal
- press up a few times
- scroll to the middle of the list
- open a category
- click on a schema
- ensure the list is scrolled to the one you clicked on

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdleDdpdmp3bHN4dTUxZDBtcnd3Z3oyazZjbXc1M2F0cHB6NXcyNm4zZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/PlgpYSFkuQi5VdoNK7/giphy.gif"/>
