### PR TITLE
Docs fix &  scripts update proposal for NixOS

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -66,7 +66,7 @@ Those include, but are not limited to the following: Ubuntu, Fedora, Debian, Arc
 
 #### What about NixOS?
 
-If using NixOS, you need [Docker](https://wiki.nixos.org/wiki/Docker) to be installed and [Flakes](https://wiki.nixos.org/wiki/Flakes) to be enabled.
+If using NixOS, you need [Docker](https://wiki.nixos.org/wiki/Docker) to be installed, `services.envfs.enabled = true;` and `programs.nix-ld.enabled = true;` to be set in your config and [Flakes](https://wiki.nixos.org/wiki/Flakes) to be enabled.
 If not using `direnv`, you can use `nix develop` or [Nix command](https://wiki.nixos.org/wiki/Nix_command).
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Let's start by choosing an officially supported platform:
 
 > [!TIP]
 > - On macOS `aarch64` (`arm64`) systems, Rosetta 2 must be installed (install it with `softwareupdate --install-rosetta`)
-> - [NixOS](https://nixos.org/) requires [`docker`](https://nixos.wiki/wiki/Docker) to be installed and [Flakes](https://nixos.wiki/wiki/Flakes) to be enabled (see the [development environment section of the dev docs](DEV_DOCS.md) for more information)
+> - [NixOS](https://nixos.org/) requires [`docker`](https://nixos.wiki/wiki/Docker) to be installed, [Flakes](https://nixos.wiki/wiki/Flakes) to be enabled and `services.envfs.enabled = true;` and `programs.nix-ld.enabled = true;` to be set in your config (see the [development environment section of the dev docs](DEV_DOCS.md) for more information)
 > - Linux with MUSL instead of GNU (e.g. [Alpine Linux](https://www.alpinelinux.org/)) is untested
 > - [WSL2](https://learn.microsoft.com/en-us/windows/wsl/) on Windows should work, but you may need to enable `systemd` within your Linux distribution
 > - macOS `x86_64` (i.e. `amd64`, "Intel") has historically worked, but is currently untested

--- a/prelude-si/toolchains/extraction.bzl
+++ b/prelude-si/toolchains/extraction.bzl
@@ -31,7 +31,7 @@ def _toolchain_extract_impl(ctx: AnalysisContext) -> list[Provider]:
     ctx.actions.write(
         extract_script,
         [
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             "OUTPUT_DIR=\"$1\"",
             "ARCHIVE=\"$2\"", 


### PR DESCRIPTION
<!-- This is only a suggestion of topics to cover on your PR description -->
<!-- Feel free to ignore it or remove irrelevant sections -->

## How does this PR change the system?

The local deployment process is flaky on NixOS, since the bazel code, generating the scripts for the bootstrap sets shebangs to paths that may be nonexistent on the system.

The easiest fix would be to just add the relevant info for the users in the docs.

Second approach would be to fix the shebangs in the generated scripts (example in `prelude-si/toolchains/extraction.bzl`; although there should be also a change made in a bazel file generating the python-wrapper and the healthcheck - I wasn't able to dig those two out)

The third possible fix that might be investigated although would take significantly more engineering effort would be to have nix do the toolchain retrieval and extraction, although I did not investigate that angle if there are any major blockers in implementing that. 

## Does it require a docs change?

<!-- Does it require a docs change and was that change made in this PR? -->
<!-- This includes "docs.systeminit.com", "DEV_DOCS.md", "README.md" and other docs within the repository -->

- [ ] No
- [X] Yes, and this PR includes it
- [ ] Yes, and this PR does not include it (reasoning below)

