### PR TITLE
fix(web): Escape forward slashes and tildes in map keys for JSON Pointer compliance

### DIFF
--- a/app/web/src/newhotness/AttributePanel.test.ts
+++ b/app/web/src/newhotness/AttributePanel.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AttributePath } from "@/api/sdf/dal/component";
+
+// REQUIRED for all testing
+import { CONTEXT } from "@/newhotness/testing/context1";
+
+/**
+ * Tests for AttributePanel - JSON Pointer escaping for map keys
+ *
+ * These tests validate that map keys with special characters (/ and ~) are properly
+ * escaped according to RFC 6901 (JSON Pointer specification) before being sent to the backend.
+ */
+
+// Track API calls made during tests
+let mockApiCalls: Array<{
+  route: string;
+  method: string;
+  payload: Record<string, unknown>;
+}>;
+
+// Mock heimdall using the inner pattern like other tests
+type HeimdallInner = typeof import("@/store/realtime/heimdall_inner");
+vi.mock("@/store/realtime/heimdall", async () => {
+  const inner = await vi.importActual<HeimdallInner>(
+    "@/store/realtime/heimdall_inner",
+  );
+  return {
+    useMakeKey: () => inner.innerUseMakeKey(CONTEXT.value),
+    useMakeArgs: () => inner.innerUseMakeArgs(CONTEXT.value),
+    bifrost: vi.fn(),
+  };
+});
+
+// Mock vue-router
+vi.mock("vue-router", () => ({
+  useRoute: () => ({
+    params: { workspacePk: "test-workspace", changeSetId: "test-changeset" },
+  }),
+}));
+
+// Mock the api composables
+vi.mock("./api_composables", () => ({
+  routes: {
+    UpdateComponentAttributes: "update-component-attributes",
+  },
+  useApi: () => ({
+    endpoint: vi.fn((route: string, _params?: { id?: string }) => ({
+      put: vi.fn(async (payload: Record<string, unknown>) => {
+        mockApiCalls.push({
+          route,
+          method: "PUT",
+          payload,
+        });
+        return {
+          req: { status: 200 },
+          newChangeSetId: "new-changeset-id",
+        };
+      }),
+    })),
+    setWatchFn: vi.fn(),
+    ok: vi.fn(() => true),
+    navigateToNewChangeSet: vi.fn(),
+  }),
+  componentTypes: {},
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApiCalls = [];
+});
+
+/**
+ * Mock API integration tests
+ *
+ * These tests simulate the setKey behavior and verify that the mocked API
+ * endpoint receives correctly escaped paths in the payload, matching how
+ * AttributePanel.vue and AttributePanelBulk.vue construct their API calls.
+ */
+describe("setKey API integration with escaped keys", () => {
+  test("API receives correctly escaped forward slash in map key", async () => {
+    // Given: The API composable and escape utility (as used in AttributePanel)
+    const { useApi, routes } = await import("./api_composables");
+    const { escapeJsonPointerSegment } = await import("./util");
+    const api = useApi();
+
+    const componentId = "test-component-123";
+    const basePath = "/domain/config";
+    const key = "test/paul"; // User enters this key in the UI
+    const value = {};
+
+    // When: Simulating setKey behavior - this is exactly what AttributePanel does
+    const escapedKey = escapeJsonPointerSegment(key);
+    const childPath = `${basePath}/${escapedKey}` as AttributePath;
+    const payload = { [childPath]: value };
+
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The mock API should have received the payload with escaped path
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.route).toBe("update-component-attributes");
+    expect(mockApiCalls[0]?.method).toBe("PUT");
+    expect(mockApiCalls[0]?.payload).toHaveProperty(
+      "/domain/config/test~1paul",
+    );
+    expect(mockApiCalls[0]?.payload["/domain/config/test~1paul"]).toEqual({});
+  });
+
+  test("API receives correctly escaped tilde in map key", async () => {
+    // Given: The API composable and escape utility
+    const { useApi, routes } = await import("./api_composables");
+    const { escapeJsonPointerSegment } = await import("./util");
+    const api = useApi();
+
+    const componentId = "test-component-456";
+    const basePath = "/domain/settings";
+    const key = "config~key"; // Key contains tilde
+    const value = "";
+
+    // When: Simulating setKey behavior with tilde in key
+    const escapedKey = escapeJsonPointerSegment(key);
+    const childPath = `${basePath}/${escapedKey}` as AttributePath;
+    const payload = { [childPath]: value };
+
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The tilde should be escaped as ~0 in the API payload
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toHaveProperty(
+      "/domain/settings/config~0key",
+    );
+    expect(mockApiCalls[0]?.payload["/domain/settings/config~0key"]).toBe("");
+  });
+
+  test("API receives correctly escaped path with both forward slash and tilde", async () => {
+    // Given: The API composable and escape utility
+    const { useApi, routes } = await import("./api_composables");
+    const { escapeJsonPointerSegment } = await import("./util");
+    const api = useApi();
+
+    const componentId = "test-component-789";
+    const basePath = "/domain/IamPolicies";
+    const key = "policy/~admin"; // Key contains both special characters
+    const value = { role: "admin" };
+
+    // When: Simulating setKey behavior with both special characters
+    const escapedKey = escapeJsonPointerSegment(key);
+    const childPath = `${basePath}/${escapedKey}` as AttributePath;
+    const payload = { [childPath]: value };
+
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: Both characters should be properly escaped (/ → ~1, ~ → ~0)
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toHaveProperty(
+      "/domain/IamPolicies/policy~1~0admin",
+    );
+    expect(
+      mockApiCalls[0]?.payload["/domain/IamPolicies/policy~1~0admin"],
+    ).toEqual({ role: "admin" });
+  });
+
+  test("API receives correctly escaped real-world AWS ARN with forward slash", async () => {
+    // Given: A realistic scenario with an AWS ARN containing forward slash
+    const { useApi, routes } = await import("./api_composables");
+    const { escapeJsonPointerSegment } = await import("./util");
+    const api = useApi();
+
+    const componentId = "test-component-aws";
+    const basePath = "/domain/IamRoles";
+    const key = "arn:aws:iam::123456789012/role-name"; // Real AWS ARN format
+    const value = { arn: key };
+
+    // When: Simulating setKey behavior with AWS ARN
+    const escapedKey = escapeJsonPointerSegment(key);
+    const childPath = `${basePath}/${escapedKey}` as AttributePath;
+    const payload = { [childPath]: value };
+
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The forward slash in the ARN should be escaped
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toHaveProperty(
+      "/domain/IamRoles/arn:aws:iam::123456789012~1role-name",
+    );
+    expect(
+      mockApiCalls[0]?.payload[
+        "/domain/IamRoles/arn:aws:iam::123456789012~1role-name"
+      ],
+    ).toEqual({ arn: key });
+  });
+
+  test("API receives multiple escaped forward slashes in path-like keys", async () => {
+    // Given: A path-like key with multiple forward slashes
+    const { useApi, routes } = await import("./api_composables");
+    const { escapeJsonPointerSegment } = await import("./util");
+    const api = useApi();
+
+    const componentId = "test-component-path";
+    const basePath = "/domain/FilePaths";
+    const key = "path/to/resource"; // Multiple slashes
+    const value = { location: key };
+
+    // When: Simulating setKey behavior with multiple slashes
+    const escapedKey = escapeJsonPointerSegment(key);
+    const childPath = `${basePath}/${escapedKey}` as AttributePath;
+    const payload = { [childPath]: value };
+
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: All forward slashes should be escaped
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toHaveProperty(
+      "/domain/FilePaths/path~1to~1resource",
+    );
+    expect(
+      mockApiCalls[0]?.payload["/domain/FilePaths/path~1to~1resource"],
+    ).toEqual({ location: key });
+  });
+
+  test("API receives normal keys without modification", async () => {
+    // Given: A normal key without special characters
+    const { useApi, routes } = await import("./api_composables");
+    const { escapeJsonPointerSegment } = await import("./util");
+    const api = useApi();
+
+    const componentId = "test-component-normal";
+    const basePath = "/domain/config";
+    const key = "normalKey123"; // No special characters
+    const value = { setting: "value" };
+
+    // When: Simulating setKey behavior with normal key
+    const escapedKey = escapeJsonPointerSegment(key);
+    const childPath = `${basePath}/${escapedKey}` as AttributePath;
+    const payload = { [childPath]: value };
+
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The key should remain unchanged in the API payload
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toHaveProperty(
+      "/domain/config/normalKey123",
+    );
+    expect(mockApiCalls[0]?.payload["/domain/config/normalKey123"]).toEqual({
+      setting: "value",
+    });
+  });
+});

