### PR TITLE
fix(web): Send correct { $source: null } format when clearing input fields

### DIFF
--- a/app/web/src/newhotness/AttributePanel.test.ts
+++ b/app/web/src/newhotness/AttributePanel.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { AttributePath } from "@/api/sdf/dal/component";
+import { AttributePath, ComponentId } from "@/api/sdf/dal/component";
 
 // REQUIRED for all testing
 import { CONTEXT } from "@/newhotness/testing/context1";
@@ -260,6 +260,346 @@ describe("setKey API integration with escaped keys", () => {
     );
     expect(mockApiCalls[0]?.payload["/domain/config/normalKey123"]).toEqual({
       setting: "value",
+    });
+  });
+});
+
+/**
+ * Tests for clearing input fields - API receives correct { $source: null } format
+ *
+ * When users clear an input field in the AttributePanel, the UI must send
+ * { $source: null } to properly unset the value and trigger attribute functions
+ * to re-run with the default/schema variant prototype.
+ *
+ * These tests validate the fix for a bug where clearing input fields sent plain null
+ * instead of { $source: null }, which caused attribute functions not to re-execute.
+ */
+describe("API integration with clearing input fields", () => {
+  test("API receives { $source: null } when user clears a string input", async () => {
+    // Given: The API composable and makeSavePayload function (as used in AttributePanel)
+    const { useApi, routes } = await import("./api_composables");
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+    const api = useApi();
+
+    const componentId = "test-component-clear";
+    const path = "/domain/image" as AttributePath;
+    const value = ""; // User cleared the input
+
+    // When: Simulating save behavior with cleared input - this is what AttributePanel does
+    const payload = makeSavePayload(path, value, PropKind.String);
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The mock API should have received { $source: null }
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.route).toBe("update-component-attributes");
+    expect(mockApiCalls[0]?.method).toBe("PUT");
+    expect(mockApiCalls[0]?.payload).toEqual({
+      "/domain/image": { $source: null },
+    });
+  });
+
+  test("API receives { $source: null } when user clears an integer input", async () => {
+    // Given: The API composable and makeSavePayload function
+    const { useApi, routes } = await import("./api_composables");
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+    const api = useApi();
+
+    const componentId = "test-component-clear-int";
+    const path = "/domain/count" as AttributePath;
+    const value = ""; // User cleared the integer input
+
+    // When: Simulating save behavior with cleared integer input
+    const payload = makeSavePayload(path, value, PropKind.Integer);
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The mock API should have received { $source: null }
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toEqual({
+      "/domain/count": { $source: null },
+    });
+  });
+
+  test("API receives actual value when user enters text in string input", async () => {
+    // Given: The API composable and makeSavePayload function
+    const { useApi, routes } = await import("./api_composables");
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+    const api = useApi();
+
+    const componentId = "test-component-value";
+    const path = "/domain/image" as AttributePath;
+    const value = "my-image:v1"; // User entered a value
+
+    // When: Simulating save behavior with actual value
+    const payload = makeSavePayload(path, value, PropKind.String);
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The mock API should have received the actual value
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toEqual({
+      "/domain/image": "my-image:v1",
+    });
+  });
+
+  test("API receives coerced integer when user enters number in integer input", async () => {
+    // Given: The API composable and makeSavePayload function
+    const { useApi, routes } = await import("./api_composables");
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+    const api = useApi();
+
+    const componentId = "test-component-int";
+    const path = "/domain/count" as AttributePath;
+    const value = "42"; // User entered an integer
+
+    // When: Simulating save behavior with integer value
+    const payload = makeSavePayload(path, value, PropKind.Integer);
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The mock API should have received the coerced integer
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toEqual({
+      "/domain/count": 42,
+    });
+  });
+
+  test("API receives subscription format when connecting components", async () => {
+    // Given: The API composable and makeSavePayload function
+    const { useApi, routes } = await import("./api_composables");
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+    const api = useApi();
+
+    const componentId = "test-component-subscription";
+    const path = "/domain/output" as AttributePath;
+    const value = "/domain/input"; // Path to subscribe to
+    const connectingComponentId = "source-component-123" as ComponentId;
+
+    // When: Simulating subscription creation
+    const payload = makeSavePayload(
+      path,
+      value,
+      PropKind.String,
+      connectingComponentId,
+    );
+    const call = api.endpoint(routes.UpdateComponentAttributes, {
+      id: componentId,
+    });
+    await call.put(payload);
+
+    // Then: The mock API should have received subscription format
+    expect(mockApiCalls).toHaveLength(1);
+    expect(mockApiCalls[0]?.payload).toEqual({
+      "/domain/output": {
+        $source: {
+          component: "source-component-123",
+          path: "/domain/input",
+        },
+      },
+    });
+  });
+});
+
+/**
+ * Unit tests for makeSavePayload function
+ *
+ * These tests verify the payload structure returned by makeSavePayload
+ * in isolation, without the full API integration.
+ */
+describe("makeSavePayload unit tests", () => {
+  test("makeSavePayload returns { $source: null } for empty string value", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User clears an input field (value becomes empty string)
+    const payload = makeSavePayload(
+      "/domain/image" as AttributePath,
+      "", // Empty string from cleared input
+      PropKind.String,
+    );
+
+    // Then: Payload should contain { $source: null } to properly unset the value
+    expect(payload).toEqual({
+      "/domain/image": { $source: null },
+    });
+  });
+
+  test("makeSavePayload returns string value when value is not empty", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User enters a string value
+    const payload = makeSavePayload(
+      "/domain/image" as AttributePath,
+      "my-image:v1",
+      PropKind.String,
+    );
+
+    // Then: Payload should contain the string value
+    expect(payload).toEqual({
+      "/domain/image": "my-image:v1",
+    });
+  });
+
+  test("makeSavePayload returns coerced integer for integer prop", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User enters an integer value
+    const payload = makeSavePayload(
+      "/domain/count" as AttributePath,
+      "42",
+      PropKind.Integer,
+    );
+
+    // Then: Payload should contain the coerced integer
+    expect(payload).toEqual({
+      "/domain/count": 42,
+    });
+  });
+
+  test("makeSavePayload returns { $source: null } for cleared integer prop", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User clears an integer input field
+    const payload = makeSavePayload(
+      "/domain/count" as AttributePath,
+      "", // Empty string from cleared input
+      PropKind.Integer,
+    );
+
+    // Then: Payload should contain { $source: null } regardless of prop kind
+    expect(payload).toEqual({
+      "/domain/count": { $source: null },
+    });
+  });
+
+  test("makeSavePayload returns coerced boolean for boolean prop", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User enters a boolean value
+    const payload = makeSavePayload(
+      "/domain/enabled" as AttributePath,
+      "true",
+      PropKind.Boolean,
+    );
+
+    // Then: Payload should contain the coerced boolean
+    expect(payload).toEqual({
+      "/domain/enabled": true,
+    });
+  });
+
+  test("makeSavePayload returns coerced float for float prop", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User enters a float value
+    const payload = makeSavePayload(
+      "/domain/price" as AttributePath,
+      "19.99",
+      PropKind.Float,
+    );
+
+    // Then: Payload should contain the coerced float
+    expect(payload).toEqual({
+      "/domain/price": 19.99,
+    });
+  });
+
+  test("makeSavePayload returns subscription format when connecting component", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: User creates a subscription connection
+    const payload = makeSavePayload(
+      "/domain/output" as AttributePath,
+      "/domain/input",
+      PropKind.String,
+      "component-123" as ComponentId,
+    );
+
+    // Then: Payload should contain { $source: { component, path } }
+    expect(payload).toEqual({
+      "/domain/output": {
+        $source: {
+          component: "component-123",
+          path: "/domain/input",
+        },
+      },
+    });
+  });
+
+  test("makeSavePayload returns subscription format even with empty path", async () => {
+    // Given: The makeSavePayload function
+    const { makeSavePayload } = await import(
+      "./logic_composables/attribute_tree"
+    );
+    const { PropKind } = await import("@/api/sdf/dal/prop");
+
+    // When: Creating a subscription with empty path (edge case)
+    const payload = makeSavePayload(
+      "/domain/output" as AttributePath,
+      "",
+      PropKind.String,
+      "component-123" as ComponentId,
+    );
+
+    // Then: Should use subscription format, not $source: null
+    expect(payload).toEqual({
+      "/domain/output": {
+        $source: {
+          component: "component-123",
+          path: "",
+        },
+      },
     });
   });
 });

