### PR TITLE
chore(dal): remove double write on new change set

### DIFF
--- a/lib/dal-test/src/expand_helpers.rs
+++ b/lib/dal-test/src/expand_helpers.rs
@@ -56,17 +56,12 @@ pub async fn create_change_set_and_update_ctx(
     let base_change_set = ChangeSet::get_by_id(ctx, base_change_set_id)
         .await
         .expect("could not find change set");
-    let workspace = ctx
-        .get_workspace_or_builtin()
-        .await
-        .expect("could not get workspace");
     let workspace_snapshot_address = base_change_set.workspace_snapshot_address;
     let change_set = ChangeSet::new(
         ctx,
         generate_fake_name().expect("could not generate fake name"),
         Some(base_change_set_id),
         workspace_snapshot_address,
-        workspace.snapshot_kind(),
     )
     .await
     .expect("could not create change set");

--- a/lib/dal-test/src/signup.rs
+++ b/lib/dal-test/src/signup.rs
@@ -59,14 +59,8 @@ impl WorkspaceSignup {
             .write(ctx)
             .await?;
 
-        let mut head_change_set = ChangeSet::new(
-            ctx,
-            "HEAD",
-            None,
-            workspace_snapshot_address,
-            WorkspaceSnapshotSelectorDiscriminants::SplitSnapshot,
-        )
-        .await?;
+        let mut head_change_set =
+            ChangeSet::new(ctx, "HEAD", None, workspace_snapshot_address).await?;
 
         let workspace = Workspace::insert_workspace(
             ctx,

--- a/lib/dal/src/workspace.rs
+++ b/lib/dal/src/workspace.rs
@@ -333,14 +333,8 @@ impl Workspace {
             // 'reset' the workspace snapshot so that we remigrate all builtins on each startup
             let new_snapshot = WorkspaceSnapshot::initial(ctx).await?;
             let new_snap_address = new_snapshot.write(ctx).await?;
-            let new_change_set = ChangeSet::new(
-                ctx,
-                DEFAULT_CHANGE_SET_NAME,
-                None,
-                new_snap_address,
-                WorkspaceSnapshotSelectorDiscriminants::LegacySnapshot,
-            )
-            .await?;
+            let new_change_set =
+                ChangeSet::new(ctx, DEFAULT_CHANGE_SET_NAME, None, new_snap_address).await?;
             found_builtin
                 .update_default_change_set_id(ctx, new_change_set.id)
                 .await?;
@@ -361,7 +355,6 @@ impl Workspace {
             DEFAULT_CHANGE_SET_NAME,
             None,
             workspace_snapshot.id().await,
-            WorkspaceSnapshotSelectorDiscriminants::LegacySnapshot,
         )
         .await?;
         let change_set_id = change_set.id;
@@ -539,7 +532,6 @@ impl Workspace {
             DEFAULT_CHANGE_SET_NAME,
             None,
             workspace_snapshot_address,
-            WorkspaceSnapshotSelectorDiscriminants::LegacySnapshot,
         )
         .await?;
 
@@ -598,7 +590,6 @@ impl Workspace {
             DEFAULT_CHANGE_SET_NAME,
             None,
             workspace_snapshot_address,
-            WorkspaceSnapshotSelectorDiscriminants::SplitSnapshot,
         )
         .await?;
 
@@ -728,7 +719,6 @@ impl Workspace {
             DEFAULT_CHANGE_SET_NAME,
             Some(builtin.default_change_set_id),
             workspace_snapshot.id().await,
-            WorkspaceSnapshotSelectorDiscriminants::LegacySnapshot,
         )
         .await?;
         let change_set_id = change_set.id;
@@ -888,8 +878,6 @@ impl Workspace {
             metadata,
         } = workspace_data.into_latest();
 
-        let workspace = ctx.get_workspace().await?;
-
         // ABANDON PREVIOUS CHANGESETS
         for mut change_set in ChangeSet::list_active(ctx).await? {
             change_set.abandon(ctx).await?;
@@ -936,7 +924,6 @@ impl Workspace {
                     change_set_data.name.clone(),
                     actual_base_changeset,
                     new_snap_address,
-                    workspace.snapshot_kind(),
                 )
                 .await?;
 


### PR DESCRIPTION
Eviction races required us to write a new snapshot for every new change set (to get a new address). This should no longer be necessary.