--- a/app/web/src/newhotness/AttributePanel.vue
+++ b/app/web/src/newhotness/AttributePanel.vue
@@ -209,7 +209,7 @@ import ComponentSecretAttribute from "./layout_components/ComponentSecretAttribu
 import { useWatchedForm } from "./logic_composables/watched_form";
 import { NameFormData } from "./ComponentDetails.vue";
 import EmptyState from "./EmptyState.vue";
-import { findAttributeValueInTree } from "./util";
+import { findAttributeValueInTree, escapeJsonPointerSegment } from "./util";
 import {
   arrayAttrTreeIntoTree,
   AttrTree,
@@ -392,8 +392,11 @@ const setKey = async (
     () => attributeTree.children.length > initialChildrenCount,
   );
 
+  // Escape the key according to RFC 6901 (JSON Pointer spec)
+  // This ensures special characters like '/' and '~' are properly escaped
+  const escapedKey = escapeJsonPointerSegment(key);
   const childPath =
-    `${attributeTree.attributeValue.path}/${key}` as AttributePath;
+    `${attributeTree.attributeValue.path}/${escapedKey}` as AttributePath;
   const payload = {
     [childPath]: value,
   };

--- a/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
+++ b/app/web/src/newhotness/explore_grid/AttributePanelBulk.vue
@@ -330,6 +330,7 @@ import {
   ExploreContext,
 } from "../types";
 import { AttributeErrors } from "../AttributePanel.vue";
+import { escapeJsonPointerSegment } from "../util";
 
 const ctx = useContext();
 const exploreContext = inject<ExploreContext>("EXPLORE_CONTEXT");
@@ -624,8 +625,11 @@ const setKey = async (
 
   const apis = createCalls();
 
+  // Escape the key according to RFC 6901 (JSON Pointer spec)
+  // This ensures special characters like '/' and '~' are properly escaped
+  const escapedKey = escapeJsonPointerSegment(key);
   const appendPath =
-    `${attributeTree.attributeValue.path}/${key}` as AttributePath;
+    `${attributeTree.attributeValue.path}/${escapedKey}` as AttributePath;
   const calls = apis.map(async (call) => {
     const payload = {
       [appendPath]: value,

--- a/app/web/src/newhotness/util.test.ts
+++ b/app/web/src/newhotness/util.test.ts
@@ -1,0 +1,134 @@
+import { expect, test, describe } from "vitest";
+import { escapeJsonPointerSegment } from "./util";
+
+/**
+ * Tests for escapeJsonPointerSegment function
+ *
+ * This function escapes string segments for use in JSON Pointers according to RFC 6901.
+ * JSON Pointers use '~' as an escape character:
+ * - '~' must be encoded as '~0'
+ * - '/' must be encoded as '~1'
+ */
+
+describe("escapeJsonPointerSegment", () => {
+  test("escapes forward slash in key name", () => {
+    // Given: A key with a forward slash
+    const key = "test/paul";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Forward slash should be escaped as ~1
+    expect(escaped).toBe("test~1paul");
+  });
+
+  test("escapes tilde in key name", () => {
+    // Given: A key with a tilde
+    const key = "a~b";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Tilde should be escaped as ~0
+    expect(escaped).toBe("a~0b");
+  });
+
+  test("escapes both tilde and forward slash in correct order", () => {
+    // Given: A key with both tilde and forward slash
+    const key = "test/~foo";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Tilde should be escaped first (~0), then forward slash (~1)
+    expect(escaped).toBe("test~1~0foo");
+  });
+
+  test("does not modify key without special characters", () => {
+    // Given: A key with only regular characters
+    const key = "normalKey123";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Key should remain unchanged
+    expect(escaped).toBe("normalKey123");
+  });
+
+  test("escapes multiple forward slashes", () => {
+    // Given: A key with multiple forward slashes
+    const key = "path/to/resource";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: All forward slashes should be escaped
+    expect(escaped).toBe("path~1to~1resource");
+  });
+
+  test("escapes multiple tildes", () => {
+    // Given: A key with multiple tildes
+    const key = "~a~b~c";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: All tildes should be escaped
+    expect(escaped).toBe("~0a~0b~0c");
+  });
+
+  test("handles empty string", () => {
+    // Given: An empty string
+    const key = "";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Empty string should remain empty
+    expect(escaped).toBe("");
+  });
+
+  test("escapes complex key with mixed special characters", () => {
+    // Given: A key with complex pattern of special characters
+    const key = "~/test/~/path~";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: All special characters should be properly escaped
+    expect(escaped).toBe("~0~1test~1~0~1path~0");
+  });
+
+  test("handles key with spaces and special characters", () => {
+    // Given: A key with spaces and special characters
+    const key = "user name/email~address";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Only special characters should be escaped, spaces remain
+    expect(escaped).toBe("user name~1email~0address");
+  });
+
+  test("escapes real-world AWS IAM path example", () => {
+    // Given: A realistic key that might be used in AWS IAM paths
+    const key = "arn:aws:iam::123456789/role";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Forward slash should be escaped
+    expect(escaped).toBe("arn:aws:iam::123456789~1role");
+  });
+
+  test("preserves other special characters", () => {
+    // Given: A key with various special characters that don't need escaping
+    const key = "key-with_special.chars@123!";
+
+    // When: Escaping the key for JSON Pointer use
+    const escaped = escapeJsonPointerSegment(key);
+
+    // Then: Only ~ and / should be escaped, other characters remain
+    expect(escaped).toBe("key-with_special.chars@123!");
+  });
+});

--- a/app/web/src/newhotness/util.ts
+++ b/app/web/src/newhotness/util.ts
@@ -165,3 +165,22 @@ export function memoizeDebounce<F extends AnyFn>(
 
   return wrappedFn;
 }
+
+/**
+ * Escapes a string segment for use in a JSON Pointer (RFC 6901).
+ * JSON Pointers use '~' as an escape character:
+ * - '~' must be encoded as '~0'
+ * - '/' must be encoded as '~1'
+ *
+ * @param segment - The string segment to escape
+ * @returns The escaped segment safe for use in a JSON Pointer path
+ *
+ * @example
+ * escapeJsonPointerSegment("test/paul") // returns "test~1paul"
+ * escapeJsonPointerSegment("a~b") // returns "a~0b"
+ * escapeJsonPointerSegment("test/~foo") // returns "test~1~0foo"
+ */
+export function escapeJsonPointerSegment(segment: string): string {
+  // Order matters: escape ~ first, then /
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}


### PR DESCRIPTION
Fixes: BUG-1120

When adding map items in the AttributesPanel with keys containing forward slashes (e.g., "test/paul") or tildes (e.g., "test~key"), the frontend was not escaping these characters according to RFC 6901 (JSON Pointer  specification) before constructing attribute paths. This caused the backend to misinterpret keys with forward slashes as nested path segments instead of literal key names.

For example, a key "test/paul" would be sent as "/domain/config/test/paul", which the backend interprets as: domain → config → test → paul (nested), instead of the intended: domain → config → "test/paul" (single key).