--- a/app/web/src/newhotness/logic_composables/attribute_tree.ts
+++ b/app/web/src/newhotness/logic_composables/attribute_tree.ts
@@ -114,13 +114,16 @@ export const makeSavePayload: MakePayload = (
   // TODO - Paul there's a better way to handle this for sure!
   let coercedVal: string | boolean | number | null = value;
 
+  const payload: componentTypes.UpdateComponentAttributesArgs = {};
+
   // We don't want to coerce a prop path when connecting via a subscription, so skip it (e.g. prop
   // kind is "integer", but the value is the prop path, which is a "string").
   if (!connectingComponentId) {
     if (value === "") {
-      // For now, we don't allow a user to enter an empty string becuase passing an empty string is
-      // effectively an unset operation.
-      coercedVal = null;
+      // When clearing an input field, send $source: null to properly unset the value
+      // and trigger attribute functions to re-run with the default/schema variant prototype
+      payload[path] = { $source: null };
+      return payload;
     } else if (propKind === PropKind.Boolean) {
       coercedVal = value.toLowerCase() === "true" || value === "1";
     } else if (propKind === PropKind.Integer) {
@@ -130,7 +133,6 @@ export const makeSavePayload: MakePayload = (
     }
   }
 
-  const payload: componentTypes.UpdateComponentAttributesArgs = {};
   payload[path] = coercedVal;
   if (connectingComponentId) {
     payload[path] = {

--- a/lib/dal/src/attribute/attributes.rs
+++ b/lib/dal/src/attribute/attributes.rs
@@ -435,13 +435,10 @@ async fn update_attributes_inner(
                         // If the parent is a map or array, remove the value
                         AttributeValue::remove(ctx, target_av_id).await?;
                     } else {
-                        // Otherwise, just set it to its default value
-                        if AttributeValue::component_prototype_id(ctx, target_av_id)
-                            .await?
-                            .is_some()
-                        {
-                            AttributeValue::use_default_prototype(ctx, target_av_id).await?;
-                        }
+                        // Otherwise, use the default prototype (either by removing an existing
+                        // component prototype to revert to the schema variant prototype, or by
+                        // creating a si:Unset component prototype to explicitly unset the value)
+                        AttributeValue::use_default_prototype(ctx, target_av_id).await?;
                     }
 
                     ctx.write_audit_log(


### PR DESCRIPTION
Fixes: BUG-1036

When users cleared an input field in the AttributePanel, the frontend was sending `{ "/path": null }` instead of `{ "$source": null }`. This caused attribute functions not to re-run after clearing manual overrides, leaving stale values in place.

Example scenario:
1. AMI component has an attribute function that computes a value for prop ImageId
2. User manually sets prop ImageId to "manual-override"
3. User clears the input field in AttributePanel
4. Expected: Attribute function re-runs and restores computed value
5. Actual: Value remains as "manual-override" - function never re-runs

## Root Cause

The frontend's makeSavePayload() function in attribute_tree.ts treated empty string inputs as plain null values instead of using the proper `{ $source: null }` format. This bypassed the correct code path that removes component prototypes and triggers attribute function re-execution.