### PR TITLE
feat(web) - helpful hiding functionality for Map view

### DIFF
--- a/app/web/src/newhotness/Workspace.vue
+++ b/app/web/src/newhotness/Workspace.vue
@@ -542,6 +542,8 @@ export type SelectionsInQueryString = Partial<{
   retainSessionState: string; // If set, the component should load up with the last state it had on this tab. Used by Explore.vue
   hideSubscriptions: string; // Flag to hide unconnected components when navigating to map
   showDiff: string; // Flag to show only components with diff on the map
+  showCredentials: string; // Flag to show or hide credential components from the map
+  showNoConnections: string; // Flag to show or hide components with no subscriptions from the map
 }>;
 
 const tokenFailStatus = ref();

--- a/app/web/src/newhotness/skeletons/ExploreMapSkeleton.vue
+++ b/app/web/src/newhotness/skeletons/ExploreMapSkeleton.vue
@@ -1,6 +1,11 @@
 <template>
   <DelayedComponent>
-    <section :class="clsx('h-full w-full', themeClasses('bg-white', 'bg-neutral-950'))">
+    <section :class="
+      clsx(
+        'h-full w-full border-t',
+        themeClasses('border-neutral-200 bg-white', 'border-neutral-800 bg-neutral-900'),
+      )
+    ">
       <div
         :class="
           clsx(

--- a/app/web/src/pages/DebugPage.vue
+++ b/app/web/src/pages/DebugPage.vue
@@ -231,6 +231,8 @@ const getButtonTooltip = (variant: string) => {
     return "The nostyle variant is used to clear ALL styles";
   } else if (variant === "flat") {
     return "Similar to the neutral style, but meant to have the same bg color as the things it is sitting on top of (e.g. appear to not have a separate bg color)";
+  } else if (variant === "toggle") {
+    return "A special tone used only for the buttons at the top of the Explore page in the area below the search bar";
   } else {
     return undefined;
   }

--- a/app/web/src/store/feature_flags.store.ts
+++ b/app/web/src/store/feature_flags.store.ts
@@ -19,6 +19,7 @@ const USER_FLAG_MAPPING = {
   SHOW_WS_DISCONNECT: "show-ws-disconnect",
   SHOW_POLICIES: "show-policies",
   SHOW_AUTHORING_NAV: "authoring-in-nav",
+  MAP_VIEW_UPGRADES: "map-view-upgrades",
 } as const;
 const WORKSPACE_FLAG_MAPPING: Record<string, string> = {
   // STORE_FLAG_NAME: "posthogFlagName",

--- a/lib/vue-lib/src/design-system/general/NewButton.vue
+++ b/lib/vue-lib/src/design-system/general/NewButton.vue
@@ -17,7 +17,9 @@
           'flex flex-row items-center justify-center rounded-sm',
           size === '2xs' || size === 'xs' ? 'gap-2xs' : 'gap-xs',
           'transition-all whitespace-nowrap leading-none font-medium max-h-fit',
-          hasLabel ? 'px-xs py-2xs' : 'p-3xs m-3xs',
+          tone === 'toggle' ? 'px-2xs min-h-[28px]' : [
+            hasLabel ? 'px-xs py-2xs' : 'p-3xs m-3xs',
+          ],
           tone !== 'empty' && 'border',
           computedTextSize,
           truncateText && 'min-w-0',
@@ -42,6 +44,16 @@
                     'text-neutral-900 bg-100 border-neutral-400 hover:bg-neutral-200',
                     'text-white bg-neutral-800 border-neutral-600 hover:bg-neutral-700',
                   ),
+                  toggle: clsx(
+                    'font-mono text-left truncate relative',
+                    themeClasses(
+                      'border-neutral-400 hover:border-action-500',
+                      'border-neutral-600 hover:border-action-300',
+                    ),
+                    active
+                      ? themeClasses('bg-action-200', 'bg-action-900')
+                      : themeClasses('bg-neutral-100', 'bg-neutral-900'),
+                  ),
                   action: [
                     'text-white',
                     themeClasses(
@@ -64,6 +76,7 @@
             {
               neutral: themeClasses('bg-neutral-100', 'bg-neutral-600'),
               flat: themeClasses('bg-neutral-200', 'bg-neutral-700'),
+              toggle: '',
               action: themeClasses('bg-[#2583EC]', 'bg-[#1D5BA0]'),
               warning: themeClasses('bg-white', 'bg-[#67452D]'),
               destructive: themeClasses('bg-white', 'bg-[#562E2E]'),
@@ -104,7 +117,7 @@
       <TruncateWithTooltip
         v-if="truncateText && hasLabel"
         ref="truncateRef"
-        :class="size === '2xs' || size === 'xs' ? 'py-3xs' : 'py-2xs'"
+        :class="labelClasses"
       >
         <slot v-if="confirmClick && confirmFirstClickAt" name="confirm-click">
           |
@@ -118,7 +131,7 @@
       </TruncateWithTooltip>
       <span
         v-else-if="hasLabel"
-        :class="size === '2xs' || size === 'xs' ? 'py-3xs' : 'py-2xs'"
+        :class="labelClasses"
       >
         <slot v-if="confirmClick && confirmFirstClickAt" name="confirm-click">
           |
@@ -148,6 +161,7 @@
               {
                 neutral: '',
                 flat: '',
+                toggle: '',
                 action: '',
                 warning: '',
                 destructive: '',
@@ -349,6 +363,11 @@ const focus = () => {
 const { width: buttonWidth } = useElementSize(mainElRef);
 
 const scaleEffectClasses = computed(() => {
+  // The toggle button tone does not scale
+  if (props.tone === "toggle") {
+    return "";
+  }
+
   // This prevents the button from scaling too much if it is wide
   if (buttonWidth.value < 200) {
     return tw`hover:scale-105 active:scale-100`;
@@ -390,6 +409,14 @@ const computedTextSize = computed(() => {
   }
 });
 
+const labelClasses = computed(() => {
+  if (props.tone === "toggle") {
+    return tw`py-2xs text-[13px] font-normal`;
+  }
+
+  return props.size === '2xs' || props.size === 'xs' ? tw`py-3xs` : tw`py-2xs`;
+});
+
 const tooltipObject = computed(() =>
   props.tooltip
     ? {
@@ -415,6 +442,7 @@ export type ButtonSizes = "2xs" | "xs" | "sm" | "md" | "lg" | "xl";
 export const BUTTON_TONES = [
   "neutral",
   "flat", // similar to neutral, but has the same bg as the content its sitting on top of
+  "toggle", // alternative neutral style used for buttons in the same area as ExploreModeTile
   "action",
   "warning",
   "destructive",


### PR DESCRIPTION
## How does this PR change the system?

This PR adds two hiding features to the Map view to make it easier to navigate and read. One hiding feature hides all credential components from the Map, while the other hides all components which have no connections to any other components. Both features are on by default, with a button to toggle them off.

Both features are behind a feature flag so that we can have our team try them out before rolling anything out to users.

This PR also includes some minor refactoring improvements and style fixes to the area the buttons were added to.

#### Screenshots:

https://github.com/user-attachments/assets/003172c7-5015-4b9b-a610-96ba20793724

#### Out of Scope:

These hiding features may be better implemented via a different UI than individual buttons, and we may decide that one or both should be disabled by default instead of enabled by default.

This PR also does not make any other changes to the Map besides these two hiding features.

## How was it tested?

Aggressive manual testing with a wide variety of components and configurations.

## Does it require a docs change?

Not yet, but if we roll out this feature we will want to update the docs to explain it to users.
