### PR TITLE
fix(clover): check case sensitive paths to catch naughty specs

### DIFF
--- a/bin/clover/src/pipelines/azure/spec.ts
+++ b/bin/clover/src/pipelines/azure/spec.ts
@@ -916,18 +916,18 @@ export function parseEndpointPath(path: string) {
   const segments = path.slice(1).split("/");
 
   // /subscriptions/{subscriptionId}
-  if (segments.shift() !== "subscriptions") return undefined;
+  if (segments.shift()?.toLowerCase() !== "subscriptions") return undefined;
   if (!segments.shift()) return undefined; // skip value
 
   // /resourceGroups/{resourceGroupName} (optional)
-  const hasResourceGroupParam = segments[0] === "resourceGroups";
-  if (segments[0] === "resourceGroups") {
+  const hasResourceGroupParam = segments[0]?.toLowerCase() === "resourcegroups";
+  if (segments[0]?.toLowerCase() === "resourcegroups") {
     segments.shift();
     if (!segments.shift()) return undefined; // skip value
   }
 
   // /providers/Microsoft.Compute
-  if (segments.shift() !== "providers") return undefined;
+  if (segments.shift()?.toLowerCase() !== "providers") return undefined;
   let resourceType = segments.shift();
   if (!resourceType) return undefined;
   // List operations (top level operations with no resource group param)


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

Some paths are not following the paradigm (using `resourcegroups` instead of `resourceGroups`) so we must check the paths without case sensitivity.


## How was it tested?

The tests running here should be sufficient. I verified that the missing asset generates locally. 

The changes generated here are most likely assets that missed the last round of updates when we stopped generating them with the nest assets changes.

- [X] Integration tests pass

## In short: [:link:](https://giphy.com/)

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdldmgxcmVyenI3ajE1bXk4bW81cm9zbmgxNGgzNzhtM2ZocWRpbWFiMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/NfOD0Bv11XnhK/giphy.gif"/>