### PR TITLE
feat(luminork): Add `is_overlay` flag to func list of the Schema Variant MV

### DIFF
--- a/lib/dal-materialized-views/src/luminork/schema/variant/default.rs
+++ b/lib/dal-materialized-views/src/luminork/schema/variant/default.rs
@@ -26,15 +26,17 @@ pub async fn assemble(
 
     let mut variant_func_ids = SchemaVariant::all_func_ids(&ctx, default_variant_id).await?;
     let overlay_func_ids = Schema::all_overlay_func_ids(&ctx, schema_id).await?;
-    variant_func_ids.extend(overlay_func_ids);
 
     let func_details = build_func_details(
         &ctx,
         schema_id,
         schema_variant.id(),
-        variant_func_ids.clone(),
+        &variant_func_ids,
+        &overlay_func_ids,
     )
     .await?;
+
+    variant_func_ids.extend(overlay_func_ids);
 
     let domain_props = {
         let domain =

--- a/lib/luminork-server/src/service/v1/schemas/mod.rs
+++ b/lib/luminork-server/src/service/v1/schemas/mod.rs
@@ -289,6 +289,7 @@ pub struct SchemaVariantFunc {
     #[schema(value_type = String, example = "01H9ZQD35JPMBGHH69BT0Q79VZ")]
     pub id: FuncId,
     pub func_kind: SchemaVariantFuncKind,
+    pub is_overlay: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, ToSchema)]
@@ -333,6 +334,7 @@ impl From<LuminorkSchemaVariantFunc> for SchemaVariantFunc {
                     func_kind: k.into(),
                 },
             },
+            is_overlay: inner.is_overlay,
         }
     }
 }
@@ -711,7 +713,7 @@ pub struct BuildingResponseV1 {
     pub estimated_completion_seconds: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum SchemaVariantResponseV1 {
     Success(Box<GetSchemaVariantV1Response>),

--- a/lib/si-frontend-mv-types-rs/src/luminork_schema_variant_func.rs
+++ b/lib/si-frontend-mv-types-rs/src/luminork_schema_variant_func.rs
@@ -24,6 +24,7 @@ use crate::management::ManagementFuncKind;
 pub struct LuminorkSchemaVariantFunc {
     pub id: FuncId,
     pub func_kind: FuncKindVariant,
+    pub is_overlay: bool,
 }
 
 #[derive(


### PR DESCRIPTION
Adds a flag to the variantFuncs prop of the get schema variant luminork call so we can know which functions are overlays.
Untested yet